### PR TITLE
issue: 3656233 Use tcp_rx_pbuf_free() for SocketXtreme TCP flow

### DIFF
--- a/src/core/dev/buffer_pool.h
+++ b/src/core/dev/buffer_pool.h
@@ -76,8 +76,8 @@ inline static void free_lwip_pbuf(struct pbuf_custom *pbuf_custom)
  */
 class buffer_pool {
 public:
-    buffer_pool(buffer_pool_type type, size_t buf_size, pbuf_free_custom_fn custom_free_function,
-                alloc_t alloc_func = nullptr, free_t free_func = nullptr);
+    buffer_pool(buffer_pool_type type, size_t buf_size, alloc_t alloc_func = nullptr,
+                free_t free_func = nullptr);
     ~buffer_pool();
 
     void register_memory(ib_ctx_handler *p_ib_ctx_h);
@@ -146,7 +146,6 @@ private:
     bpool_stats_t m_bpool_stat_static;
     xlio_allocator_heap m_allocator_data;
     xlio_allocator_heap m_allocator_metadata;
-    pbuf_free_custom_fn m_custom_free_function;
 };
 
 extern buffer_pool *g_buffer_pool_rx_ptr;

--- a/src/core/dev/rfs_uc_tcp_gro.cpp
+++ b/src/core/dev/rfs_uc_tcp_gro.cpp
@@ -185,11 +185,9 @@ bool rfs_uc_tcp_gro::add_packet(mem_buf_desc_t *mem_buf_desc, void *payload_ptr,
 
     mem_buf_desc->reset_ref_count();
 
-    mem_buf_desc->lwip_pbuf.pbuf.flags = PBUF_FLAG_IS_CUSTOM;
     mem_buf_desc->lwip_pbuf.pbuf.len = mem_buf_desc->lwip_pbuf.pbuf.tot_len =
         mem_buf_desc->rx.sz_payload;
     mem_buf_desc->lwip_pbuf.pbuf.ref = 1;
-    mem_buf_desc->lwip_pbuf.pbuf.type = PBUF_REF;
     mem_buf_desc->lwip_pbuf.pbuf.next = NULL;
     mem_buf_desc->lwip_pbuf.pbuf.payload = payload_ptr;
 
@@ -234,11 +232,9 @@ void rfs_uc_tcp_gro::flush_gro_desc(void *pv_fd_ready_array)
 
         m_gro_desc.p_first->lwip_pbuf.pbuf.gro = 1;
 
-        m_gro_desc.p_first->lwip_pbuf.pbuf.flags = PBUF_FLAG_IS_CUSTOM;
         m_gro_desc.p_first->lwip_pbuf.pbuf.tot_len = m_gro_desc.p_first->lwip_pbuf.pbuf.len =
             (m_gro_desc.p_first->sz_data - m_gro_desc.p_first->rx.n_transport_header_len);
         m_gro_desc.p_first->lwip_pbuf.pbuf.ref = 1;
-        m_gro_desc.p_first->lwip_pbuf.pbuf.type = PBUF_REF;
         m_gro_desc.p_first->lwip_pbuf.pbuf.payload =
             (u8_t *)(m_gro_desc.p_first->p_buffer + m_gro_desc.p_first->rx.n_transport_header_len);
         m_gro_desc.p_first->rx.is_xlio_thr = m_gro_desc.p_last->rx.is_xlio_thr;

--- a/src/core/lwip/pbuf.h
+++ b/src/core/lwip/pbuf.h
@@ -43,16 +43,12 @@ extern "C" {
 typedef enum {
     PBUF_NONE, /* impossible type to catch zeroed pbuf objects */
     PBUF_RAM, /* pbuf data is stored in RAM */
-    PBUF_REF, /* pbuf is an incoming buffer with custom free function */
     PBUF_STACK, /* pbuf is allocated on stack and mustn't be freed */
     PBUF_ZEROCOPY /* pbuf points to user's memory which mustn't be modified */
 } pbuf_type;
 
 /** indicates this packet's data should be immediately passed to the application */
 #define PBUF_FLAG_PUSH 0x01U
-/** indicates this is a custom pbuf: pbuf_free and pbuf_header handle such a
-    a pbuf differently */
-#define PBUF_FLAG_IS_CUSTOM 0x02U
 
 /** Private data depending on type */
 enum {
@@ -121,8 +117,7 @@ typedef void (*pbuf_free_custom_fn)(struct pbuf *p);
 struct pbuf_custom {
     /** The actual pbuf */
     struct pbuf pbuf;
-    /** This function is called when pbuf_free deallocates this pbuf(_custom) */
-    pbuf_free_custom_fn custom_free_function;
+    u64_t padding; /* TODO Remove and optimize mem_buf_desc alignment. */
 };
 
 /* Initializes the pbuf module. This call is empty for now, but may not be in future. */

--- a/src/core/lwip/tcp.c
+++ b/src/core/lwip/tcp.c
@@ -52,6 +52,7 @@
 
 tcp_tx_pbuf_alloc_fn external_tcp_tx_pbuf_alloc;
 tcp_tx_pbuf_free_fn external_tcp_tx_pbuf_free;
+tcp_rx_pbuf_free_fn external_tcp_rx_pbuf_free;
 tcp_seg_alloc_fn external_tcp_seg_alloc;
 tcp_seg_free_fn external_tcp_seg_free;
 /* allow user to be notified upon tcp_state changes */
@@ -65,6 +66,11 @@ void register_tcp_tx_pbuf_alloc(tcp_tx_pbuf_alloc_fn fn)
 void register_tcp_tx_pbuf_free(tcp_tx_pbuf_free_fn fn)
 {
     external_tcp_tx_pbuf_free = fn;
+}
+
+void register_tcp_rx_pbuf_free(tcp_rx_pbuf_free_fn fn)
+{
+    external_tcp_rx_pbuf_free = fn;
 }
 
 void register_tcp_seg_alloc(tcp_seg_alloc_fn fn)

--- a/src/core/lwip/tcp.h
+++ b/src/core/lwip/tcp.h
@@ -62,8 +62,10 @@ typedef struct pbuf *(*tcp_tx_pbuf_alloc_fn)(void *p_conn, pbuf_type type, pbuf_
 void register_tcp_tx_pbuf_alloc(tcp_tx_pbuf_alloc_fn fn);
 
 typedef void (*tcp_tx_pbuf_free_fn)(void *p_conn, struct pbuf *p);
+typedef void (*tcp_rx_pbuf_free_fn)(struct pbuf *p);
 
 void register_tcp_tx_pbuf_free(tcp_tx_pbuf_free_fn fn);
+void register_tcp_rx_pbuf_free(tcp_rx_pbuf_free_fn fn);
 
 typedef struct tcp_seg *(*tcp_seg_alloc_fn)(void *p_conn);
 
@@ -75,6 +77,7 @@ void register_tcp_seg_free(tcp_seg_free_fn fn);
 
 extern tcp_tx_pbuf_alloc_fn external_tcp_tx_pbuf_alloc;
 extern tcp_tx_pbuf_free_fn external_tcp_tx_pbuf_free;
+extern tcp_rx_pbuf_free_fn external_tcp_rx_pbuf_free;
 extern tcp_seg_alloc_fn external_tcp_seg_alloc;
 extern tcp_seg_free_fn external_tcp_seg_free;
 

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -1090,19 +1090,17 @@ static void do_global_ctors_helper()
         safe_mce_sys().rx_buf_size = 0;
     }
 
-    NEW_CTOR(
-        g_buffer_pool_rx_rwqe,
-        buffer_pool(BUFFER_POOL_RX, calc_rx_wqe_buff_size(), buffer_pool::free_rx_lwip_pbuf_custom,
-                    (safe_mce_sys().m_ioctl.user_alloc.flags & IOCTL_USER_ALLOC_RX
-                         ? safe_mce_sys().m_ioctl.user_alloc.memalloc
-                         : nullptr),
-                    (safe_mce_sys().m_ioctl.user_alloc.flags & IOCTL_USER_ALLOC_RX
-                         ? safe_mce_sys().m_ioctl.user_alloc.memfree
-                         : nullptr)));
+    NEW_CTOR(g_buffer_pool_rx_rwqe,
+             buffer_pool(BUFFER_POOL_RX, calc_rx_wqe_buff_size(),
+                         (safe_mce_sys().m_ioctl.user_alloc.flags & IOCTL_USER_ALLOC_RX
+                              ? safe_mce_sys().m_ioctl.user_alloc.memalloc
+                              : nullptr),
+                         (safe_mce_sys().m_ioctl.user_alloc.flags & IOCTL_USER_ALLOC_RX
+                              ? safe_mce_sys().m_ioctl.user_alloc.memfree
+                              : nullptr)));
 
     if (safe_mce_sys().enable_striding_rq) {
-        NEW_CTOR(g_buffer_pool_rx_stride,
-                 buffer_pool(BUFFER_POOL_RX, 0, buffer_pool::free_rx_lwip_pbuf_custom));
+        NEW_CTOR(g_buffer_pool_rx_stride, buffer_pool(BUFFER_POOL_RX, 0));
         g_buffer_pool_rx_ptr = g_buffer_pool_rx_stride;
     } else {
         g_buffer_pool_rx_ptr = g_buffer_pool_rx_rwqe;
@@ -1119,7 +1117,6 @@ static void do_global_ctors_helper()
                                          ? safe_mce_sys().tx_buf_size
                                          : get_lwip_tcp_mss(g_p_net_device_table_mgr->get_max_mtu(),
                                                             safe_mce_sys().lwip_mss)),
-                         buffer_pool::free_tx_lwip_pbuf_custom,
                          (safe_mce_sys().m_ioctl.user_alloc.flags & IOCTL_USER_ALLOC_TX
                               ? safe_mce_sys().m_ioctl.user_alloc.memalloc
                               : NULL),
@@ -1127,8 +1124,7 @@ static void do_global_ctors_helper()
                               ? safe_mce_sys().m_ioctl.user_alloc.memfree
                               : NULL)));
 
