### PR TITLE
issue: 3690535 Remove SO_XLIO_RING_USER_MEMORY

### DIFF
--- a/src/core/dev/net_device_val.cpp
+++ b/src/core/dev/net_device_val.cpp
@@ -72,30 +72,25 @@
 
 ring_alloc_logic_attr::ring_alloc_logic_attr()
     : m_ring_alloc_logic(RING_LOGIC_PER_INTERFACE)
-    , m_user_id_key(0)
     , m_use_locks(true)
+    , m_user_id_key(0)
 {
-    m_mem_desc.iov_base = NULL;
-    m_mem_desc.iov_len = 0;
     init();
 }
 
 ring_alloc_logic_attr::ring_alloc_logic_attr(ring_logic_t ring_logic, bool use_locks)
     : m_ring_alloc_logic(ring_logic)
-    , m_user_id_key(0)
     , m_use_locks(use_locks)
+    , m_user_id_key(0)
 {
-    m_mem_desc.iov_base = NULL;
-    m_mem_desc.iov_len = 0;
     init();
 }
 
 ring_alloc_logic_attr::ring_alloc_logic_attr(const ring_alloc_logic_attr &other)
     : m_hash(other.m_hash)
     , m_ring_alloc_logic(other.m_ring_alloc_logic)
-    , m_user_id_key(other.m_user_id_key)
-    , m_mem_desc(other.m_mem_desc)
     , m_use_locks(other.m_use_locks)
+    , m_user_id_key(other.m_user_id_key)
 {
 }
 
@@ -118,8 +113,6 @@ void ring_alloc_logic_attr::init()
 
     HASH_ITER(m_ring_alloc_logic, size_t);
     HASH_ITER(m_user_id_key, uint64_t);
-    HASH_ITER(m_mem_desc.iov_base, uintptr_t);
-    HASH_ITER(m_mem_desc.iov_len, size_t);
     HASH_ITER(m_use_locks, bool);
 
     m_hash = h;
@@ -130,14 +123,6 @@ void ring_alloc_logic_attr::set_ring_alloc_logic(ring_logic_t logic)
 {
     if (m_ring_alloc_logic != logic) {
         m_ring_alloc_logic = logic;
-        init();
-    }
-}
-
-void ring_alloc_logic_attr::set_memory_descriptor(iovec &mem_desc)
-{
-    if (m_mem_desc.iov_base != mem_desc.iov_base || m_mem_desc.iov_len != mem_desc.iov_len) {
-        m_mem_desc = mem_desc;
         init();
     }
 }
@@ -162,8 +147,7 @@ const std::string ring_alloc_logic_attr::to_str() const
 {
     std::stringstream ss;
 
-    ss << "allocation logic " << m_ring_alloc_logic << " key " << m_user_id_key << " user address "
-       << m_mem_desc.iov_base << " user length " << m_mem_desc.iov_len << " use locks "
+    ss << "allocation logic " << m_ring_alloc_logic << " key " << m_user_id_key << " use locks "
        << !!m_use_locks;
 
     return ss.str();

--- a/src/core/dev/net_device_val.h
+++ b/src/core/dev/net_device_val.h
@@ -60,21 +60,17 @@ public:
     ring_alloc_logic_attr(ring_logic_t ring_logic, bool use_locks);
     ring_alloc_logic_attr(const ring_alloc_logic_attr &other);
     void set_ring_alloc_logic(ring_logic_t logic);
-    void set_memory_descriptor(iovec &mem_desc);
     void set_user_id_key(uint64_t user_id_key);
     void set_use_locks(bool use_locks);
     const std::string to_str() const;
     inline ring_logic_t get_ring_alloc_logic() { return m_ring_alloc_logic; }
-    inline iovec *get_memory_descriptor() { return &m_mem_desc; }
     inline uint64_t get_user_id_key() { return m_user_id_key; }
     inline bool get_use_locks() { return m_use_locks; }
 
     bool operator==(const ring_alloc_logic_attr &other) const
     {
         return (m_ring_alloc_logic == other.m_ring_alloc_logic &&
-                m_user_id_key == other.m_user_id_key &&
-                m_mem_desc.iov_base == other.m_mem_desc.iov_base &&
-                m_mem_desc.iov_len == other.m_mem_desc.iov_len && m_use_locks == other.m_use_locks);
+                m_user_id_key == other.m_user_id_key && m_use_locks == other.m_use_locks);
     }
 
     bool operator!=(const ring_alloc_logic_attr &other) const { return !(*this == other); }
