### PR TITLE
issue: 3656233 Fix infinite loop on a broken buffer reclaim

### DIFF
--- a/src/core/dev/cq_mgr_mlx5_strq.cpp
+++ b/src/core/dev/cq_mgr_mlx5_strq.cpp
@@ -577,7 +577,8 @@ void cq_mgr_mlx5_strq::reclaim_recv_buffer_helper(mem_buf_desc_t *buff)
                 if (unlikely(buff->lwip_pbuf.pbuf.desc.attr != PBUF_DESC_STRIDE)) {
                     __log_info_err("CQ STRQ reclaim_recv_buffer_helper with incompatible "
                                    "mem_buf_desc_t object");
-                    continue;
+                    // We cannot continue iterating over a broken buffer object.
+                    break;
                 }
 
                 mem_buf_desc_t *rwqe =

--- a/src/core/dev/rfs_uc.cpp
+++ b/src/core/dev/rfs_uc.cpp
@@ -147,19 +147,10 @@ bool rfs_uc::prepare_flow_spec()
 bool rfs_uc::rx_dispatch_packet(mem_buf_desc_t *p_rx_wc_buf_desc, void *pv_fd_ready_array)
 {
     p_rx_wc_buf_desc->reset_ref_count();
-
     for (uint32_t i = 0; i < m_n_sinks_list_entries; ++i) {
         if (likely(m_sinks_list[i])) {
-#ifdef RDTSC_MEASURE_RX_DISPATCH_PACKET
-            RDTSC_TAKE_START(g_rdtsc_instr_info_arr[RDTSC_FLOW_RX_DISPATCH_PACKET]);
-#endif // RDTSC_MEASURE_RX_DISPATCH_PACKET
-            p_rx_wc_buf_desc->inc_ref_count();
-            m_sinks_list[i]->rx_input_cb(p_rx_wc_buf_desc, pv_fd_ready_array);
-#ifdef RDTSC_MEASURE_RX_DISPATCH_PACKET
-            RDTSC_TAKE_END(g_rdtsc_instr_info_arr[RDTSC_FLOW_RX_DISPATCH_PACKET]);
-#endif // RDTSC_MEASURE_RX_DISPATCH_PACKET
-       // Check packet ref_count to see the last receiver is interested in this packet
-            if (p_rx_wc_buf_desc->dec_ref_count() > 1) {
+            bool consumed = m_sinks_list[i]->rx_input_cb(p_rx_wc_buf_desc, pv_fd_ready_array);
+            if (consumed) {
                 // The sink will be responsible to return the buffer to CQ for reuse
                 return true;
             }

--- a/src/core/dev/ring_slave.cpp
+++ b/src/core/dev/ring_slave.cpp
@@ -556,27 +556,8 @@ rfs_rule *ring_slave::tls_rx_create_rule(const flow_tuple &flow_spec_5t, xlio_ti
 static inline bool check_rx_packet(sockinfo *si, mem_buf_desc_t *p_rx_wc_buf_desc,
                                    void *fd_ready_array)
 {
-    // Dispatching: Notify new packet to the FIRST registered receiver ONLY
-#ifdef RDTSC_MEASURE_RX_DISPATCH_PACKET
-    RDTSC_TAKE_START(g_rdtsc_instr_info_arr[RDTSC_FLOW_RX_DISPATCH_PACKET]);
-#endif // RDTSC_MEASURE_RX_DISPATCH_PACKET
-
     p_rx_wc_buf_desc->reset_ref_count();
-    p_rx_wc_buf_desc->inc_ref_count();
-
-    si->rx_input_cb(p_rx_wc_buf_desc, fd_ready_array);
-
-#ifdef RDTSC_MEASURE_RX_DISPATCH_PACKET
-    RDTSC_TAKE_END(g_rdtsc_instr_info_arr[RDTSC_FLOW_RX_DISPATCH_PACKET]);
-#endif // RDTSC_MEASURE_RX_DISPATCH_PACKET
-
-    // Check packet ref_count to see the last receiver is interested in this packet
-    if (p_rx_wc_buf_desc->dec_ref_count() > 1) {
-        // The sink will be responsible to return the buffer to CQ for reuse
-        return true;
-    }
-    // Reuse this data buffer & mem_buf_desc
-    return false;
+    return si->rx_input_cb(p_rx_wc_buf_desc, fd_ready_array);
 }
 
 // All CQ wce come here for some basic sanity checks and then are distributed to the correct ring

--- a/src/core/sock/sockinfo_tcp.cpp
+++ b/src/core/sock/sockinfo_tcp.cpp
@@ -1075,7 +1075,7 @@ retry_is_ready:
 
                 /* Set return values for nonblocking socket and finish processing */
                 if (!block_this_run) {
-                    // non blocking socket should return inorder not to tx_wait()
+                    // non blocking socket should return in order not to tx_wait()
                     if (total_tx > 0) {
                         m_tx_consecutive_eagain_count = 0;
                         goto done;
@@ -5052,9 +5052,9 @@ int sockinfo_tcp::rx_wait_helper(int &poll_count, bool blocking)
     }
 
     if (m_sysvar_tcp_ctl_thread == option_tcp_ctl_thread::CTL_THREAD_DELEGATE_TCP_TIMERS) {
-        // There are scenarios when rx_wait_helper is called in an infinte loop but exists before
-        // OS epoll_wait. Delegated TPC timers must be attempted in such case.
-        // This is a slow path. So calling chrono::now(), even with every iterantion, is OK here.
+        // There are scenarios when rx_wait_helper is called in an infinite loop but exits before
+        // OS epoll_wait. Delegated TCP timers must be attempted in such case.
+        // This is a slow path. So calling chrono::now(), even with every iteration, is OK here.
         g_thread_local_event_handler.do_tasks();
     }
 


### PR DESCRIPTION
## Description
Striding RQ specific code of buffer reclaim leads to an infinite loop if the buffer has wrong type.

##### What
Fix infinite loop in an error path.

##### Why ?
Bugfix.

## Change type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

