### PR TITLE
issue: 3531436 Fixing GRO polling and flush segfault

### DIFF
--- a/src/core/dev/cq_mgr.cpp
+++ b/src/core/dev/cq_mgr.cpp
@@ -656,12 +656,13 @@ void cq_mgr::process_tx_buffer_list(mem_buf_desc_t *p_mem_buf_desc)
     BULLSEYE_EXCLUDE_BLOCK_END
 }
 
+// This method is called when ring release returns unposted buffers.
 void cq_mgr::mem_buf_desc_return_to_owner(mem_buf_desc_t *p_mem_buf_desc,
                                           void *pv_fd_ready_array /*=NULL*/)
 {
     cq_logfuncall("");
     NOT_IN_USE(pv_fd_ready_array);
-    reclaim_recv_buffer_helper(p_mem_buf_desc);
+    cq_mgr::reclaim_recv_buffer_helper(p_mem_buf_desc);
 }
 
 int cq_mgr::poll_and_process_element_rx(uint64_t *p_cq_poll_sn, void *pv_fd_ready_array)
@@ -734,12 +735,6 @@ int cq_mgr::poll_and_process_element_tx(uint64_t *p_cq_poll_sn)
     }
 
     return ret;
-}
-
-mem_buf_desc_t *cq_mgr::poll_and_process_socketxtreme()
-{
-    cq_logerr("SocketXtreme mode is supported by mlx5 cq manager only");
-    return nullptr;
 }
 
 bool cq_mgr::reclaim_recv_buffers(mem_buf_desc_t *rx_reuse_lst)

--- a/src/core/dev/cq_mgr.h
+++ b/src/core/dev/cq_mgr.h
@@ -137,7 +137,7 @@ public:
      */
     virtual int poll_and_process_element_rx(uint64_t *p_cq_poll_sn, void *pv_fd_ready_array = NULL);
     virtual int poll_and_process_element_tx(uint64_t *p_cq_poll_sn);
