### PR TITLE
issue: 3588192 Blocking API hanging with delegated TCP timers

### DIFF
--- a/contrib/jenkins_tests/gtest.sh
+++ b/contrib/jenkins_tests/gtest.sh
@@ -4,37 +4,52 @@ source $(dirname $0)/globals.sh
 
 echo "Checking for gtest ..."
 
-# Check dependencies
-if [ $(test -d ${install_dir} >/dev/null 2>&1 || echo $?) ]; then
-	echo "[SKIP] Not found ${install_dir} : build should be done before this stage"
-	exit 1
+if [[ -z "${MANUAL_RUN}" ]]; then
+	# Check dependencies
+	if [ $(test -d ${install_dir} >/dev/null 2>&1 || echo $?) ]; then
+		echo "[SKIP] Not found ${install_dir} : build should be done before this stage"
+		exit 1
+	fi
+
+	if [ $(command -v ibdev2netdev >/dev/null 2>&1 || echo $?) ]; then
+		echo "[SKIP] ibdev2netdev tool does not exist"
+		exit 1
+	fi
+
+	cd $WORKSPACE
+
+	rm -rf $gtest_dir
+	mkdir -p $gtest_dir
+	cd $gtest_dir
+
+	gtest_app="$PWD/tests/gtest/gtest"
+	gtest_lib=$install_dir/lib/${prj_lib}
+	opt2=''
+else
+	# Enable running gtest tests manually without build stage requirement.
+	# To run manually. From main directory:
+	# env MANUAL_RUN=1 MANUAL_RUN_GTEST_APP=<gtest-path>/gtest MANUAL_RUN_INST_DIR=<xlio-install-path> MANUAL_RUN_ADAPTER='ConnectX-6' WORKSPACE=$PWD TARGET=default jenkins_test_gtest=yes contrib/test_jenkins.sh
+	cd $WORKSPACE
+	gtest_app=${MANUAL_RUN_GTEST_APP}
+	install_dir=${MANUAL_RUN_INST_DIR}
+	gtest_lib=$install_dir/lib/${prj_lib}
+	opt2=${MANUAL_RUN_ADAPTER:-'ConnectX-7'}
 fi
-
-if [ $(command -v ibdev2netdev >/dev/null 2>&1 || echo $?) ]; then
-	echo "[SKIP] ibdev2netdev tool does not exist"
-	exit 1
-fi
-
-cd $WORKSPACE
-
-rm -rf $gtest_dir
-mkdir -p $gtest_dir
-cd $gtest_dir
-
-gtest_app="$PWD/tests/gtest/gtest"
-gtest_lib=$install_dir/lib/${prj_lib}
 
 # Retrieve server/client addresses for the test.
 # $1 - [ib|eth|inet6] to select link type or empty to select the first found
 #
 function do_get_addrs()
 {
-	gtest_ip_list=""
-	if [ ! -z $(do_get_ip $1) ]; then
-		gtest_ip_list="$(do_get_ip $1)"
+	gtest_ip_list="$(do_get_ip $1 $2)"
+	if [ ! -z $2 ]; then
+		gtest_ip_list_2="$(do_get_ip $1 $2 $gtest_ip_list)"
+	else
+		gtest_ip_list_2="$(do_get_ip $1 '' $gtest_ip_list)"
 	fi
-	if [ ! -z $(do_get_ip $1 '' $gtest_ip_list) ]; then
-		gtest_ip_list="${gtest_ip_list},$(do_get_ip $1 '' $gtest_ip_list)"
+
+	if [ ! -z ${gtest_ip_list_2} ]; then
+		gtest_ip_list="${gtest_ip_list},${gtest_ip_list_2}"
 	else
 		echo "[SKIP] two eth interfaces are required. found: ${gtest_ip_list}" >&2
 		exit 0
@@ -43,14 +58,16 @@ function do_get_addrs()
 	echo $gtest_ip_list
 }
 
-gtest_opt="--addr=$(do_get_addrs 'eth')"
-gtest_opt_ipv6="--addr=$(do_get_addrs 'inet6') -r fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff" # Remote - Dummy Address
+gtest_opt="--addr=$(do_get_addrs 'eth' ${opt2})"
+gtest_opt_ipv6="--addr=$(do_get_addrs 'inet6' ${opt2}) -r fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff" # Remote - Dummy Address
 
 set +eE
 
