### PR TITLE
Fix dpcp CI Test buffers

### DIFF
--- a/contrib/jenkins_tests/test.sh
+++ b/contrib/jenkins_tests/test.sh
@@ -133,11 +133,11 @@ for test_link in $test_ip_list; do
 
 				${sudo_cmd} $timeout_exe ${vutil}  -a "${test_app}" -x "--load-vma=${test_lib} " -t "${test}:tc[1-9]$" \
 						-s "${test_remote_ip}" -p "${test_remote_port}" -l "${test_dir}/${test_name}.log" \
-						-e "XLIO_TX_BUFS=20000 XLIO_RX_BUFS=20000"
+						-e "XLIO_TX_BUFS=20000"
 			else
 				${sudo_cmd} $timeout_exe $PWD/tests/verifier/verifier.pl -a ${test_app} -x " --load-vma=$test_lib " \
 					-t ${test}:tc[1-9]$ -s ${test_ip} -l ${test_dir}/${test_name}.log \
-					-e " XLIO_TX_BUFS=20000 XLIO_RX_BUFS=20000 " \
+					-e " XLIO_TX_BUFS=20000 " \
 					--progress=0
 			fi
 


### PR DESCRIPTION
## Description
CI Test phase slowness

##### What
CI Test phase sets 20000 RX buffers which require too much memory in case of striding RQ.

##### Why ?
CI failures

##### How ?
Remove buffers setting from the test

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [X] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

