### PR TITLE
issue: 3602243 Recover neigh after link down/up

### DIFF
--- a/src/core/proto/neighbour.cpp
+++ b/src/core/proto/neighbour.cpp
@@ -1429,6 +1429,7 @@ neigh_eth::neigh_eth(neigh_key key)
         // 	{curr state,            event,                  next state,             action func   }
 
         {ST_NOT_ACTIVE, EV_KICK_START, ST_INIT, NULL},
+        {ST_NOT_ACTIVE, EV_ARP_RESOLVED, ST_READY, NULL},
         {ST_ERROR, EV_KICK_START, ST_INIT, NULL},
         {ST_INIT, EV_ARP_RESOLVED, ST_READY, NULL},
         {ST_INIT, EV_START_RESOLUTION, ST_INIT_RESOLUTION, NULL},


### PR DESCRIPTION
## Description
Recover neigh after ling down/up.
After link down state neigh entry is destroyed.
On connect() call during link down neigh can not complete initialization and move from state ST_ERROR
 to state ST_NOT_ACTIVE with next state SM_ST_STAY(-3).
Time for moving to this state is controlled by XLIO_NEIGH_NUM_ERR_RETRIES.
When link is up neigh can be reachable and event EV_ARP_RESOLVED signals about this.
So this change allows to move from ST_NOT_ACTIVE to EV_ARP_RESOLVED skipping ST_INIT, ST_INIT_RESOLUTION, ST_SOLICIT_SEND.

##### What
Fix issue related link down/up case.

##### Why ?
RM#3602243 

## Change type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [x] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

