### PR TITLE
issue: Support IP_BIND_ADDRESS_NO_PORT

### DIFF
--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -152,6 +152,11 @@ static int free_libxlio_resources()
     }
     g_p_route_table_mgr = NULL;
 
+    if (g_bind_no_port) {
+        delete g_bind_no_port;
+    }
+    g_bind_no_port = NULL;
+
     if (g_p_rule_table_mgr) {
         delete g_p_rule_table_mgr;
     }
@@ -1052,6 +1057,8 @@ static void do_global_ctors_helper()
 
     NEW_CTOR(g_p_route_table_mgr, route_table_mgr());
 
+    NEW_CTOR(g_bind_no_port, bind_no_port());
+
     NEW_CTOR(g_zc_cache, mapping_cache((size_t)safe_mce_sys().zc_cache_threshold * ONE_MB));
 
     safe_mce_sys().rx_buf_size = std::min(safe_mce_sys().rx_buf_size, 0xFF00U);
@@ -1209,6 +1216,7 @@ void reset_globals()
     g_p_event_handler_manager = NULL;
     g_p_agent = NULL;
     g_p_route_table_mgr = NULL;
+    g_bind_no_port = NULL;
     g_p_rule_table_mgr = NULL;
     g_stats_file = NULL;
     g_p_net_device_table_mgr = NULL;

