### PR TITLE
issue: 3580073 Print XLIO_MEMORY_LIMIT_USER in the XLIO header

### DIFF
--- a/README
+++ b/README
@@ -152,6 +152,7 @@ Example:
  XLIO DETAILS: Buffer batching mode           1 (Batch and reclaim buffers) [XLIO_BUFFER_BATCHING_MODE]
  XLIO DETAILS: Mem Allocation type            Huge pages                 [XLIO_MEM_ALLOC_TYPE]
  XLIO DETAILS: Memory limit                   2 GB                       [XLIO_MEMORY_LIMIT]
+ XLIO DETAILS: Memory limit (user allocator)  0                          [XLIO_MEMORY_LIMIT_USER]
  XLIO DETAILS: Num of UC ARPs                 3                          [XLIO_NEIGH_UC_ARP_QUATA]
  XLIO DETAILS: UC ARP delay (msec)            10000                      [XLIO_NEIGH_UC_ARP_DELAY_MSEC]
  XLIO DETAILS: Num of neigh restart retries   1                          [XLIO_NEIGH_NUM_ERR_RETRIES]
@@ -955,6 +956,12 @@ dynamic memory allocation and XLIO memory consumption can exceed the limit.
 Default value is 2GB
 
 The following XLIO neigh parameters are for advanced users or internal support only:
+
+XLIO_MEMORY_LIMIT_USER
+Memory limit for external user allocator. The user allocator can optionally be
+provided with XLIO extra API. Default value 0 makes XLIO use XLIO_MEMORY_LIMIT
+value for user allocations.
+Default value is 0
 
 XLIO_NEIGH_UC_ARP_QUATA
 XLIO will send UC ARP in case neigh state is NUD_STALE.

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -778,6 +778,9 @@ void print_xlio_global_settings()
                       option_alloc_type::to_str(safe_mce_sys().mem_alloc_type));
     VLOG_PARAM_STRING("Memory limit", safe_mce_sys().memory_limit, MCE_DEFAULT_MEMORY_LIMIT,
                       SYS_VAR_MEMORY_LIMIT, option_size::to_str(safe_mce_sys().memory_limit));
+    VLOG_PARAM_STRING("Memory limit (user allocator)", safe_mce_sys().memory_limit_user,
+                      MCE_DEFAULT_MEMORY_LIMIT_USER, SYS_VAR_MEMORY_LIMIT_USER,
+                      option_size::to_str(safe_mce_sys().memory_limit_user));
     VLOG_PARAM_NUMBER("Hugepage log2", safe_mce_sys().hugepage_log2, MCE_DEFAULT_HUGEPAGE_LOG2,
                       SYS_VAR_HUGEPAGE_LOG2);
 


### PR DESCRIPTION
## Description
Print XLIO_MEMORY_LIMIT_USER parameter in the XLIO header to avoid confusion when it's set explicitly. Describe it in the advanced section of README.

##### What
Print XLIO_MEMORY_LIMIT_USER parameter in the XLIO header.

##### Why ?
This parameter is used more often than expected. Describe it to avoid confusion.

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

