### PR TITLE
issue: 3601148 Fixing IPv6 header copy

### DIFF
--- a/src/core/proto/header.cpp
+++ b/src/core/proto/header.cpp
@@ -46,7 +46,6 @@ header::header()
     : m_actual_hdr_addr(0)
     , m_transport_header_tx_offset(0)
     , m_is_vlan_enabled(false)
-    , m_transport_type(XLIO_TRANSPORT_UNKNOWN)
 {
     header::init();
 }
@@ -59,7 +58,6 @@ header::header(const header &h)
     m_aligned_l2_l3_len = h.m_aligned_l2_l3_len;
     m_transport_header_tx_offset = h.m_transport_header_tx_offset;
     m_is_vlan_enabled = h.m_is_vlan_enabled;
-    m_transport_type = h.m_transport_type;
     m_actual_hdr_addr = 0;
 }
 
@@ -270,13 +268,13 @@ header_ipv6::header_ipv6()
     : header()
 {
     header_ipv6::init();
-    update_actual_hdr_addr();
 }
 
 header_ipv6::header_ipv6(const header_ipv6 &h)
     : header(h)
 {
     m_header = h.m_header;
+    update_actual_hdr_addr();
 };
 
 void header_ipv6::configure_ip_header(uint8_t protocol, const ip_address &src,

--- a/src/core/proto/header.h
+++ b/src/core/proto/header.h
@@ -154,7 +154,6 @@ public:
     uint16_t m_aligned_l2_l3_len;
     uint16_t m_transport_header_tx_offset;
     bool m_is_vlan_enabled;
-    transport_type_t m_transport_type;
 };
 
 class header_ipv4 : public header {


### PR DESCRIPTION
## Description
Segfault during IPv6 send packets

##### What
IPv6 header copy constructor does not set m_actual_hdr_addr.
The issue popped out after latest changes.

##### Why ?
Fix crash

## Change type
What kind of change does this PR introduce?
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [X] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

