### PR TITLE
issue: 3592264 Fix compilation with modern clang

### DIFF
--- a/config/m4/compiler.m4
+++ b/config/m4/compiler.m4
@@ -201,7 +201,7 @@ case $CC in
     clang*|clang++*)
         AC_MSG_RESULT([clang])
         CFLAGS="$CFLAGS -Wall -Werror -Wno-self-assign"
-        CXXFLAGS="$CXXFLAGS -Wall -Werror -Wno-overloaded-virtual"
+        CXXFLAGS="$CXXFLAGS -Wall -Werror"
         # workaround for clang w/o -Wnon-c-typedef-for-linkage
         CXXFLAGS="$CXXFLAGS -Wno-unknown-warning-option -Wno-non-c-typedef-for-linkage"
         ;;

--- a/config/m4/utls.m4
+++ b/config/m4/utls.m4
@@ -53,10 +53,9 @@ AS_IF([test "$prj_cv_dpcp" -ne 0],
          [[dpcp::tis* _tis;
            dpcp::dek* _dek;
            int key_type = (int)dpcp::DEK_ATTR_TLS;
-           key_type = key_type;
            int tis_bit = (int)dpcp::TIS_ATTR_TLS;
-           tis_bit = tis_bit;
-           (void)_tis; (void)_dek;]])],
+           (void)_tis; (void)_dek;
+           (void)key_type; (void)tis_bit;]])],
          [prj_cv_dpcp_1_1_3=1])
     AC_LANG_POP()
     ])

--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -281,6 +281,7 @@ libxlio_la_SOURCES := \
 	sock/sockinfo_ulp.h \
 	sock/tcp_seg_pool.h \
 	sock/sock-redirect.h \
+	sock/sock-redirect-internal.h \
 	sock/sockinfo_nvme.h \
 	\
 	util/chunk_list.h \

--- a/src/core/dev/cq_mgr.h
+++ b/src/core/dev/cq_mgr.h
@@ -182,7 +182,7 @@ protected:
      * @p_cq_poll_sn global unique wce id that maps last wce polled
      * @return Number of successfully polled wce
      */
-    virtual int poll(xlio_ibv_wc *p_wce, int num_entries, uint64_t *p_cq_poll_sn);
+    int poll(xlio_ibv_wc *p_wce, int num_entries, uint64_t *p_cq_poll_sn);
     void compensate_qp_poll_failed();
     inline void process_recv_buffer(mem_buf_desc_t *buff, void *pv_fd_ready_array = NULL);
 

--- a/src/core/dev/cq_mgr_mlx5.h
+++ b/src/core/dev/cq_mgr_mlx5.h
@@ -79,7 +79,7 @@ protected:
     mem_buf_desc_t *m_rx_hot_buffer;
 
     inline struct xlio_mlx5_cqe *check_cqe(void);
-    virtual mem_buf_desc_t *poll(enum buff_status_e &status);
+    mem_buf_desc_t *poll(enum buff_status_e &status);
 
     inline struct xlio_mlx5_cqe *get_cqe_tx(uint32_t &num_polled_cqes);
     void log_cqe_error(struct xlio_mlx5_cqe *cqe);

--- a/src/core/dev/qp_mgr_eth_mlx5.h
+++ b/src/core/dev/qp_mgr_eth_mlx5.h
@@ -75,16 +75,18 @@ public:
     xlio_ib_mlx5_qp_t m_mlx5_qp;
 
 #ifdef DEFINED_UTLS