-    virtual mem_buf_desc_t *poll_and_process_socketxtreme();
+    virtual mem_buf_desc_t *poll_and_process_socketxtreme() { return nullptr; };
 
     /**
      * This will check if the cq was drained, and if it wasn't it will drain it.
@@ -150,8 +150,8 @@ public:
     // CQ implements the Rx mem_buf_desc_owner.
     // These callbacks will be called for each Rx buffer that passed processed completion
     // Rx completion handling at the cq_mgr level is forwarding the packet to the ib_comm_mgr layer
-    virtual void mem_buf_desc_return_to_owner(mem_buf_desc_t *p_mem_buf_desc,
-                                              void *pv_fd_ready_array = NULL);
+    void mem_buf_desc_return_to_owner(mem_buf_desc_t *p_mem_buf_desc,
+                                      void *pv_fd_ready_array = NULL);
 
     virtual void add_qp_rx(qp_mgr *qp);
     virtual void del_qp_rx(qp_mgr *qp);

--- a/src/core/dev/cq_mgr_mlx5.h
+++ b/src/core/dev/cq_mgr_mlx5.h
@@ -62,9 +62,8 @@ public:
     virtual ~cq_mgr_mlx5();
 
     virtual int drain_and_proccess(uintptr_t *p_recycle_buffers_last_wr_id = NULL);
-    virtual int poll_and_process_element_rx(uint64_t *p_cq_poll_sn, void *pv_fd_ready_array = NULL);
     virtual mem_buf_desc_t *poll_and_process_socketxtreme();
-
+    virtual int poll_and_process_element_rx(uint64_t *p_cq_poll_sn, void *pv_fd_ready_array = NULL);
     virtual int poll_and_process_element_tx(uint64_t *p_cq_poll_sn);
 
     mem_buf_desc_t *cqe_process_rx(mem_buf_desc_t *p_mem_buf_desc, enum buff_status_e status);
@@ -86,7 +85,6 @@ protected:
     void log_cqe_error(struct xlio_mlx5_cqe *cqe);
     inline void cqe_to_mem_buff_desc(struct xlio_mlx5_cqe *cqe, mem_buf_desc_t *p_rx_wc_buf_desc,
                                      enum buff_status_e &status);
-    void cqe_to_xlio_wc(struct xlio_mlx5_cqe *cqe, xlio_ibv_wc *wc);
     inline void update_global_sn(uint64_t &cq_poll_sn, uint32_t rettotal);
     void lro_update_hdr(struct xlio_mlx5_cqe *cqe, mem_buf_desc_t *p_rx_wc_buf_desc);
 

--- a/src/core/dev/cq_mgr_mlx5_strq.cpp
+++ b/src/core/dev/cq_mgr_mlx5_strq.cpp
@@ -412,29 +412,6 @@ int cq_mgr_mlx5_strq::drain_and_proccess_helper(mem_buf_desc_t *buff, mem_buf_de
     return ret_total;
 }
 
-int cq_mgr_mlx5_strq::drain_and_proccess_socketxtreme(uintptr_t *p_recycle_buffers_last_wr_id)
-{
-    uint32_t ret_total = 0;
-    while (((m_n_sysvar_progress_engine_wce_max > m_n_wce_counter) && (!m_b_was_drained)) ||
-           p_recycle_buffers_last_wr_id) {
-        buff_status_e status = BS_OK;
-        mem_buf_desc_t *buff = nullptr;
-        mem_buf_desc_t *buff_wqe = poll(status, buff);
-        if (!buff && !buff_wqe) {
-            m_b_was_drained = true;
-            return ret_total;
-        }
-
-        ret_total +=
-            drain_and_proccess_helper(buff, buff_wqe, status, p_recycle_buffers_last_wr_id);
-    }
-
-    m_n_wce_counter = 0; // Actually strides count.
-    m_b_was_drained = false;
-
-    return ret_total;
-}
-
 int cq_mgr_mlx5_strq::drain_and_proccess(uintptr_t *p_recycle_buffers_last_wr_id)
 {
     cq_logfuncall("cq was %s drained. %d processed wce since last check. %d wce in m_rx_queue",
@@ -448,37 +425,31 @@ int cq_mgr_mlx5_strq::drain_and_proccess(uintptr_t *p_recycle_buffers_last_wr_id
     // Internal thread:
     //   Frequency of real polling can be controlled by
     //   PROGRESS_ENGINE_INTERVAL and PROGRESS_ENGINE_WCE_MAX.
-    // socketxtreme:
-    //   User does socketxtreme_poll()
     // Cleanup:
     //   QP down logic to release rx buffers should force polling to do this.
     //   Not null argument indicates one.
 
-    if (safe_mce_sys().enable_socketxtreme) {
-        ret_total = drain_and_proccess_socketxtreme(p_recycle_buffers_last_wr_id);
-    } else {
-        while (((m_n_sysvar_progress_engine_wce_max > m_n_wce_counter) && (!m_b_was_drained)) ||
-               p_recycle_buffers_last_wr_id) {
-            buff_status_e status = BS_OK;
-            mem_buf_desc_t *buff = nullptr;
-            mem_buf_desc_t *buff_wqe = poll(status, buff);
-            if (!buff && !buff_wqe) {
-                update_global_sn(cq_poll_sn, ret_total);
-                m_b_was_drained = true;
-                m_p_ring->m_gro_mgr.flush_all(nullptr);
-                return ret_total;
-            }
-
-            ret_total +=
-                drain_and_proccess_helper(buff, buff_wqe, status, p_recycle_buffers_last_wr_id);
+    while (((m_n_sysvar_progress_engine_wce_max > m_n_wce_counter) && (!m_b_was_drained)) ||
+           p_recycle_buffers_last_wr_id) {
+        buff_status_e status = BS_OK;
+        mem_buf_desc_t *buff = nullptr;
+        mem_buf_desc_t *buff_wqe = poll(status, buff);
+        if (!buff && !buff_wqe) {
+            update_global_sn(cq_poll_sn, ret_total);
+            m_b_was_drained = true;
+            m_p_ring->m_gro_mgr.flush_all(nullptr);
+            return ret_total;
         }
 
-        update_global_sn(cq_poll_sn, ret_total);
-
-        m_p_ring->m_gro_mgr.flush_all(nullptr);
-        m_n_wce_counter = 0; // Actually strides count.
-        m_b_was_drained = false;
+        ret_total +=
+            drain_and_proccess_helper(buff, buff_wqe, status, p_recycle_buffers_last_wr_id);
     }
+
+    update_global_sn(cq_poll_sn, ret_total);
+
+    m_p_ring->m_gro_mgr.flush_all(nullptr);
+    m_n_wce_counter = 0; // Actually strides count.
+    m_b_was_drained = false;
 
     // Update cq statistics
     m_p_cq_stat->n_rx_sw_queue_len = m_rx_queue.size();
@@ -542,43 +513,35 @@ int cq_mgr_mlx5_strq::poll_and_process_element_rx(uint64_t *p_cq_poll_sn, void *
                        m_n_sysvar_rx_prefetch_bytes_before_poll);
     }
 
-    if (safe_mce_sys().enable_socketxtreme) {
-        mem_buf_desc_t *buff = poll_and_process_socketxtreme();
+    buff_status_e status = BS_OK;
+    uint32_t ret = 0;
+    while (ret < m_n_sysvar_cq_poll_batch_max) {
+        mem_buf_desc_t *buff = nullptr;
+        mem_buf_desc_t *buff_wqe = poll(status, buff);
+
+        if (buff_wqe && (++m_qp_rec.debt >= (int)m_n_sysvar_rx_num_wr_to_post_recv)) {
+            compensate_qp_poll_failed(); // Reuse this method as success.
+        }
+
         if (buff) {
-            process_recv_buffer(buff, pv_fd_ready_array);
-            ++ret_rx_processed;
+            ++ret;
+            if (cqe_process_rx(buff, status)) {
+                ++ret_rx_processed;
+                process_recv_buffer(buff, pv_fd_ready_array);
+            }
+        } else if (!buff_wqe) {
+            m_b_was_drained = true;
+            break;
         }
+    }
+
+    update_global_sn(*p_cq_poll_sn, ret);
+
+    if (likely(ret > 0)) {
+        m_n_wce_counter += ret; // Actually strides count.
+        m_p_ring->m_gro_mgr.flush_all(pv_fd_ready_array);
     } else {
-        buff_status_e status = BS_OK;
-        uint32_t ret = 0;
-        while (ret < m_n_sysvar_cq_poll_batch_max) {
-            mem_buf_desc_t *buff = nullptr;
-            mem_buf_desc_t *buff_wqe = poll(status, buff);
-
-            if (buff_wqe && (++m_qp_rec.debt >= (int)m_n_sysvar_rx_num_wr_to_post_recv)) {
-                compensate_qp_poll_failed(); // Reuse this method as success.
-            }
-
-            if (buff) {
-                ++ret;
-                if (cqe_process_rx(buff, status)) {
-                    ++ret_rx_processed;
-                    process_recv_buffer(buff, pv_fd_ready_array);
-                }
-            } else if (!buff_wqe) {
-                m_b_was_drained = true;
-                break;
-            }
-        }
-
-        update_global_sn(*p_cq_poll_sn, ret);
-
-        if (likely(ret > 0)) {
-            m_n_wce_counter += ret; // Actually strides count.
-            m_p_ring->m_gro_mgr.flush_all(pv_fd_ready_array);
-        } else {
-            compensate_qp_poll_failed();
-        }
+        compensate_qp_poll_failed();
     }
 
     return ret_rx_processed;
@@ -591,14 +554,6 @@ void cq_mgr_mlx5_strq::add_qp_rx(qp_mgr *qp)
     _hot_buffer_stride = nullptr;
     _current_wqe_consumed_bytes = 0U;
     cq_mgr::add_qp_rx(qp);
-}
-
-void cq_mgr_mlx5_strq::mem_buf_desc_return_to_owner(mem_buf_desc_t *p_mem_buf_desc,
-                                                    void *pv_fd_ready_array)
-{
-    cq_logfuncall("");
-    NOT_IN_USE(pv_fd_ready_array);
-    cq_mgr::reclaim_recv_buffer_helper(p_mem_buf_desc);
 }
 
 void cq_mgr_mlx5_strq::statistics_print()

--- a/src/core/dev/cq_mgr_mlx5_strq.h
+++ b/src/core/dev/cq_mgr_mlx5_strq.h
@@ -46,11 +46,9 @@ public:
     virtual ~cq_mgr_mlx5_strq() override;
 
     virtual int drain_and_proccess(uintptr_t *p_recycle_buffers_last_wr_id = NULL) override;
+    virtual mem_buf_desc_t *poll_and_process_socketxtreme() override;
     virtual int poll_and_process_element_rx(uint64_t *p_cq_poll_sn,
                                             void *pv_fd_ready_array = NULL) override;
-    virtual mem_buf_desc_t *poll_and_process_socketxtreme() override;
-    virtual void mem_buf_desc_return_to_owner(mem_buf_desc_t *p_mem_buf_desc,
-                                              void *pv_fd_ready_array = NULL) override;
     virtual void add_qp_rx(qp_mgr *qp) override;
     virtual uint32_t clean_cq() override;
 
@@ -67,8 +65,6 @@ private:
     inline bool set_current_hot_buffer();
     inline bool strq_cqe_to_mem_buff_desc(struct xlio_mlx5_cqe *cqe, enum buff_status_e &status,
                                           bool &is_filler);
-    void cqe_to_xlio_wc_socketxtreme(struct xlio_mlx5_cqe *cqe, xlio_ibv_wc *wc);
-    int drain_and_proccess_socketxtreme(uintptr_t *p_recycle_buffers_last_wr_id);
     int drain_and_proccess_helper(mem_buf_desc_t *buff, mem_buf_desc_t *buff_wqe,
                                   buff_status_e status, uintptr_t *p_recycle_buffers_last_wr_id);
     mem_buf_desc_t *process_strq_cq_element_rx(mem_buf_desc_t *p_mem_buf_desc,

--- a/src/core/dev/qp_mgr.cpp
+++ b/src/core/dev/qp_mgr.cpp
@@ -368,6 +368,7 @@ void qp_mgr::release_rx_buffers()
     if (m_curr_rx_wr) {
         qp_logdbg("Returning %d pending post_recv buffers to CQ owner", m_curr_rx_wr);
         while (m_curr_rx_wr) {
+            // Cleaning unposted buffers. Unposted buffers are not attached to any strides.
             --m_curr_rx_wr;
             mem_buf_desc_t *p_mem_buf_desc =
                 (mem_buf_desc_t *)(uintptr_t)m_ibv_rx_wr_array[m_curr_rx_wr].wr_id;


### PR DESCRIPTION
## Description
1. Remove special socketxtreme drain and poll_and_process methods for non socketxtreme_poll flows. 

- This fixes GRO flush segfaults and allows single flow for any polling method

2. Improve GRO flush during socketxtrme_poll. 

- Allow flushed events to be collected on the same call up to a limit of ncompletions.

##### What
With this PR also following issues were not seen:
https://redmine.mellanox.com/issues/3568465
https://redmine.mellanox.com/issues/3568428

Low-scale performance crypto:
|                  |  3.20.1 |  LRO   | LRO+GRO+flags |
| ----------- | ------- | ------- | ------------------ |
| randread  |   2177  |   2199 |  2212                  |
| randwrite |   1999  |   2006 |                            |
| randrw     |  1780   |  1798  | 1840                   |

High-scale performance non-crypto:
|                  | 3.20.1  | LRO    | LRO+flags |  LRO+GRO |  LRO+GRO+flags |
| ----------- | ------- | ------- | ----------- | ------------ | ------------------- |
| randread  |  2319   |   2351 |  2357        |  2387          | 2436                    |
| randwrite  |  2098  |   2080 |  2082         |  2073          | 2095                    |
| randrw      | 2008   |  1994  | 1978          | 1992          | 2025                    |

flags:
XLIO_RX_PREFETCH_BYTES_BEFORE_POLL=0
XLIO_RX_PREFETCH_BYTES=64

GRO:
XLIO_GRO_STREAMS_MAX=9216


##### Why ?
Fixing segfaults

## Change type
What kind of change does this PR introduce?
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [X] Code follows the style de facto guidelines of this project
- [X] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

