### PR TITLE
issue: 3574901 Unlock sockinfo_tcp before destruction

### DIFF
--- a/src/core/sock/sockinfo_tcp.cpp
+++ b/src/core/sock/sockinfo_tcp.cpp
@@ -5841,13 +5841,15 @@ void tcp_timers_collection::handle_timer_expired(void *user_data)
          * TODO Check on is_cleaned() is not safe completely.
          */
         if (!p_sock->trylock_tcp_con()) {
+            bool destroyable = false;
             if (!p_sock->is_cleaned()) {
                 p_sock->handle_timer_expired(iter->user_data);
-                if (p_sock->is_destroyable_no_lock()) {
-                    g_p_fd_collection->destroy_sockfd(p_sock);
-                }
+                destroyable = p_sock->is_destroyable_no_lock();
             }
             p_sock->unlock_tcp_con();
+            if (destroyable) {
+                g_p_fd_collection->destroy_sockfd(p_sock);
+            }
         }
         iter = iter->next;
     }


### PR DESCRIPTION
Segmentation fault in tcp timers, where we delete sockinfo_tcp object, and then call unlock for that object.
The fix - first unlock and only then delete the object.

## Change type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