-${WORKSPACE}/configure --prefix=$install_dir
-make -C tests/gtest
-rc=$(($rc+$?))
+if [[ -z "${MANUAL_RUN}" ]]; then
+	${WORKSPACE}/configure --prefix=$install_dir
+	make -C tests/gtest
+	rc=$(($rc+$?))
+fi
 
 eval "${sudo_cmd} pkill -9 ${prj_service} 2>/dev/null || true"
 eval "${sudo_cmd} ${install_dir}/sbin/${prj_service} --console -v5 &"
@@ -59,19 +76,30 @@ eval "${sudo_cmd} ${install_dir}/sbin/${prj_service} --console -v5 &"
 eval "${sudo_cmd} $timeout_exe env GTEST_TAP=2 LD_PRELOAD=$gtest_lib $gtest_app $gtest_opt --gtest_filter=-xlio_*:tcp_send_zc* --gtest_output=xml:${WORKSPACE}/${prefix}/test-basic.xml"
 rc=$(($rc+$?))
 
+# Exclude EXTRA API tests IPv6
 eval "${sudo_cmd} $timeout_exe env GTEST_TAP=2 LD_PRELOAD=$gtest_lib $gtest_app $gtest_opt_ipv6 --gtest_filter=-xlio_*:tcp_send_zc* --gtest_output=xml:${WORKSPACE}/${prefix}/test-basic-ipv6.xml"
 rc=$(($rc+$?))
 
-make -C tests/gtest clean
-make -C tests/gtest CPPFLAGS="-DEXTRA_API_ENABLED=1"
+# Verify Delegated TCP Timers tests
+eval "${sudo_cmd} $timeout_exe env XLIO_RX_POLL_ON_TX_TCP=1 XLIO_TCP_ABORT_ON_CLOSE=1 XLIO_TCP_CTL_THREAD=delegate GTEST_TAP=2 LD_PRELOAD=$gtest_lib $gtest_app $gtest_opt --gtest_filter=-xlio*:tcp_send_zc* --gtest_output=xml:${WORKSPACE}/${prefix}/test-delegate.xml"
 rc=$(($rc+$?))
+
+# Verify Delegated TCP Timers tests IPv6
+eval "${sudo_cmd} $timeout_exe env XLIO_RX_POLL_ON_TX_TCP=1 XLIO_TCP_ABORT_ON_CLOSE=1 XLIO_TCP_CTL_THREAD=delegate GTEST_TAP=2 LD_PRELOAD=$gtest_lib $gtest_app $gtest_opt_ipv6 --gtest_filter=-xlio*:tcp_send_zc* --gtest_output=xml:${WORKSPACE}/${prefix}/test-delegate-ipv6.xml"
+rc=$(($rc+$?))
+
+if [[ -z "${MANUAL_RUN}" ]]; then
+	make -C tests/gtest clean
+	make -C tests/gtest CPPFLAGS="-DEXTRA_API_ENABLED=1"
+	rc=$(($rc+$?))
+fi
 
 # Verify XLIO EXTRA API tests
 eval "${sudo_cmd} $timeout_exe env GTEST_TAP=2 LD_PRELOAD=$gtest_lib $gtest_app $gtest_opt --gtest_filter=xlio_*:-socketxtreme_poll.*:socketxtreme_ring.*:xlio_send_zc.* --gtest_output=xml:${WORKSPACE}/${prefix}/test-extra.xml"
 rc=$(($rc+$?))
 
 # Verify XLIO EXTRA API socketxtreme mode tests
-eval "${sudo_cmd} $timeout_exe env XLIO_SOCKETXTREME=1 GTEST_TAP=2 LD_PRELOAD=$gtest_lib $gtest_app $gtest_opt --gtest_filter=socketxtreme_poll.*:socketxtreme_ring.* --gtest_output=xml:${WORKSPACE}/${prefix}/test-socketxtreme.xml"
+eval "${sudo_cmd} $timeout_exe env XLIO_SOCKETXTREME=1 GTEST_TAP=2 LD_PRELOAD=$gtest_lib $gtest_app $gtest_opt --gtest_filter=socketxtreme_poll.*:socketxtreme_ring.*:sock_socket.*:tcp_bind.*:tcp_connect.*:tcp_sendto.*:tcp_set_get_sockopt*:udp_bind.*:udp_connect.*:udp_sendto.*:udp_socket.* --gtest_output=xml:${WORKSPACE}/${prefix}/test-socketxtreme.xml"
 rc=$(($rc+$?))
 
 # Verify XLIO EXTRA API tests IPv6