-    NEW_CTOR(g_buffer_pool_zc,
-             buffer_pool(BUFFER_POOL_TX, 0, buffer_pool::free_tx_lwip_pbuf_custom));
+    NEW_CTOR(g_buffer_pool_zc, buffer_pool(BUFFER_POOL_TX, 0));
 
     NEW_CTOR(g_tcp_seg_pool, tcp_seg_pool());
 

--- a/src/core/proto/mem_buf_desc.h
+++ b/src/core/proto/mem_buf_desc.h
@@ -68,8 +68,7 @@ public:
     enum flags { TYPICAL = 0, CLONED = 0x01, ZCOPY = 0x02 };
 
 public:
-    mem_buf_desc_t(uint8_t *buffer, size_t size, pbuf_type type,
-                   pbuf_free_custom_fn custom_free_function)
+    mem_buf_desc_t(uint8_t *buffer, size_t size, pbuf_type type)
         : p_buffer(buffer)
         , m_flags(mem_buf_desc_t::TYPICAL)
         , lkey(0)
@@ -86,7 +85,6 @@ public:
         reset_ref_count();
 
         lwip_pbuf.pbuf.type = type;
-        lwip_pbuf.custom_free_function = custom_free_function;
     }
 
     // Copy constructor for the clone() method.

--- a/src/core/proto/neighbour.cpp
+++ b/src/core/proto/neighbour.cpp
@@ -679,8 +679,6 @@ bool neigh_entry::post_send_tcp(neigh_send_data *p_data)
     BULLSEYE_EXCLUDE_BLOCK_END
 
     p_mem_buf_desc->lwip_pbuf.pbuf.payload = (u8_t *)p_mem_buf_desc->p_buffer + h->m_total_hdr_len;
