### PR TITLE
issue: 3286324 Fixing stuck empty rx ring cleanup

### DIFF
--- a/src/core/dev/qp_mgr.cpp
+++ b/src/core/dev/qp_mgr.cpp
@@ -384,7 +384,7 @@ void qp_mgr::release_rx_buffers()
               m_last_posted_rx_wr_id);
     uintptr_t last_polled_rx_wr_id = 0;
     while (m_p_cq_mgr_rx && last_polled_rx_wr_id != m_last_posted_rx_wr_id && errno != EIO &&
-           !m_p_ib_ctx_handler->is_removed()) {
+           !m_p_ib_ctx_handler->is_removed() && !is_rq_empty()) {
 
         // Process the FLUSH'ed WQE's
         int ret = m_p_cq_mgr_rx->drain_and_proccess(&last_polled_rx_wr_id);

--- a/src/core/dev/qp_mgr.h
+++ b/src/core/dev/qp_mgr.h
@@ -383,7 +383,8 @@ protected:
 
     virtual int send_to_wire(xlio_ibv_send_wr *p_send_wqe, xlio_wr_tx_packet_attr attr,
                              bool request_comp, xlio_tis *tis, unsigned credits);
-    virtual bool is_completion_need() { return !m_n_unsignaled_count; };
+    virtual bool is_completion_need() { return !m_n_unsignaled_count; }
+    virtual bool is_rq_empty() const { return false; }
 };
 
 class qp_mgr_eth : public qp_mgr {

--- a/src/core/dev/qp_mgr_eth_mlx5.h
+++ b/src/core/dev/qp_mgr_eth_mlx5.h
@@ -194,6 +194,8 @@ protected:
         return NULL;
     }
 
+    virtual bool is_rq_empty() const { return (m_mlx5_qp.rq.head == m_mlx5_qp.rq.tail); }
+
 private:
 #endif /* DEFINED_UTLS */
     inline int fill_wqe_send(xlio_ibv_send_wr *pswr);


### PR DESCRIPTION
When the ring is destroyed and the RQ is empty the termination loop becomes infinte. It waits for the last_posted_wqe to be retrieved. but since it is empty the last posted wqe was already retrieved.

## Description
XLIO stuck infinitely in ring destruction

##### What
If the RQ is empty, ring destruction will loop inifintely.
See more details in commit message

##### Why ?
Fixing stuck XLIO

##### How ?
Try to fetch last posted wqe only if the RQ is not empty.

## Change type
What kind of change does this PR introduce?
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [X] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