@@ -85,8 +81,6 @@ public:
             m_ring_alloc_logic = other.m_ring_alloc_logic;
             m_user_id_key = other.m_user_id_key;
             m_hash = other.m_hash;
-            m_mem_desc.iov_base = other.m_mem_desc.iov_base;
-            m_mem_desc.iov_len = other.m_mem_desc.iov_len;
             m_use_locks = other.m_use_locks;
         }
         return *this;
@@ -101,12 +95,11 @@ public:
 
 private:
     size_t m_hash;
-    /* ring allocation logic , per thread per fd ... */
+    /* Ring allocation logic: per thread, per interface, etc */
     ring_logic_t m_ring_alloc_logic;
-    /* either user_idx or key as defined in ring_logic_t */
-    uint64_t m_user_id_key;
-    iovec m_mem_desc;
     bool m_use_locks;
+    /* Either user_idx or key as defined in ring_logic_t */
+    uint64_t m_user_id_key;
     void init();
 };
 

--- a/src/core/dev/ring_allocation_logic.h
+++ b/src/core/dev/ring_allocation_logic.h
@@ -93,8 +93,9 @@ public:
     bool should_migrate_ring();
     bool is_logic_support_migration()
     {
-        return m_res_key.get_ring_alloc_logic() >= RING_LOGIC_PER_THREAD &&
-            m_res_key.get_ring_alloc_logic() < RING_LOGIC_PER_OBJECT && m_ring_migration_ratio > 0;
+        return m_ring_migration_ratio > 0 &&
+            m_res_key.get_ring_alloc_logic() >= RING_LOGIC_PER_THREAD &&
+            m_res_key.get_ring_alloc_logic() < RING_LOGIC_PER_OBJECT;
     }
     uint64_t calc_res_key_by_logic();
     inline ring_logic_t get_alloc_logic_type() { return m_res_key.get_ring_alloc_logic(); }

--- a/src/core/dev/ring_allocation_logic.h
+++ b/src/core/dev/ring_allocation_logic.h
@@ -84,6 +84,8 @@ protected:
     ring_allocation_logic(ring_logic_t ring_allocation_logic, int ring_migration_ratio,
                           source_t source, resource_allocation_key &ring_profile);
 
+    void debug_print_type(const char *type);
+
 public:
     /* careful, you'll lose the previous key !! */
     resource_allocation_key *create_new_key(const ip_address &addr, int suggested_cpu = NO_CPU);
@@ -101,6 +103,8 @@ public:
     inline ring_logic_t get_alloc_logic_type() { return m_res_key.get_ring_alloc_logic(); }
     inline void disable_migration() { m_ring_migration_ratio = -1; }
 
+    const std::string to_str() const;
+
 private:
     int m_ring_migration_ratio;
     int m_migration_try_count;
@@ -114,11 +118,13 @@ public:
     ring_allocation_logic_rx()
         : ring_allocation_logic()
     {
+        debug_print_type("Rx");
     }
     ring_allocation_logic_rx(source_t source, resource_allocation_key &ring_profile)
         : ring_allocation_logic(safe_mce_sys().ring_allocation_logic_rx,
                                 safe_mce_sys().ring_migration_ratio_rx, source, ring_profile)
     {
+        debug_print_type("Rx");
     }
 };
 
@@ -127,11 +133,13 @@ public:
     ring_allocation_logic_tx()
         : ring_allocation_logic()
     {
+        debug_print_type("Tx");
     }
     ring_allocation_logic_tx(source_t source, resource_allocation_key &ring_profile)
         : ring_allocation_logic(safe_mce_sys().ring_allocation_logic_tx,
                                 safe_mce_sys().ring_migration_ratio_tx, source, ring_profile)
     {
+        debug_print_type("Tx");
     }
 };
 