-    xlio_tis *tls_context_setup_tx(const xlio_tls_info *info);
-    xlio_tir *tls_create_tir(bool cached);
+    xlio_tis *tls_context_setup_tx(const xlio_tls_info *info) override;
+    xlio_tir *tls_create_tir(bool cached) override;
     int tls_context_setup_rx(xlio_tir *tir, const xlio_tls_info *info, uint32_t next_record_tcp_sn,
-                             xlio_comp_cb_t callback, void *callback_arg);
-    void tls_context_resync_tx(const xlio_tls_info *info, xlio_tis *tis, bool skip_static);
-    void tls_resync_rx(xlio_tir *tir, const xlio_tls_info *info, uint32_t hw_resync_tcp_sn);
-    void tls_get_progress_params_rx(xlio_tir *tir, void *buf, uint32_t lkey);
-    void tls_release_tis(xlio_tis *tis);
-    void tls_release_tir(xlio_tir *tir);
-    void tls_tx_post_dump_wqe(xlio_tis *tis, void *addr, uint32_t len, uint32_t lkey, bool first);
+                             xlio_comp_cb_t callback, void *callback_arg) override;
+    void tls_context_resync_tx(const xlio_tls_info *info, xlio_tis *tis, bool skip_static) override;
+    void tls_resync_rx(xlio_tir *tir, const xlio_tls_info *info,
+                       uint32_t hw_resync_tcp_sn) override;
+    void tls_get_progress_params_rx(xlio_tir *tir, void *buf, uint32_t lkey) override;
+    void tls_release_tis(xlio_tis *tis) override;
+    void tls_release_tir(xlio_tir *tir) override;
+    void tls_tx_post_dump_wqe(xlio_tis *tis, void *addr, uint32_t len, uint32_t lkey,
+                              bool first) override;
 #endif /* DEFINED_UTLS */
 #ifdef DEFINED_DPCP
 #define DPCP_TIS_FLAGS     (dpcp::TIS_ATTR_TRANSPORT_DOMAIN | dpcp::TIS_ATTR_PD)

--- a/src/core/dev/ring_simple.h
+++ b/src/core/dev/ring_simple.h
@@ -131,10 +131,10 @@ public:
     void modify_cq_moderation(uint32_t period, uint32_t count);
 
 #ifdef DEFINED_UTLS
-    bool tls_tx_supported(void) { return m_tls.tls_tx; }
-    bool tls_rx_supported(void) { return m_tls.tls_rx; }
+    bool tls_tx_supported(void) override { return m_tls.tls_tx; }
+    bool tls_rx_supported(void) override { return m_tls.tls_rx; }
     bool tls_sync_dek_supported() { return m_tls.tls_synchronize_dek; }
-    xlio_tis *tls_context_setup_tx(const xlio_tls_info *info)
+    xlio_tis *tls_context_setup_tx(const xlio_tls_info *info) override
     {
         std::lock_guard<decltype(m_lock_ring_tx)> lock(m_lock_ring_tx);
 
@@ -149,7 +149,7 @@ public:
 
         return tis;
     }
-    xlio_tir *tls_create_tir(bool cached)
+    xlio_tir *tls_create_tir(bool cached) override
     {
         /*
          * This method can be called for either RX or TX ring.
@@ -159,7 +159,7 @@ public:
         return m_p_qp_mgr->tls_create_tir(cached);
     }
     int tls_context_setup_rx(xlio_tir *tir, const xlio_tls_info *info, uint32_t next_record_tcp_sn,
-                             xlio_comp_cb_t callback, void *callback_arg)
+                             xlio_comp_cb_t callback, void *callback_arg) override
     {
         /* Protect with TX lock since we post WQEs to the send queue. */
         std::lock_guard<decltype(m_lock_ring_tx)> lock(m_lock_ring_tx);
@@ -176,7 +176,7 @@ public:
 
         return rc;
     }
-    void tls_context_resync_tx(const xlio_tls_info *info, xlio_tis *tis, bool skip_static)
+    void tls_context_resync_tx(const xlio_tls_info *info, xlio_tis *tis, bool skip_static) override
     {
         std::lock_guard<decltype(m_lock_ring_tx)> lock(m_lock_ring_tx);
         m_p_qp_mgr->tls_context_resync_tx(info, tis, skip_static);
@@ -184,12 +184,12 @@ public:
         uint64_t dummy_poll_sn = 0;
         m_p_cq_mgr_tx->poll_and_process_element_tx(&dummy_poll_sn);
     }
-    void tls_resync_rx(xlio_tir *tir, const xlio_tls_info *info, uint32_t hw_resync_tcp_sn)
+    void tls_resync_rx(xlio_tir *tir, const xlio_tls_info *info, uint32_t hw_resync_tcp_sn) override
     {
         std::lock_guard<decltype(m_lock_ring_tx)> lock(m_lock_ring_tx);
         m_p_qp_mgr->tls_resync_rx(tir, info, hw_resync_tcp_sn);
     }
