### PR TITLE
issue: 3480683 Update default repo url for build_pkg.sh

### DIFF
--- a/contrib/build_pkg.sh
+++ b/contrib/build_pkg.sh
@@ -63,7 +63,7 @@ opt_input=${opt_input:=$(pwd)}
 opt_output=${opt_output:=${opt_input}/pkg}
 
 pkg_name=libxlio
-pkg_url="https://github.com/Mellanox-lab/${pkg_name}"
+pkg_url=${pkg_url:="https://github.com/Mellanox/${pkg_name}"}
 pkg_dir=${opt_output}
 pkg_log=${pkg_dir}/build_pkg.log
 pkg_src="${pkg_name}*"


### PR DESCRIPTION
## Description
Update default repo url for build_pkg.sh

##### What
Change default url to https://github.com/Mellanox/libxlio

##### Why ?
Fix clone issue.

## Change type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