--- a/src/core/dev/ring_allocation_logic.h
+++ b/src/core/dev/ring_allocation_logic.h
@@ -98,19 +98,13 @@ public:
     }
     uint64_t calc_res_key_by_logic();
     inline ring_logic_t get_alloc_logic_type() { return m_res_key.get_ring_alloc_logic(); }
-    inline void enable_migration(bool active) { m_active = active; }
-    const std::string to_str() const;
-
-protected:
-    const char *m_type;
-    const void *m_owner;
+    inline void disable_migration() { m_ring_migration_ratio = -1; }
 
 private:
     int m_ring_migration_ratio;
-    source_t m_source;
     int m_migration_try_count;
+    source_t m_source;
     uint64_t m_migration_candidate;
-    bool m_active;
     resource_allocation_key m_res_key;
 };
 
@@ -120,13 +114,10 @@ public:
         : ring_allocation_logic()
     {
     }
-    ring_allocation_logic_rx(source_t source, resource_allocation_key &ring_profile,
-                             const void *owner)
+    ring_allocation_logic_rx(source_t source, resource_allocation_key &ring_profile)
         : ring_allocation_logic(safe_mce_sys().ring_allocation_logic_rx,
                                 safe_mce_sys().ring_migration_ratio_rx, source, ring_profile)
     {
-        m_type = "Rx";
-        m_owner = owner;
     }
 };
 
@@ -136,13 +127,10 @@ public:
         : ring_allocation_logic()
     {
     }
-    ring_allocation_logic_tx(source_t source, resource_allocation_key &ring_profile,
-                             const void *owner)
+    ring_allocation_logic_tx(source_t source, resource_allocation_key &ring_profile)
         : ring_allocation_logic(safe_mce_sys().ring_allocation_logic_tx,
                                 safe_mce_sys().ring_migration_ratio_tx, source, ring_profile)
     {
-        m_type = "Tx";
-        m_owner = owner;
     }
 };
 

