### PR TITLE
issue: 3580073 Add option_size for size parameters

### DIFF
--- a/README
+++ b/README
@@ -86,11 +86,11 @@ Example:
  XLIO DETAILS: Ring On Device Memory TX       0                          [XLIO_RING_DEV_MEM_TX]
  XLIO DETAILS: TCP max syn rate               0 (no limit)               [XLIO_TCP_MAX_SYN_RATE]
  XLIO DETAILS: Zerocopy Mem Bufs              200000                     [XLIO_ZC_BUFS]
- XLIO DETAILS: Zerocopy Cache Threshold       10240                      [XLIO_ZC_CACHE_THRESHOLD]
+ XLIO DETAILS: Zerocopy Cache Threshold       10 GB                      [XLIO_ZC_CACHE_THRESHOLD]
  XLIO DETAILS: Tx Mem Segs TCP                1000000                    [XLIO_TX_SEGS_TCP]
  XLIO DETAILS: Tx Mem Bufs                    200000                     [XLIO_TX_BUFS]
  XLIO DETAILS: Tx Mem Buf size                0                          [XLIO_TX_BUF_SIZE]
- XLIO DETAILS: ZC TX size                     32768                      [XLIO_ZC_TX_SIZE]
+ XLIO DETAILS: ZC TX size                     32 KB                      [XLIO_ZC_TX_SIZE]
  XLIO DETAILS: Tx QP WRE                      32768                      [XLIO_TX_WRE]
  XLIO DETAILS: Tx QP WRE Batching             64                         [XLIO_TX_WRE_BATCHING]
  XLIO DETAILS: Tx Max QP INLINE               204                        [XLIO_TX_MAX_INLINE]
@@ -99,7 +99,7 @@ Example:
  XLIO DETAILS: Tx Prefetch Bytes              256                        [XLIO_TX_PREFETCH_BYTES]
  XLIO DETAILS: Tx Bufs Batch TCP              16                         [XLIO_TX_BUFS_BATCH_TCP]
  XLIO DETAILS: Tx Segs Batch TCP              64                         [XLIO_TX_SEGS_BATCH_TCP]
- XLIO DETAILS: TCP Send Buffer size           1000000                    [XLIO_TCP_SEND_BUFFER_SIZE]
+ XLIO DETAILS: TCP Send Buffer size           1 MB                       [XLIO_TCP_SEND_BUFFER_SIZE]
  XLIO DETAILS: Rx Mem Bufs                    200000                     [XLIO_RX_BUFS]
  XLIO DETAILS: Rx Mem Buf size                0                          [XLIO_RX_BUF_SIZE]
  XLIO DETAILS: Rx QP WRE                      16000                      [XLIO_RX_WRE]
@@ -137,7 +137,7 @@ Example:
  XLIO DETAILS: Offloaded Sockets              Enabled                    [XLIO_OFFLOADED_SOCKETS]
  XLIO DETAILS: Timer Resolution (msec)        10                         [XLIO_TIMER_RESOLUTION_MSEC]
  XLIO DETAILS: TCP Timer Resolution (msec)    100                        [XLIO_TCP_TIMER_RESOLUTION_MSEC]
- XLIO DETAILS: TCP control thread             0 (Disabled)               [XLIO_TCP_CTL_THREAD]
+ XLIO DETAILS: TCP control thread             Disabled                   [XLIO_TCP_CTL_THREAD]
  XLIO DETAILS: TCP timestamp option           0                          [XLIO_TCP_TIMESTAMP_OPTION]
  XLIO DETAILS: TCP nodelay                    0                          [XLIO_TCP_NODELAY]
  XLIO DETAILS: TCP quickack                   0                          [XLIO_TCP_QUICKACK]
@@ -150,7 +150,7 @@ Example:
  XLIO DETAILS: Internal Thread Arm CQ         Disabled                   [XLIO_INTERNAL_THREAD_ARM_CQ]
  XLIO DETAILS: Thread mode                    Multi spin lock            [XLIO_THREAD_MODE]
  XLIO DETAILS: Buffer batching mode           1 (Batch and reclaim buffers) [XLIO_BUFFER_BATCHING_MODE]