-    void tls_get_progress_params_rx(xlio_tir *tir, void *buf, uint32_t lkey)
+    void tls_get_progress_params_rx(xlio_tir *tir, void *buf, uint32_t lkey) override
     {
         std::lock_guard<decltype(m_lock_ring_tx)> lock(m_lock_ring_tx);
         if (lkey == LKEY_USE_DEFAULT) {
@@ -200,18 +200,19 @@ public:
         uint64_t dummy_poll_sn = 0;
         m_p_cq_mgr_tx->poll_and_process_element_tx(&dummy_poll_sn);
     }
-    void tls_release_tis(xlio_tis *tis)
+    void tls_release_tis(xlio_tis *tis) override
     {
         std::lock_guard<decltype(m_lock_ring_tx)> lock(m_lock_ring_tx);
         m_p_qp_mgr->tls_release_tis(tis);
     }
-    void tls_release_tir(xlio_tir *tir)
+    void tls_release_tir(xlio_tir *tir) override
     {
         /* TIR objects are protected with TX lock */
         std::lock_guard<decltype(m_lock_ring_tx)> lock(m_lock_ring_tx);
         m_p_qp_mgr->tls_release_tir(tir);
     }
-    void tls_tx_post_dump_wqe(xlio_tis *tis, void *addr, uint32_t len, uint32_t lkey, bool first)
+    void tls_tx_post_dump_wqe(xlio_tis *tis, void *addr, uint32_t len, uint32_t lkey,
+                              bool first) override
     {
         std::lock_guard<decltype(m_lock_ring_tx)> lock(m_lock_ring_tx);
         if (lkey == LKEY_USE_DEFAULT) {

--- a/src/core/proto/dst_entry.cpp
+++ b/src/core/proto/dst_entry.cpp
@@ -421,6 +421,12 @@ void dst_entry::notify_cb()
     set_state(false);
 }
 
+void dst_entry::notify_cb(event *ev)
+{
+    NOT_IN_USE(ev);
+    notify_cb();
+}
+
 void dst_entry::configure_ip_header(header *h, uint16_t packet_id)
 {
     h->configure_ip_header(get_protocol_type(), m_pkt_src_ip, m_dst_ip, *this, packet_id);

--- a/src/core/proto/dst_entry.h
+++ b/src/core/proto/dst_entry.h
@@ -78,6 +78,7 @@ public:
     virtual ~dst_entry();
 
     virtual void notify_cb();
+    virtual void notify_cb(event *ev);
 
     virtual bool prepare_to_send(struct xlio_rate_limit_t &rate_limit, bool skip_rules = false,
                                  bool is_connect = false);

--- a/src/core/sock/pipeinfo.cpp
+++ b/src/core/sock/pipeinfo.cpp
@@ -329,9 +329,11 @@ void pipeinfo::write_lbm_pipe_enhance()
     orig_os_api.write(m_fd, buf, 1);
 }
 
-void pipeinfo::statistics_print()
+void pipeinfo::statistics_print(vlog_levels_t log_level)
 {
     bool b_any_activiy = false;
+    NOT_IN_USE(log_level);
+
     if (m_p_socket_stats->counters.n_tx_sent_byte_count ||
         m_p_socket_stats->counters.n_tx_sent_pkt_count || m_p_socket_stats->counters.n_tx_errors ||
         m_p_socket_stats->counters.n_tx_eagain) {

--- a/src/core/sock/pipeinfo.h
+++ b/src/core/sock/pipeinfo.h
@@ -64,7 +64,7 @@ public:
     // true)
     ssize_t tx(xlio_tx_call_attr_t &tx_arg);
 
-    void statistics_print();
+    void statistics_print(vlog_levels_t log_level = VLOG_DEBUG);
 
     virtual inline fd_type_t get_type() { return FD_TYPE_PIPE; }
 

--- a/src/core/sock/sock-redirect-internal.h
+++ b/src/core/sock/sock-redirect-internal.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2001-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef SOCK_REDIRECT_INTERNAL_H
+#define SOCK_REDIRECT_INTERNAL_H
+
+#include "config.h"
+
+/*
+ * Workaround for clang compilation error with fortified wrapper redefinition.
+ */
+#ifdef __clang__
+#ifdef HAVE___READ_CHK
+#define read read_unused
+#endif
+#ifdef HAVE___RECV_CHK
+#define recv recv_unused
+#endif
+#ifdef HAVE___RECVFROM_CHK
+#define recvfrom recvfrom_unused
+#endif
+#ifdef HAVE___POLL_CHK
+#define poll poll_unused
+#endif
+#ifdef HAVE___PPOLL_CHK
+#define ppoll ppoll_unused
+#endif
+#endif /* __clang__ */
+#include <unistd.h>
+#include <sys/socket.h>
+#include <poll.h>
+#ifdef __clang__
+#ifdef HAVE___READ_CHK
+#undef read
+#endif
+#ifdef HAVE___RECV_CHK
+#undef recv
+#endif
+#ifdef HAVE___RECVFROM_CHK
+#undef recvfrom
+#endif
+#ifdef HAVE___POLL_CHK
+#undef poll
+#endif
+#ifdef HAVE___PPOLL_CHK
+#undef ppoll
+#endif
+#endif /* __clang__ */
+
+#endif /* SOCK_REDIRECT_INTERNAL_H */

--- a/src/core/sock/sock-redirect.cpp
+++ b/src/core/sock/sock-redirect.cpp
@@ -30,6 +30,8 @@
  * SOFTWARE.
  */
 
+// sock-redirect-internal.h must be first
+#include "sock-redirect-internal.h"
 #include "sock-redirect.h"
 
 #include <sys/time.h>

--- a/src/core/sock/sockinfo_tcp.cpp
+++ b/src/core/sock/sockinfo_tcp.cpp
@@ -1057,7 +1057,6 @@ retry_is_ready:
             if (tx_size == 0) {
                 if (unlikely(!is_rts())) {
                     si_tcp_logdbg("TX on disconnected socket");
-                    ret = -1;
                     errno = ECONNRESET;
                     goto err;
                 }

--- a/src/core/sock/sockinfo_ulp.h
+++ b/src/core/sock/sockinfo_ulp.h
@@ -101,7 +101,7 @@ private:
     void terminate_session_fatal(uint8_t alert_type);
 
     err_t tls_rx_consume_ready_packets(void);
-    err_t recv(struct pbuf *p);
+    err_t recv(struct pbuf *p) override;
     void copy_by_offset(uint8_t *dst, uint32_t offset, uint32_t len);
     uint16_t offset_to_host16(uint32_t offset);
     int tls_rx_decrypt(struct pbuf *plist);

--- a/tools/daemon/tc.c
+++ b/tools/daemon/tc.c
@@ -282,8 +282,10 @@ int tc_add_filter_link(tc_t tc, int ifindex, int prio, int ht, int id, struct so
     uint32_t opt_ht = HANDLE_SET(ht, 0, 0);
     struct rtattr *opts = NULL;
     struct {
-        struct tc_u32_sel sel;
-        struct tc_u32_key keys[20];
+        union {
+            struct tc_u32_sel sel;
+            uint8_t pad[sizeof(struct tc_u32_sel) + sizeof(struct tc_u32_key) * 20U];
+        };
     } opt_sel;
 
     tc_req(tc, ifindex, proto, RTM_NEWTFILTER,
@@ -362,8 +364,10 @@ int tc_add_filter_tap2dev(tc_t tc, int ifindex, int prio, int id, short proto,
     uint32_t opt_ht = HANDLE_SET(0x800, 0, 0);
     struct rtattr *opts = NULL;
     struct {
-        struct tc_u32_sel sel;
-        struct tc_u32_key keys[20];
+        union {
+            struct tc_u32_sel sel;
+            uint8_t pad[sizeof(struct tc_u32_sel) + sizeof(struct tc_u32_key) * 20U];
+        };
     } opt_sel;
 
     tc_req(tc, ifindex, proto, RTM_NEWTFILTER,
@@ -501,8 +505,10 @@ int tc_add_filter_dev2tap(tc_t tc, int ifindex, int prio, int ht, int bkt, int i
     uint32_t opt_ht = HANDLE_SET(ht, bkt, 0);
     struct rtattr *opts = NULL;
     struct {
-        struct tc_u32_sel sel;
-        struct tc_u32_key keys[10];
+        union {
+            struct tc_u32_sel sel;
+            uint8_t pad[sizeof(struct tc_u32_sel) + sizeof(struct tc_u32_key) * 10U];
+        };
     } opt_sel;
 
     tc_req(tc, ifindex, proto, RTM_NEWTFILTER,


### PR DESCRIPTION
## Description
There are multiple issues with clang:

- UTLS detection always fails because clang doesn't build the autotools code snippet
- UTLS related code doesn't have consistent override keyword
- xliod fails to compile because of a GNU extension
- clang fails to compile XLIO syscall implementation when the fortified version exists

##### What
Fix compilation errors with clang-16.

##### Why ?
Compilation issues.

## Change type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

