### PR TITLE
issue: 3580084 Print report at exit on buffer errors

### DIFF
--- a/src/core/dev/buffer_pool.h
+++ b/src/core/dev/buffer_pool.h
@@ -82,6 +82,8 @@ public:
 
     void register_memory(ib_ctx_handler *p_ib_ctx_h);
     void print_val_tbl();
+    void print_report(vlog_levels_t log_level = VLOG_DEBUG);
+    static void print_report_on_errors(vlog_levels_t log_level);
 
     uint32_t find_lkey_by_ib_ctx_thread_safe(ib_ctx_handler *p_ib_ctx_h);
 

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -184,6 +184,10 @@ static int free_libxlio_resources()
     }
     g_tcp_seg_pool = NULL;
 
+    if (safe_mce_sys().print_report) {
+        buffer_pool::print_report_on_errors(VLOG_INFO);
+    }
+
     if (g_buffer_pool_zc) {
         delete g_buffer_pool_zc;
     }

--- a/src/core/sock/tcp_seg_pool.cpp
+++ b/src/core/sock/tcp_seg_pool.cpp
@@ -156,7 +156,7 @@ bool tcp_seg_pool::expand()
     return true;
 }
 
-void tcp_seg_pool::print_report(vlog_levels_t log_level /*= VLOG_DEBUG*/)
+void tcp_seg_pool::print_report(vlog_levels_t log_level /*=VLOG_DEBUG*/)
 {
     vlog_printf(log_level, "TCP segments pool statistics:\n");
     vlog_printf(log_level, "  allocations=%u expands=%u total_segs=%u\n", m_stats.allocations,

--- a/src/core/util/sys_vars.cpp
+++ b/src/core/util/sys_vars.cpp
@@ -762,6 +762,7 @@ void mce_sys_var::get_env_params()
 
     service_enable = MCE_DEFAULT_SERVICE_ENABLE;
 
+    print_report = MCE_DEFAULT_PRINT_REPORT;
     log_level = VLOG_DEFAULT;
     log_details = MCE_DEFAULT_LOG_DETAILS;
     log_colors = MCE_DEFAULT_LOG_COLORS;
@@ -1194,6 +1195,10 @@ void mce_sys_var::get_env_params()
     case MCE_SPEC_NONE:
     default:
         break;
+    }
+
+    if ((env_ptr = getenv(SYS_VAR_PRINT_REPORT)) != NULL) {
+        print_report = atoi(env_ptr) ? true : false;
     }
 
     if ((env_ptr = getenv(SYS_VAR_LOG_FILENAME)) != NULL) {

--- a/src/core/util/sys_vars.cpp
+++ b/src/core/util/sys_vars.cpp
@@ -210,9 +210,8 @@ size_t from_str(const char *str)
     return 0U;
 }
 
-const char *to_str(size_t size)
+const char *to_str(size_t size, char *s, size_t len)
 {
-    static char str[64];
     static const char *suffixes[] = {"", " KB", " MB", " GB", nullptr};
     int sfx_idx = 0;
 
@@ -220,9 +219,15 @@ const char *to_str(size_t size)
         ++sfx_idx;
         size /= 1024U;
     }
-    snprintf(str, sizeof(str), "%zu%s", size, suffixes[sfx_idx]);
+    snprintf(s, len, "%zu%s", size, suffixes[sfx_idx]);
 
-    return str;
+    return s;
+}
+
+const char *to_str(size_t size)
+{
+    static char str[64];
+    return to_str(size, str, sizeof(str));
 }
 } // namespace option_size
 

--- a/src/core/util/sys_vars.h
+++ b/src/core/util/sys_vars.h
@@ -200,6 +200,7 @@ const char *to_str(xlio_spec_t level);
 namespace option_size {
 size_t from_str(const char *str);
 const char *to_str(size_t size);
+const char *to_str(size_t size, char *s, size_t len);
 } // namespace option_size
 
 namespace option_3 {

--- a/src/core/util/sys_vars.h
+++ b/src/core/util/sys_vars.h
@@ -351,6 +351,7 @@ public:
 
     uint32_t mce_spec;
 
+    bool print_report;
     vlog_levels_t log_level;
     uint32_t log_details;
     char log_filename[PATH_MAX];
@@ -559,6 +560,7 @@ extern mce_sys_var &safe_mce_sys();
  * This block consists of library specific configuration
  * environment variables
  */
+#define SYS_VAR_PRINT_REPORT        "XLIO_PRINT_REPORT"
 #define SYS_VAR_LOG_LEVEL           "XLIO_TRACELEVEL"
 #define SYS_VAR_LOG_DETAILS         "XLIO_LOG_DETAILS"
 #define SYS_VAR_LOG_FILENAME        "XLIO_LOG_FILE"
@@ -720,6 +722,7 @@ extern mce_sys_var &safe_mce_sys();
  * This block consists of default values for library specific
  * configuration variables
  */
+#define MCE_DEFAULT_PRINT_REPORT             (false)
 #define MCE_DEFAULT_TCP_SEND_BUFFER_SIZE     (1024 * 1024)
 #define MCE_DEFAULT_LOG_FILE                 ("")
 #define MCE_DEFAULT_CONF_FILE                ("/etc/libxlio.conf")


### PR DESCRIPTION
## Description
**Note, only 2 last commits are relevant.**

Print a report during XLIO termination on buffer allocation errors. Undocumented parameter XLIO_PRINT_REPORT controls this feature and is disabled by default.

##### What
Print report at exit on buffer errors.

##### Why ?
Improve observability of runtime resource allocation failures.

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

