### PR TITLE
issue: 3427021 Removed generic warning that was prompted each time XLIO ran

### DIFF
--- a/src/core/dev/ib_ctx_handler.cpp
+++ b/src/core/dev/ib_ctx_handler.cpp
@@ -448,9 +448,7 @@ uint32_t ib_ctx_handler::mem_reg(void *addr, size_t length, uint64_t access)
     mr = ibv_reg_mr(m_p_ibv_pd, addr, length, access);
     VALGRIND_MAKE_MEM_DEFINED(mr, sizeof(ibv_mr));
     if (NULL == mr) {
-        ibch_logerr("failed registering a memory region "
-                    "(errno=%d %m)",
-                    errno);
+        print_warning_rlimit_memlock(length, errno);
     } else {
         m_mr_map_lkey[mr->lkey] = mr;
         lkey = mr->lkey;

--- a/src/core/util/utils.cpp
+++ b/src/core/util/utils.cpp
@@ -205,6 +205,20 @@ void print_roce_lag_warnings(const char *interface, char *disable_path /* = NULL
                 "********************\n");
 }
 
+void print_warning_rlimit_memlock(size_t length, int error)
+{
+    vlog_printf(VLOG_ERROR,
+                "**********************************************************************************"
+                "********************\n");
+    vlog_printf(VLOG_ERROR, "* Failed registering a memory region of size %zu bytes\n", length);
+    vlog_printf(VLOG_ERROR, "* (errno=%d %m)\n", error);
+    vlog_printf(VLOG_ERROR, "* Could be due to lack of locked memory in kernel.\n");
+    vlog_printf(VLOG_ERROR, "* Please check max allowed locked memory (ulimit -l)\n");
+    vlog_printf(VLOG_ERROR,
+                "**********************************************************************************"
+                "********************\n");
+}
+
 void compute_tx_checksum(mem_buf_desc_t *p_mem_buf_desc, bool l3_csum, bool l4_csum)
 {
     unsigned short l3_checksum = -1, l4_checksum = -1;

--- a/src/core/util/utils.h
+++ b/src/core/util/utils.h
@@ -282,6 +282,9 @@ size_t get_local_ll_addr(const char *ifname, unsigned char *addr, int addr_len, 
 void print_roce_lag_warnings(const char *interface, char *disable_path = NULL,
                              const char *port1 = NULL, const char *port2 = NULL);
 
+/*Print a warning to the user when there was an error registering memory*/
+void print_warning_rlimit_memlock(size_t length, int error);
+
 bool check_bond_device_exist(const char *ifname);
 bool get_bond_active_slave_name(IN const char *bond_name, OUT char *active_slave_name, IN int sz);
 bool get_bond_slave_state(IN const char *slave_name, OUT char *curr_state, IN int sz);


### PR DESCRIPTION
## Description
Deleted check for locked memory during initialization of XLIO and added a message to the user when the locked memory is not enough.

##### What
Notifies the user to check locked memory in kernel, and provides a possible problem and solution user should check

## Change type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