@@ -79,7 +107,15 @@ eval "${sudo_cmd} $timeout_exe env GTEST_TAP=2 LD_PRELOAD=$gtest_lib $gtest_app 
 rc=$(($rc+$?))
 
 # Verify XLIO EXTRA API socketxtreme mode tests IPv6
-eval "${sudo_cmd} $timeout_exe env XLIO_SOCKETXTREME=1 GTEST_TAP=2 LD_PRELOAD=$gtest_lib $gtest_app $gtest_opt_ipv6 --gtest_filter=socketxtreme_poll.*:socketxtreme_ring.* --gtest_output=xml:${WORKSPACE}/${prefix}/test-socketxtreme-ipv6.xml"
+eval "${sudo_cmd} $timeout_exe env XLIO_SOCKETXTREME=1 GTEST_TAP=2 LD_PRELOAD=$gtest_lib $gtest_app $gtest_opt_ipv6 --gtest_filter=socketxtreme_poll.*:socketxtreme_ring.*:sock_socket.*:tcp_bind.*:tcp_connect.*:tcp_sendto.*:tcp_set_get_sockopt*:udp_bind.*:udp_connect.*:udp_sendto.*:udp_socket.* --gtest_output=xml:${WORKSPACE}/${prefix}/test-socketxtreme-ipv6.xml"
+rc=$(($rc+$?))
+
+# Verify socketxtreme mode and Delegated TCP Timers tests
+eval "${sudo_cmd} $timeout_exe env XLIO_SOCKETXTREME=1 XLIO_RX_POLL_ON_TX_TCP=1 XLIO_TCP_ABORT_ON_CLOSE=1 XLIO_TCP_CTL_THREAD=delegate GTEST_TAP=2 LD_PRELOAD=$gtest_lib $gtest_app $gtest_opt --gtest_filter=socketxtreme_poll.*:socketxtreme_ring.*:sock_socket.*:tcp_bind.*:tcp_connect.*:tcp_sendto.*:tcp_set_get_sockopt*:udp_bind.*:udp_connect.*:udp_sendto.*:udp_socket.* --gtest_output=xml:${WORKSPACE}/${prefix}/test-socketxtreme-delegate.xml"
+rc=$(($rc+$?))
+
+# Verify socketxtreme mode and Delegated TCP Timers tests IPv6
+eval "${sudo_cmd} $timeout_exe env XLIO_SOCKETXTREME=1 XLIO_RX_POLL_ON_TX_TCP=1 XLIO_TCP_ABORT_ON_CLOSE=1 XLIO_TCP_CTL_THREAD=delegate GTEST_TAP=2 LD_PRELOAD=$gtest_lib $gtest_app $gtest_opt_ipv6 --gtest_filter=socketxtreme_poll.*:socketxtreme_ring.*:sock_socket.*:tcp_bind.*:tcp_connect.*:tcp_sendto.*:tcp_set_get_sockopt*:udp_bind.*:udp_connect.*:udp_sendto.*:udp_socket.* --gtest_output=xml:${WORKSPACE}/${prefix}/test-socketxtreme-delegate-ipv6.xml"
 rc=$(($rc+$?))
 
 eval "${sudo_cmd} pkill -9 ${prj_service} 2>/dev/null || true"

--- a/src/core/event/event_handler_manager.h
+++ b/src/core/event/event_handler_manager.h
@@ -183,7 +183,7 @@ public:
 
 protected:
     pthread_t m_event_handler_tid;
-    bool m_b_continue_running;
+    bool m_b_continue_running = false;
     int m_cq_epfd;
     int m_epfd;
 

