### PR TITLE
Delay socket_fd_api cleanup

### DIFF
--- a/src/core/dev/rfs_rule_dpcp.cpp
+++ b/src/core/dev/rfs_rule_dpcp.cpp
@@ -39,10 +39,6 @@
 
 #define MODULE_NAME "rfs_rule_dpcp"
 
-rfs_rule_dpcp::~rfs_rule_dpcp()
-{
-}
-
 bool rfs_rule_dpcp::create(const xlio_ibv_flow_attr &attrs, dpcp::tir &in_tir,
                            dpcp::adapter &in_adapter)
 {

--- a/src/core/dev/rfs_rule_dpcp.h
+++ b/src/core/dev/rfs_rule_dpcp.h
@@ -47,7 +47,7 @@ using namespace std;
 
 class rfs_rule_dpcp : public rfs_rule {
 public:
-    virtual ~rfs_rule_dpcp();
+    virtual ~rfs_rule_dpcp() = default;
 
     bool create(const xlio_ibv_flow_attr &attrs, dpcp::tir &in_tir, dpcp::adapter &in_adapter);
 

--- a/src/core/sock/fd_collection.cpp
+++ b/src/core/sock/fd_collection.cpp
@@ -530,12 +530,12 @@ int fd_collection::del_sockfd(int fd, bool b_cleanup /*=false*/, bool is_for_udp
         // so we have to stages:
         // 1. Prepare to close: kikstarts TCP connection termination
         // 2. Socket deletion when TCP connection == CLOSED
-        if (p_sfd_api->prepare_to_close()) {
+        if (p_sfd_api->prepare_to_close() && !safe_mce_sys().deferred_close) {
             // the socket is already closable
             ret_val = del(fd, b_cleanup, m_p_sockfd_map);
         } else {
             lock();
-            // The socket is not ready for close.
+            // Handle the socket removal in the internal thread.
             // Delete it from fd_col and add it to pending_to_remove list.
             // This socket will be handled and destroyed now by fd_col.
             // This will be done from fd_col timer handler.


### PR DESCRIPTION
## Description
Fix the spikes in close syscall latency by making it asynchronous.
Move the deletion of the socket(socket_fd_api) to tread_loop or to thread_local do_tasks.

## Change type
What kind of change does this PR introduce?
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