- XLIO DETAILS: Mem Allocate type              2 (Huge Pages)             [XLIO_MEM_ALLOC_TYPE]
+ XLIO DETAILS: Mem Allocation type            Huge pages                 [XLIO_MEM_ALLOC_TYPE]
  XLIO DETAILS: Num of UC ARPs                 3                          [XLIO_NEIGH_UC_ARP_QUATA]
  XLIO DETAILS: UC ARP delay (msec)            10000                      [XLIO_NEIGH_UC_ARP_DELAY_MSEC]
  XLIO DETAILS: Num of neigh restart retries   1                          [XLIO_NEIGH_NUM_ERR_RETRIES]
@@ -171,8 +171,8 @@ Example:
  XLIO DETAILS: TCP abort on close             Disabled                   [XLIO_TCP_ABORT_ON_CLOSE]
  XLIO DETAILS: Polling Rx on Tx TCP           Disabled                   [XLIO_RX_POLL_ON_TX_TCP]
  XLIO DETAILS: Trig dummy send getsockname()  Disabled                   [XLIO_TRIGGER_DUMMY_SEND_GETSOCKNAME]
- XLIO DETAILS: Skip CQ polling in rx          0 (Disabled)               [XLIO_SKIP_POLL_IN_RX]
- XLIO DETAILS: Lock Type                      0 (Spin)                   [XLIO_MULTILOCK]
+ XLIO DETAILS: Skip CQ polling in rx          Disabled                   [XLIO_SKIP_POLL_IN_RX]
+ XLIO DETAILS: Lock Type                      Spin                       [XLIO_MULTILOCK]
  XLIO INFO   : ---------------------------------------------------------------------------
 
 XLIO_TRACELEVEL
@@ -317,8 +317,8 @@ Number of global zerocopy data buffer elements allocation.
 Default value is 200000
 
 XLIO_ZC_CACHE_THRESHOLD
-Memory limit for zerocopy (mapping) cache in MB.
-Default value is 10240
+Memory limit for the mapping cache which is use by sendfile().
+Default value is 10GB
 
 XLIO_TX_SEGS_TCP
 Number of TCP LWIP segments allocation for each XLIO process.
@@ -1018,13 +1018,13 @@ Use value of 2 in order to disable the congestion algorithm.
 Default value is 0 (LWIP).
 
 XLIO_TCP_SEND_BUFFER_SIZE
-TCP send buffer size in bytes of LWIP.
-Default value is 1000000.
+TCP send buffer size of LWIP.
+Default value is 1MB.
 
 XLIO_ZC_TX_SIZE
 Determines the maximum segment size for zero copy buffers.
 Maximum value is 65535.
-Default value is 32768.
+Default value is 32KB.
 
 XLIO_TCP_MAX_SYN_RATE
 Limit the number of TCP SYN packets that XLIO will handle

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -106,7 +106,6 @@ bool g_is_forked_child = false;
 bool g_init_global_ctors_done = true;
 static command_netlink *s_cmd_nl = NULL;
 #define MAX_VERSION_STR_LEN 128
-#define ONE_MB              (1024 * 1024)
 
 global_stats_t g_global_stat_static;
 
@@ -543,16 +542,17 @@ void print_xlio_global_settings()
 
     VLOG_PARAM_NUMBER("Zerocopy Mem Bufs", safe_mce_sys().zc_num_bufs, MCE_DEFAULT_ZC_NUM_BUFS,
                       SYS_VAR_ZC_NUM_BUFS);
-    VLOG_PARAM_NUMBER("Zerocopy Cache Threshold", safe_mce_sys().zc_cache_threshold,
-                      MCE_DEFAULT_ZC_CACHE_THRESHOLD, SYS_VAR_ZC_CACHE_THRESHOLD);
+    VLOG_PARAM_STRING("Zerocopy Cache Threshold", safe_mce_sys().zc_cache_threshold,
+                      MCE_DEFAULT_ZC_CACHE_THRESHOLD, SYS_VAR_ZC_CACHE_THRESHOLD,
+                      option_size::to_str(safe_mce_sys().zc_cache_threshold));
     VLOG_PARAM_NUMBER("Tx Mem Segs TCP", safe_mce_sys().tx_num_segs_tcp,
                       MCE_DEFAULT_TX_NUM_SEGS_TCP, SYS_VAR_TX_NUM_SEGS_TCP);
     VLOG_PARAM_NUMBER("Tx Mem Bufs", safe_mce_sys().tx_num_bufs, MCE_DEFAULT_TX_NUM_BUFS,
                       SYS_VAR_TX_NUM_BUFS);