-    p_mem_buf_desc->lwip_pbuf.pbuf.type = PBUF_RAM;
-
     p_mem_buf_desc->p_next_desc = NULL;
 
     // copy L4 neigh buffer to tx buffer

--- a/src/core/proto/xlio_lwip.cpp
+++ b/src/core/proto/xlio_lwip.cpp
@@ -135,6 +135,7 @@ xlio_lwip::xlio_lwip()
 
     register_tcp_tx_pbuf_alloc(sockinfo_tcp::tcp_tx_pbuf_alloc);
     register_tcp_tx_pbuf_free(sockinfo_tcp::tcp_tx_pbuf_free);
+    register_tcp_rx_pbuf_free(sockinfo_tcp::tcp_rx_pbuf_free);
     register_tcp_state_observer(sockinfo_tcp::tcp_state_observer);
     register_ip_route_mtu(sockinfo_tcp::get_route_mtu);
     register_sys_now(sys_now);

--- a/src/core/sock/sockinfo_tcp.cpp
+++ b/src/core/sock/sockinfo_tcp.cpp
@@ -154,19 +154,13 @@ static lock_base *get_new_tcp_lock()
 
 inline void sockinfo_tcp::lwip_pbuf_init_custom(mem_buf_desc_t *p_desc)
 {
-    /* Override default free function to return rx pbuf to the CQ cache */
-    const pbuf_free_custom_fn custom_free_function = sockinfo_tcp::tcp_rx_pbuf_free;
-
     if (!p_desc->lwip_pbuf.pbuf.gro) {
-        p_desc->lwip_pbuf.pbuf.flags = PBUF_FLAG_IS_CUSTOM;
         p_desc->lwip_pbuf.pbuf.len = p_desc->lwip_pbuf.pbuf.tot_len =
             (p_desc->sz_data - p_desc->rx.n_transport_header_len);
         p_desc->lwip_pbuf.pbuf.ref = 1;
-        p_desc->lwip_pbuf.pbuf.type = PBUF_REF;
         p_desc->lwip_pbuf.pbuf.next = NULL;
         p_desc->lwip_pbuf.pbuf.payload =
             (u8_t *)p_desc->p_buffer + p_desc->rx.n_transport_header_len;
-        p_desc->lwip_pbuf.custom_free_function = custom_free_function;
     }
     p_desc->lwip_pbuf.pbuf.gro = 0;
 }

