### PR TITLE
issue: 3600396 Handle empty IP list in ipv4_select_saddr

### DIFF
--- a/src/core/dev/src_addr_selector.cpp
+++ b/src/core/dev/src_addr_selector.cpp
@@ -256,5 +256,9 @@ const ip_data *src_addr_selector::ipv4_select_saddr(const net_device_val &dst_de
         }
     }
 
-    return (!ip_arr[0]->local_addr.is_anyaddr() ? ip_arr[0].get() : nullptr);
+    if (unlikely(ip_arr.size() == 0) || ip_arr[0]->local_addr.is_anyaddr()) {
+        return nullptr;
+    }
+
+    return ip_arr[0].get();
 }


### PR DESCRIPTION
In case of empty list of IP addresses in src selection, we should not access the vector to prevent seg fault.
Return nullptr instead.

## Change type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