-    VLOG_PARAM_NUMBER("Tx Mem Buf size", safe_mce_sys().tx_buf_size, MCE_DEFAULT_TX_BUF_SIZE,
-                      SYS_VAR_TX_BUF_SIZE);
-    VLOG_PARAM_NUMBER("ZC TX size", safe_mce_sys().zc_tx_size, MCE_DEFAULT_ZC_TX_SIZE,
-                      SYS_VAR_ZC_TX_SIZE);
+    VLOG_PARAM_STRING("Tx Mem Buf size", safe_mce_sys().tx_buf_size, MCE_DEFAULT_TX_BUF_SIZE,
+                      SYS_VAR_TX_BUF_SIZE, option_size::to_str(safe_mce_sys().tx_buf_size));
+    VLOG_PARAM_STRING("ZC TX size", safe_mce_sys().zc_tx_size, MCE_DEFAULT_ZC_TX_SIZE,
+                      SYS_VAR_ZC_TX_SIZE, option_size::to_str(safe_mce_sys().zc_tx_size));
     VLOG_PARAM_NUMBER("Tx QP WRE", safe_mce_sys().tx_num_wr, MCE_DEFAULT_TX_NUM_WRE,
                       SYS_VAR_TX_NUM_WRE);
     VLOG_PARAM_NUMBER("Tx QP WRE Batching", safe_mce_sys().tx_num_wr_to_signal,
@@ -573,8 +573,9 @@ void print_xlio_global_settings()
                       MCE_DEFAULT_TX_SEGS_BATCH_TCP, SYS_VAR_TX_SEGS_BATCH_TCP);
     VLOG_PARAM_NUMBER("Tx Segs Ring Batch TCP", safe_mce_sys().tx_segs_ring_batch_tcp,
                       MCE_DEFAULT_TX_SEGS_RING_BATCH_TCP, SYS_VAR_TX_SEGS_RING_BATCH_TCP);