--- a/src/core/sock/sockinfo_tcp.cpp
+++ b/src/core/sock/sockinfo_tcp.cpp
@@ -155,9 +155,7 @@ static lock_base *get_new_tcp_lock()
 inline void sockinfo_tcp::lwip_pbuf_init_custom(mem_buf_desc_t *p_desc)
 {
     /* Override default free function to return rx pbuf to the CQ cache */
-    static pbuf_free_custom_fn custom_free_function =
-        (is_socketxtreme() ? p_desc->lwip_pbuf.custom_free_function
-                           : sockinfo_tcp::tcp_rx_pbuf_free);
+    const pbuf_free_custom_fn custom_free_function = sockinfo_tcp::tcp_rx_pbuf_free;
 
     if (!p_desc->lwip_pbuf.pbuf.gro) {
         p_desc->lwip_pbuf.pbuf.flags = PBUF_FLAG_IS_CUSTOM;


### PR DESCRIPTION
## Description
Custom lwip free method is used to free buffers which are not accepted as socket payload. SocketXtreme flow uses default buffer_pool method which bypasses cq_mgr. In a multithreaded application this leads to global lock usage and potential contention in some scenarios.

Use sockinfo_tcp method unconditionally for all TCP RX packets to avoid the global lock.

##### What
Use sockinfo_tcp method unconditionally for all TCP RX packets to avoid the global lock.

##### Why ?
Performance optimization.

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

