### PR TITLE
issue: 3286324 Moving is_empty_rq to outside of UTLS ifdef

### DIFF
--- a/src/core/dev/qp_mgr_eth_mlx5.h
+++ b/src/core/dev/qp_mgr_eth_mlx5.h
@@ -144,6 +144,8 @@ protected:
     void put_tls_tis_in_cache(xlio_tis *tis);
     void ti_released(xlio_ti *ti);
 
+    virtual bool is_rq_empty() const override { return (m_mlx5_qp.rq.head == m_mlx5_qp.rq.tail); }
+
     inline bool is_sq_wqe_prop_valid(sq_wqe_prop *p, sq_wqe_prop *prev)
     {
         unsigned p_i = p - m_sq_wqe_idx_to_prop;
@@ -193,8 +195,6 @@ protected:
         NOT_IN_USE(is_tls);
         return NULL;
     }
-
-    virtual bool is_rq_empty() const { return (m_mlx5_qp.rq.head == m_mlx5_qp.rq.tail); }
 
 private:
 #endif /* DEFINED_UTLS */


### PR DESCRIPTION
## Description
is_empty_rq method was put under DEFINED_UTLS

##### What
Moving is_empty_rq 

##### Why ?
is_empty_rq should be always available

## Change type
What kind of change does this PR introduce?
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [X] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