--- a/src/core/proto/dst_entry.cpp
+++ b/src/core/proto/dst_entry.cpp
@@ -60,7 +60,7 @@ dst_entry::dst_entry(const sock_addr &dst, uint16_t src_port, socket_data &sock_
     , m_so_bindtodevice_ip(in6addr_any)
     , m_route_src_ip(in6addr_any)
     , m_pkt_src_ip(in6addr_any)
-    , m_ring_alloc_logic_tx(sock_data.fd, ring_alloc_logic, this)
+    , m_ring_alloc_logic_tx(sock_data.fd, ring_alloc_logic)
     , m_p_tx_mem_buf_desc_list(NULL)
     , m_p_zc_mem_buf_desc_list(NULL)
     , m_b_tx_mem_buf_desc_list_pending(false)
@@ -833,7 +833,7 @@ bool dst_entry::update_ring_alloc_logic(int fd, lock_base &socket_lock,
 {
     resource_allocation_key old_key(*m_ring_alloc_logic_tx.get_key());
 
-    m_ring_alloc_logic_tx = ring_allocation_logic_tx(fd, ring_alloc_logic, this);
+    m_ring_alloc_logic_tx = ring_allocation_logic_tx(fd, ring_alloc_logic);
 
     if (*m_ring_alloc_logic_tx.get_key() != old_key) {
         std::lock_guard<decltype(m_tx_migration_lock)> locker(m_tx_migration_lock);

--- a/src/core/proto/neighbour.cpp
+++ b/src/core/proto/neighbour.cpp
@@ -221,7 +221,7 @@ neigh_entry::neigh_entry(neigh_key key, transport_type_t _type, bool is_init_res
 
     // Allocate one ring for g_p_neigh_table_mgr. All eigh_entry objects will share the same ring.
     ring_alloc_logic_attr ring_attr(RING_LOGIC_PER_OBJECT, true);
-    m_ring_allocation_logic = ring_allocation_logic_tx(g_p_neigh_table_mgr, ring_attr, this);
+    m_ring_allocation_logic = ring_allocation_logic_tx(g_p_neigh_table_mgr, ring_attr);
 
     if (is_init_resources) {
         m_p_ring = m_p_dev->reserve_ring(m_ring_allocation_logic.get_key());

--- a/src/core/sock/sockinfo.cpp
+++ b/src/core/sock/sockinfo.cpp
@@ -395,31 +395,6 @@ int sockinfo::setsockopt(int __level, int __optname, const void *__optval, sockl
                 errno = EINVAL;
             }
             break;
-        case SO_XLIO_RING_USER_MEMORY:
-            if (__optval) {
-                if (__optlen == sizeof(iovec)) {
-                    iovec *attr = (iovec *)__optval;
-                    m_ring_alloc_log_rx.set_memory_descriptor(*attr);
-                    m_ring_alloc_logic_rx =
-                        ring_allocation_logic_rx(get_fd(), m_ring_alloc_log_rx, this);
-                    if (m_p_rx_ring || m_rx_ring_map.size()) {
-                        si_logwarn("user asked to assign memory for "
-                                   "RX ring but ring already exists");
-                    }
-                    ret = SOCKOPT_INTERNAL_XLIO_SUPPORT;
-                } else {
-                    ret = SOCKOPT_NO_XLIO_SUPPORT;
-                    errno = EINVAL;
-                    si_logdbg("SOL_SOCKET, SO_XLIO_RING_USER_MEMORY - "
-                              "bad length expected %zu got %d",
-                              sizeof(iovec), __optlen);
-                }
-            } else {
-                ret = SOCKOPT_NO_XLIO_SUPPORT;
-                errno = EINVAL;
-                si_logdbg("SOL_SOCKET, SO_XLIO_RING_USER_MEMORY - NOT HANDLED, optval == NULL");
-            }
-            break;
         case SO_XLIO_FLOW_TAG:
             if (__optval) {
                 if (__optlen == sizeof(uint32_t)) {

--- a/src/core/sock/sockinfo_tcp.cpp
+++ b/src/core/sock/sockinfo_tcp.cpp
@@ -337,8 +337,6 @@ sockinfo_tcp::sockinfo_tcp(int fd, int domain)
     tcp_err(&m_pcb, sockinfo_tcp::err_lwip_cb);
     tcp_sent(&m_pcb, sockinfo_tcp::ack_recvd_lwip_cb);
 
-    m_n_pbufs_rcvd = m_n_pbufs_freed = 0;
-
     m_parent = NULL;
     m_iomux_ready_fd_array = NULL;
 

--- a/src/core/sock/sockinfo_tcp.h
+++ b/src/core/sock/sockinfo_tcp.h
@@ -588,10 +588,6 @@ private:
     uint64_t m_user_huge_page_mask;
     unsigned m_required_send_block;
     uint16_t m_external_vlan_tag = 0U;
-
-    // stats
-    uint64_t m_n_pbufs_rcvd;
-    uint64_t m_n_pbufs_freed;
 };
 typedef struct tcp_seg tcp_seg;
 

--- a/src/core/xlio_extra.h
+++ b/src/core/xlio_extra.h
@@ -50,7 +50,6 @@
 #define SO_XLIO_GET_API          2800
 #define SO_XLIO_USER_DATA        2801
 #define SO_XLIO_RING_ALLOC_LOGIC 2810
-#define SO_XLIO_RING_USER_MEMORY 2811
 #define SO_XLIO_FLOW_TAG         2820
 #define SO_XLIO_SHUTDOWN_RX      2821
 #define SO_XLIO_PD               2822


### PR DESCRIPTION
## Description
This is leftover from the Multi Packet RQ removal. In current code, this option doesn't have effect and only wastes 96 bytes per socket.

Also, reduce ring_allocation_logic size (64 bytes per socket).

##### What
Remove SO_XLIO_RING_USER_MEMORY and related code.

##### Why ?
Code cleanup and reduce socket size.

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