--- a/src/core/sock/sock-redirect.cpp
+++ b/src/core/sock/sock-redirect.cpp
@@ -369,27 +369,42 @@ int init_child_process_for_nginx()
             // UDP sockets
             sockinfo_udp *udp_sock = dynamic_cast<sockinfo_udp *>(parent_sock_fd_api);
             if (udp_sock) {
-                int optval;
-                socklen_t optlen = sizeof(optval);
-                if (udp_sock->getsockopt(SOL_SOCKET, SO_REUSEPORT, &optval, &optlen) < 0) {
+                int reuse_port;
+                socklen_t optlen = sizeof(reuse_port);
+                if (udp_sock->getsockopt(SOL_SOCKET, SO_REUSEPORT, &reuse_port, &optlen) < 0) {
                     srdr_logdbg("fd=%d - getsockopt() failed", sock_fd);
                     continue;
                 }
                 uint16_t port = ntohs(sa.get_in_port());
-                bool use_as_udp_listen_socket = optval && port;
-                if (!use_as_udp_listen_socket) {
+                bool use_as_udp_listen_socket = false;
+                /*
+                 * Specific NGINX implementation.
+                 *
+                 * In case of "reuseport" directive
+                 * NGINX master process creates a UDP socket per worker process per port before it
+                 * forks. Therefore, each worker process attaches a single UDP socket out of
+                 * #worker_processes.
+                 *
+                 * Without "reuseport" directive, NGINX master process creates a single UDP socket
+                 * before it forks. Therefore, all worker processes attach the UDP socket (single).
+                 */
+
+                if (port) {
+                    if (reuse_port) {
+                        // In case of "reuseport", Nginx master process creates #worker_processes
+                        // number of sockets before fork. In order to use a single socket per
+                        // worker we choose a socket by g_worker_index;
+                        use_as_udp_listen_socket = (udp_sockets_per_port[port] == g_worker_index);
+                    } else {
+                        // Without "reuseport", Nginx master process creates a single socket before fork.
+                        // Use this socket for all workers - always true;
+                        use_as_udp_listen_socket = true;
+                    }
+                } else {
                     continue;
                 }
 
-                /*
-                 * DANGER: This code depends on a very specific NGINX implementation detail.
-                 * NGINX master process creates a QUIC UDP socket per worker process per port
-                 * before fork(). To ensure that the copy of the global g_p_fd_collection that
-                 * this child process has contains *only* the `sockinfo_udp` pointers that
-                 * belong to it we discard all the `sock_fd`s we aggregated in the
-                 * udp_sockets_per_port and take the one indexed by the g_worker_index.
-                 */
-                if (unlikely(udp_sockets_per_port[port] == g_worker_index)) {
+                if (use_as_udp_listen_socket) {
                     srdr_logdbg("worker %d is using fd=%d. bound to port=%d", g_worker_index,
                                 sock_fd, port);
                     g_p_fd_collection->addsocket(sock_fd, si->get_family(),

--- a/src/core/sock/sockinfo.cpp
+++ b/src/core/sock/sockinfo.cpp
@@ -59,7 +59,7 @@
 #define si_logfunc    __log_info_func
 #define si_logfuncall __log_info_funcall
 
-sockinfo::sockinfo(int fd, int domain, bool use_ring_locks)
+sockinfo::sockinfo(int fd, int domain, bool use_ring_locks, uint8_t sock_type)
     : socket_fd_api(fd)
     , m_flow_tag_enabled(false)
     , m_b_blocking(true)
@@ -71,6 +71,7 @@ sockinfo::sockinfo(int fd, int domain, bool use_ring_locks)
     , m_n_tsing_flags(0)
     , m_protocol(PROTO_UNDEFINED)
     , m_src_sel_flags(0U)
+    , m_sock_type(sock_type)
     , m_lock_rcv(MULTILOCK_RECURSIVE, MODULE_NAME "::m_lock_rcv")
     , m_lock_snd(MODULE_NAME "::m_lock_snd")
     , m_state(SOCKINFO_OPENED)
@@ -97,6 +98,7 @@ sockinfo::sockinfo(int fd, int domain, bool use_ring_locks)
     , m_n_uc_ttl_hop_lim(m_family == AF_INET
                              ? safe_mce_sys().sysctl_reader.get_net_ipv4_ttl()
                              : safe_mce_sys().sysctl_reader.get_net_ipv6_hop_limit())
+    , m_bind_no_port(0)
     , m_is_ipv6only(safe_mce_sys().sysctl_reader.get_ipv6_bindv6only())
     , m_p_rings_fds(NULL)
 {
@@ -539,6 +541,22 @@ int sockinfo::setsockopt(int __level, int __optname, const void *__optval, sockl
                 }
             }
             break;
+        case IP_BIND_ADDRESS_NO_PORT: {
+            if (__optval && __optlen == sizeof(int)) {
+                int val = *(int *)__optval;
+                m_bind_no_port = val;
+                // In TCP connect flow we don't call os.connect, as oposed to UDP connect flow.
+                // Therefore, UDP flow can support IP_BIND_ADDRESS_NO_PORT out-of-box using kernel
+                // calls.
+                ret = (get_sock_type() == SOCK_STREAM) ? SOCKOPT_INTERNAL_XLIO_SUPPORT
+                                                       : SOCKOPT_HANDLE_BY_OS;
+                break;
+            }
+            ret = SOCKOPT_NO_XLIO_SUPPORT;
+            errno = EINVAL;
+            si_logdbg("IP_BIND_ADDRESS_NO_PORT - NOT HANDLED, optval or optlen are not valid");
+            break;
+        }
         default:
             break;
         }

--- a/src/core/sock/sockinfo_tcp.h
+++ b/src/core/sock/sockinfo_tcp.h
@@ -64,6 +64,8 @@ enum tcp_sock_offload_e {
 
 enum tcp_sock_state_e {
     TCP_SOCK_INITED = 1,
+    TCP_SOCK_BOUND_NO_PORT, // internal state that indicate that bind() called after
+                            // IP_BIND_ADDRESS_NO_PORT, but before connect()
     TCP_SOCK_BOUND,
     TCP_SOCK_LISTEN_READY, // internal state that indicate that prepareListen was called
     TCP_SOCK_ACCEPT_READY,

--- a/src/core/sock/sockinfo_udp.cpp
+++ b/src/core/sock/sockinfo_udp.cpp
@@ -371,7 +371,7 @@ const char *setsockopt_level_to_str(int level)
 tscval_t g_si_tscv_last_poll = 0;
 
 sockinfo_udp::sockinfo_udp(int fd, int domain)
-    : sockinfo(fd, domain, true)
+    : sockinfo(fd, domain, true, SOCK_DGRAM)
     , m_mc_tx_src_ip(in6addr_any, domain)
     , m_b_mc_tx_loop(
           safe_mce_sys().tx_mc_loopback_default) // default value is 'true'. User can change this

--- a/src/core/util/sock_addr.h
+++ b/src/core/util/sock_addr.h
@@ -311,9 +311,9 @@ public:
         return sockaddr2str(&u_sa.m_sa, sizeof(u_sa), port);
     }
 
-protected:
     void clear_sa() { memset(&u_sa, 0, sizeof(u_sa)); }
 
+protected:
     union {
         struct sockaddr m_sa;
         struct sockaddr_in m_sa_in;


### PR DESCRIPTION
1. Support IP_BIND_ADDRESS_NO_PORT in setsockopt, for both TCP and UDP.
2. Nginx initialization for UDP listen sockets that are not set to "reuseport".

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