--- a/src/core/sock/sockinfo.h
+++ b/src/core/sock/sockinfo.h
@@ -412,12 +412,6 @@ protected:
     void remove_cqfd_from_sock_rx_epfd(ring *p_ring);
     int os_wait_sock_rx_epfd(epoll_event *ep_events, int maxevents);
     virtual bool try_un_offloading(); // un-offload the socket if possible
-    virtual inline void do_wakeup()
-    {
-        if (!is_socketxtreme()) {
-            wakeup_pipe::do_wakeup();
-        }
-    }
 
     bool is_shadow_socket_present() { return m_fd >= 0 && m_fd != m_rx_epfd; }
     inline bool is_socketxtreme() { return safe_mce_sys().enable_socketxtreme; }

--- a/src/core/util/wakeup.h
+++ b/src/core/util/wakeup.h
@@ -43,7 +43,6 @@ class wakeup {
 public:
     wakeup(void);
     virtual ~wakeup() {};
-    virtual void do_wakeup() = 0;
     virtual bool is_wakeup_fd(int fd) = 0;
     virtual void remove_wakeup_fd() = 0;
     void going_to_sleep();

--- a/src/core/util/wakeup_pipe.h
+++ b/src/core/util/wakeup_pipe.h
@@ -43,7 +43,7 @@ class wakeup_pipe : public wakeup {
 public:
     wakeup_pipe(void);
     ~wakeup_pipe();
-    virtual void do_wakeup();
+    void do_wakeup();
     virtual inline bool is_wakeup_fd(int fd) { return fd == g_wakeup_pipes[0]; };
     virtual void remove_wakeup_fd();
 

--- a/tests/gtest/tcp/tcp_bind.cc
+++ b/tests/gtest/tcp/tcp_bind.cc
@@ -402,6 +402,8 @@ TEST_F(tcp_bind, bind_IP6_4_dual_stack_reuse_addr_listen)
  */
 TEST_F(tcp_bind, mapped_ipv4_bind)
 {
+    SKIP_TRUE(!getenv("XLIO_SOCKETXTREME"), "Skip Socketxtreme");
+
     if (!test_mapped_ipv4()) {
         return;
     }

--- a/tests/gtest/udp/udp_bind.cc
+++ b/tests/gtest/udp/udp_bind.cc
@@ -309,6 +309,8 @@ TEST_F(udp_bind, bind_IP6_4_dual_stack_reuse_addr)
  */
 TEST_F(udp_bind, mapped_ipv4_bind_recv)
 {
+    SKIP_TRUE(!getenv("XLIO_SOCKETXTREME"), "Skip Socketxtreme");
+
     if (!test_mapped_ipv4()) {
         return;
     }
@@ -377,6 +379,8 @@ TEST_F(udp_bind, mapped_ipv4_bind_recv)
  */
 TEST_F(udp_bind, mapped_ipv4_bind_send)
 {
+    SKIP_TRUE(!getenv("XLIO_SOCKETXTREME"), "Skip Socketxtreme");
+
     if (!test_mapped_ipv4()) {
         return;
     }

--- a/tests/gtest/udp/udp_connect.cc
+++ b/tests/gtest/udp/udp_connect.cc
@@ -182,6 +182,8 @@ TEST_F(udp_connect, ti_4)
  */
 TEST_F(udp_connect, mapped_ipv4_connect)
 {
+    SKIP_TRUE(!getenv("XLIO_SOCKETXTREME"), "Skip Socketxtreme");
+
     if (!test_mapped_ipv4()) {
         return;
     }


### PR DESCRIPTION
## Description
Several issues related Socketxtreme or delegated timers

##### What
1. Fixed wakeup waiting thread with Socketxtreme mode.
2. Fixed no TCP timers attempt in delegated mode for blocking calls.
3. Enhanced gtest CI to include More socketxtreme tests and delegated timers tests.

##### Why ?
Socketxterme/Delegate functionality

##### How ?
1. In case of socketxtreme wakeup method was skipped. wakeup must always be called regardless this is POSIX or socketxtreme API.
2. Added delegated timers attempt in rx_wait_helper method which is called for every blocking API. Thus, solving many scenarios that would hang with delegated timers and blocking calls.

## Change type
What kind of change does this PR introduce?
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [X] Code follows the style de facto guidelines of this project
- [X] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [X] Test has been added (if possible)

