### PR TITLE
issue: 3678579 Fix last_unsent and last_unacked

### DIFF
--- a/src/core/lwip/tcp.c
+++ b/src/core/lwip/tcp.c
@@ -1265,7 +1265,7 @@ void tcp_pcb_purge(struct tcp_pcb *pcb)
         tcp_tx_segs_free(pcb, pcb->unsent);
         tcp_tx_segs_free(pcb, pcb->unacked);
         pcb->unacked = pcb->unsent = NULL;
-        pcb->last_unsent = NULL;
+        pcb->last_unacked = pcb->last_unsent = NULL;
 #if TCP_OVERSIZE
         pcb->unsent_oversize = 0;
 #endif /* TCP_OVERSIZE */

--- a/src/core/lwip/tcp_in.c
+++ b/src/core/lwip/tcp_in.c
@@ -1221,6 +1221,7 @@ static void tcp_receive(struct tcp_pcb *pcb, tcp_in_data *in_data)
             /* If there's nothing left to acknowledge, stop the retransmit
                timer, otherwise reset it to start again */
             if (pcb->unacked == NULL) {
+                pcb->last_unacked = NULL;
                 if (persist) {
                     /* start persist timer */
                     pcb->persist_cnt = 0;

--- a/src/core/lwip/tcp_out.c
+++ b/src/core/lwip/tcp_out.c
@@ -2037,6 +2037,7 @@ void tcp_rexmit_rto(struct tcp_pcb *pcb)
     pcb->unsent = pcb->unacked;
     /* unacked queue is now empty */
     pcb->unacked = NULL;
+    pcb->last_unacked = NULL;
 
     /* increment number of retransmissions */
     ++pcb->nrtx;

--- a/src/core/lwip/tcp_out.c
+++ b/src/core/lwip/tcp_out.c
@@ -136,7 +136,7 @@ static struct pbuf *tcp_output_alloc_header(struct tcp_pcb *pcb, u16_t optlen, u
 err_t tcp_send_fin(struct tcp_pcb *pcb)
 {
     /* first, try to add the fin to the last unsent segment */
-    if (pcb->last_unsent != NULL) {
+    if (pcb->unsent != NULL) {
         if ((TCPH_FLAGS(pcb->last_unsent->tcphdr) & (TCP_SYN | TCP_FIN | TCP_RST)) == 0) {
             /* no SYN/FIN/RST flag in the header, we can add the FIN flag */
             TCPH_SET_FLAG(pcb->last_unsent->tcphdr, TCP_FIN);

--- a/src/core/lwip/tcp_out.c
+++ b/src/core/lwip/tcp_out.c
@@ -1625,6 +1625,9 @@ err_t tcp_output(struct tcp_pcb *pcb)
         pcb->unacked->next = pcb->unsent;
         pcb->unsent = pcb->unacked;
         pcb->unacked = NULL;
+        if (NULL == pcb->last_unsent) {
+            pcb->last_unsent = pcb->last_unacked;
+        }
         pcb->last_unacked = NULL;
     }
     seg = pcb->unsent;

--- a/src/core/lwip/tcp_out.c
+++ b/src/core/lwip/tcp_out.c
@@ -2068,7 +2068,11 @@ void tcp_rexmit(struct tcp_pcb *pcb)
     /* Move the first unacked segment to the unsent queue */
     /* Keep the unsent queue sorted. */
     seg = pcb->unacked;
-    pcb->unacked = seg->next;
+
+    pcb->unacked = pcb->unacked->next;
+    if (NULL == pcb->unacked) {
+        pcb->last_unacked = NULL;
+    }
 
     cur_seg = &(pcb->unsent);
     while (*cur_seg && TCP_SEQ_LT((*cur_seg)->seqno, seg->seqno)) {


### PR DESCRIPTION
1. Use last_unsent and last_unacked instead of iterating queues.
2. Fix incorrect values for last_unsent and last_unacked.

## Change type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