-    VLOG_PARAM_NUMBER("TCP Send Buffer size", safe_mce_sys().tcp_send_buffer_size,
-                      MCE_DEFAULT_TCP_SEND_BUFFER_SIZE, SYS_VAR_TCP_SEND_BUFFER_SIZE);
+    VLOG_PARAM_STRING("TCP Send Buffer size", safe_mce_sys().tcp_send_buffer_size,
+                      MCE_DEFAULT_TCP_SEND_BUFFER_SIZE, SYS_VAR_TCP_SEND_BUFFER_SIZE,
+                      option_size::to_str(safe_mce_sys().tcp_send_buffer_size));
     VLOG_PARAM_NUMBER(
         "Rx Mem Bufs", safe_mce_sys().rx_num_bufs,
         (safe_mce_sys().enable_striding_rq ? MCE_DEFAULT_STRQ_NUM_BUFS : MCE_DEFAULT_RX_NUM_BUFS),
@@ -1052,7 +1053,7 @@ static void do_global_ctors_helper()
 
     NEW_CTOR(g_bind_no_port, bind_no_port());
 
-    NEW_CTOR(g_zc_cache, mapping_cache((size_t)safe_mce_sys().zc_cache_threshold * ONE_MB));
+    NEW_CTOR(g_zc_cache, mapping_cache(safe_mce_sys().zc_cache_threshold));
 
     safe_mce_sys().rx_buf_size = std::min(safe_mce_sys().rx_buf_size, 0xFF00U);
     if (safe_mce_sys().rx_buf_size <=

--- a/src/core/util/sys_vars.cpp
+++ b/src/core/util/sys_vars.cpp
@@ -312,7 +312,7 @@ OPTION_FROM_TO_STR_IMPL
 
 namespace option_tcp_ctl_thread {
 static option_t<mode_t> options[] = {
-    {CTL_THREAD_DISABLE, "Disable", {"disable", NULL, NULL}},
+    {CTL_THREAD_DISABLE, "Disabled", {"disable", "disabled", NULL}},
     {CTL_THREAD_DELEGATE_TCP_TIMERS, "Delegated TCP timers", {"delegate", NULL, NULL}},
     {CTL_THREAD_WITH_WAKEUP, "With Wakeup", {"with_wakeup", NULL, NULL}},
     {CTL_THREAD_NO_WAKEUP, "No Wakeup", {"no_wakeup", NULL, NULL}}};

--- a/src/core/util/sys_vars.cpp
+++ b/src/core/util/sys_vars.cpp
@@ -1036,7 +1036,7 @@ void mce_sys_var::get_env_params()
             256; // MCE_DEFAULT_TCP_TIMER_RESOLUTION_MSEC (10), TCP logical timer resolution, reduce
                  // CPU utilization of internal thread.
         tcp_send_buffer_size =
-            2000000; // MCE_DEFAULT_TCP_SEND_BUFFER_SIZE (1000000), LWIP TCP send buffer size.
+            2 * 1024 * 1024; // MCE_DEFAULT_TCP_SEND_BUFFER_SIZE (1 MB), LWIP TCP send buffer size.
         tcp_push_flag = false; // MCE_DEFAULT_TCP_PUSH_FLAG (true), When false, we don't set PSH
                                // flag in outgoing TCP segments.
         progress_engine_wce_max =
@@ -1090,7 +1090,7 @@ void mce_sys_var::get_env_params()
             256; // MCE_DEFAULT_TCP_TIMER_RESOLUTION_MSEC (10), TCP logical timer resolution, reduce
                  // CPU utilization of internal thread.
         tcp_send_buffer_size =
-            2000000; // MCE_DEFAULT_TCP_SEND_BUFFER_SIZE (1000000), LWIP TCP send buffer size.
+            2 * 1024 * 1024; // MCE_DEFAULT_TCP_SEND_BUFFER_SIZE (1 MB), LWIP TCP send buffer size.
         tcp_push_flag = false; // MCE_DEFAULT_TCP_PUSH_FLAG (true), When false, we don't set PSH
                                // flag in outgoing TCP segments.
         progress_engine_wce_max =
@@ -1245,7 +1245,7 @@ void mce_sys_var::get_env_params()
     }
 
     if ((env_ptr = getenv(SYS_VAR_ZC_CACHE_THRESHOLD)) != NULL) {
-        zc_cache_threshold = (uint32_t)atoi(env_ptr);
+        zc_cache_threshold = option_size::from_str(env_ptr);
     }
 
     if ((env_ptr = getenv(SYS_VAR_TX_NUM_SEGS_TCP)) != NULL) {
@@ -1257,14 +1257,14 @@ void mce_sys_var::get_env_params()
     }
 
     if ((env_ptr = getenv(SYS_VAR_TX_BUF_SIZE)) != NULL) {
-        tx_buf_size = (uint32_t)atoi(env_ptr);
+        tx_buf_size = (uint32_t)option_size::from_str(env_ptr);
     }
 
     if ((env_ptr = getenv(SYS_VAR_ZC_TX_SIZE)) != NULL) {
-        zc_tx_size = (uint32_t)atoi(env_ptr);
+        zc_tx_size = (uint32_t)option_size::from_str(env_ptr);
         if (zc_tx_size > MCE_MAX_ZC_TX_SIZE) {
-            vlog_printf(VLOG_ERROR,
-                        "ZC TX size [%d] exceeds the maximum (max=%d), setting to default.\n",
+            vlog_printf(VLOG_WARNING,
+                        "ZC TX size [%u] exceeds the maximum (max=%u), setting to default.\n",
                         zc_tx_size, MCE_MAX_ZC_TX_SIZE);
             zc_tx_size = MCE_DEFAULT_ZC_TX_SIZE;
         }
@@ -1373,7 +1373,7 @@ void mce_sys_var::get_env_params()
     }
 
     if ((env_ptr = getenv(SYS_VAR_RX_BUF_SIZE)) != NULL) {
-        rx_buf_size = (uint32_t)atoi(env_ptr);
+        rx_buf_size = (uint32_t)option_size::from_str(env_ptr);
     }
 
     if ((env_ptr = getenv(SYS_VAR_RX_NUM_WRE_TO_POST_RECV)) != NULL) {
@@ -1659,9 +1659,9 @@ void mce_sys_var::get_env_params()
     }
 
     if ((env_ptr = getenv(SYS_VAR_USER_HUGE_PAGE_SIZE)) != NULL) {
-        user_huge_page_size = (size_t)atoi(env_ptr);
-        if (!user_huge_page_size) {
-            user_huge_page_size = (size_t)strtoul(env_ptr, NULL, 16);
+        user_huge_page_size = option_size::from_str(env_ptr);
+        if (user_huge_page_size == 0) {
+            user_huge_page_size = g_hugepage_mgr.get_default_hugepage();
         }
     }
 
@@ -1943,7 +1943,7 @@ void mce_sys_var::get_env_params()
     }
 
     if ((env_ptr = getenv(SYS_VAR_TCP_SEND_BUFFER_SIZE)) != NULL) {
-        tcp_send_buffer_size = (uint32_t)atoi(env_ptr);
+        tcp_send_buffer_size = (uint32_t)option_size::from_str(env_ptr);
     }
 
     if ((env_ptr = getenv(SYS_VAR_SKIP_POLL_IN_RX)) != NULL) {

--- a/src/core/util/sys_vars.h
+++ b/src/core/util/sys_vars.h
@@ -197,6 +197,11 @@ const char *to_str(xlio_spec_t level);
     mode_t from_int(const int option, mode_t def_value);                                           \
     const char *to_str(mode_t option)
 
+namespace option_size {
+size_t from_str(const char *str);
+const char *to_str(size_t size);
+} // namespace option_size
+
 namespace option_3 {
 typedef enum { AUTO_ON_OFF_DEF } mode_t;
 OPTIONS_FROM_TO_STR_DEF;

--- a/src/core/util/sys_vars.h
+++ b/src/core/util/sys_vars.h
@@ -368,8 +368,8 @@ public:
     int ring_dev_mem_tx;
     int tcp_max_syn_rate;
 
+    size_t zc_cache_threshold;
     uint32_t zc_num_bufs;
-    uint32_t zc_cache_threshold;
     uint32_t tx_num_segs_tcp;
     uint32_t tx_num_bufs;
     uint32_t tx_buf_size;
@@ -703,7 +703,7 @@ extern mce_sys_var &safe_mce_sys();
  * This block consists of default values for library specific
  * configuration variables
  */
-#define MCE_DEFAULT_TCP_SEND_BUFFER_SIZE     (1000000)
+#define MCE_DEFAULT_TCP_SEND_BUFFER_SIZE     (1024 * 1024)
 #define MCE_DEFAULT_LOG_FILE                 ("")
 #define MCE_DEFAULT_CONF_FILE                ("/etc/libxlio.conf")
 #define MCE_DEFAULT_STATS_FILE               ("")
@@ -726,7 +726,7 @@ extern mce_sys_var &safe_mce_sys();
 #define MCE_DEFAULT_ZC_NUM_BUFS              (200000)
 #define MCE_DEFAULT_ZC_TX_SIZE               (32768)
 #define MCE_DEFAULT_TCP_NODELAY_TRESHOLD     (0)
-#define MCE_DEFAULT_ZC_CACHE_THRESHOLD       (10 * 1024) // 10GB
+#define MCE_DEFAULT_ZC_CACHE_THRESHOLD       (10LU * 1024 * 1024 * 1024) // 10GB
 #define MCE_DEFAULT_TX_NUM_SEGS_TCP          (1000000)
 #define MCE_DEFAULT_TX_NUM_BUFS              (200000)
 #define MCE_DEFAULT_TX_BUF_SIZE              (0)


### PR DESCRIPTION
## Description
This is a part of hugepage optimization effort. PR is rebased on top of #22, only 2 commits are relevant.

Introduce option_size namespace with from_str() and to_str() methods to simplify and unify parameters which represent size. This approach follows other option-like implementations.

option_size::from_str() accepts dec, hex, oct formats and case insensitive suffixes B, K/KB, M/MB, G/GB. This is more convenient for big numbers.

##### What
Introduce option_size namespace with from_str() and to_str() methods.

##### Why ?
Simplify and unify parameters which represent size. Out of box user experience improvement.

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

