### PR TITLE
issue: 3698256 Socket isolation feature

### DIFF
--- a/src/core/dev/net_device_val.cpp
+++ b/src/core/dev/net_device_val.cpp
@@ -1023,7 +1023,7 @@ ring *net_device_val::reserve_ring(resource_allocation_key *key)
 
     if (m_h_ring_map.end() == ring_iter) {
         nd_logdbg("Creating new RING for %s", key->to_str().c_str());
-        // copy key since we keep pointer and socket can die so map will lose pointer
+        // Copy key since we keep pointer and socket can die so map will lose pointer
         resource_allocation_key *new_key = new resource_allocation_key(*key);
         the_ring = create_ring(new_key);
         if (!the_ring) {
@@ -1048,9 +1048,12 @@ ring *net_device_val::reserve_ring(resource_allocation_key *key)
             BULLSEYE_EXCLUDE_BLOCK_END
         }
 
+        if (key->get_ring_alloc_logic() == RING_LOGIC_ISOLATE) {
+            // Keep isolated rings until termination. Destructor will delete the ring.
+            ADD_RING_REF_CNT;
+        }
         g_p_net_device_table_mgr->global_ring_wakeup();
     }
-    // now we are sure the ring is in the map
 
     ADD_RING_REF_CNT;
     the_ring = GET_THE_RING(key);

--- a/src/core/dev/ring_allocation_logic.cpp
+++ b/src/core/dev/ring_allocation_logic.cpp
@@ -113,6 +113,9 @@ uint64_t ring_allocation_logic::calc_res_key_by_logic()
     case RING_LOGIC_PER_OBJECT:
         res_key = reinterpret_cast<uint64_t>(m_source.m_object);
         break;
+    case RING_LOGIC_ISOLATE:
+        res_key = 0;
+        break;
     default:
         // not suppose to get here
         ral_logdbg("non-valid ring logic = %d", m_res_key.get_ring_alloc_logic());

--- a/src/core/sock/sockinfo.cpp
+++ b/src/core/sock/sockinfo.cpp
@@ -103,7 +103,6 @@ sockinfo::sockinfo(int fd, int domain, bool use_ring_locks)
     , m_is_ipv6only(safe_mce_sys().sysctl_reader.get_ipv6_bindv6only())
     , m_p_rings_fds(NULL)
 {
-    m_ring_alloc_logic_rx = ring_allocation_logic_rx(get_fd(), m_ring_alloc_log_rx, this);
     m_rx_epfd = orig_os_api.epoll_create(128);
     if (unlikely(m_rx_epfd == -1)) {
         throw_xlio_exception("create internal epoll");
@@ -113,6 +112,8 @@ sockinfo::sockinfo(int fd, int domain, bool use_ring_locks)
         m_fd = m_rx_epfd;
         m_fd_context = (void *)((uintptr_t)m_fd);
     }
+
+    m_ring_alloc_logic_rx = ring_allocation_logic_rx(get_fd(), m_ring_alloc_log_rx, this);
 
     m_p_socket_stats = &m_socket_stats; // Save stats as local copy and allow state publisher to
                                         // copy from this location

--- a/src/core/sock/sockinfo_tcp.cpp
+++ b/src/core/sock/sockinfo_tcp.cpp
@@ -4556,6 +4556,40 @@ int sockinfo_tcp::tcp_setsockopt(int __level, int __optname, __const void *__opt
             ret = -1;
             errno = EINVAL;
             break;
+        case SO_XLIO_ISOLATE:
+            // See option description in the extra API header.
+            pass_to_os_cond = false;
+            // We support SO_XLIO_ISOLATE only when no TX/RX rings are assigned.
+            if (__optlen == sizeof(int) && !m_p_connected_dst_entry && m_rx_ring_map.empty()) {
+                int tempval = *reinterpret_cast<const int *>(__optval);
+                bool ring_isolated =
+                    m_ring_alloc_log_rx.get_ring_alloc_logic() == RING_LOGIC_ISOLATE &&
+                    m_ring_alloc_log_tx.get_ring_alloc_logic() == RING_LOGIC_ISOLATE;
+
+                if (tempval == SO_XLIO_ISOLATE_DEFAULT && !ring_isolated) {
+                    // Do nothing.
+                    break;
+                }
+                if (tempval == SO_XLIO_ISOLATE_SAFE) {
+                    if (safe_mce_sys().tcp_ctl_thread ==
+                            option_tcp_ctl_thread::CTL_THREAD_DELEGATE_TCP_TIMERS &&
+                        !ring_isolated) {
+                        m_tcp_con_lock = multilock::create_new_lock(MULTILOCK_RECURSIVE, "tcp_con");
+                    }
+                    m_ring_alloc_log_rx = ring_alloc_logic_attr(RING_LOGIC_ISOLATE, true);
+                    m_ring_alloc_log_tx = ring_alloc_logic_attr(RING_LOGIC_ISOLATE, true);
+                    m_ring_alloc_logic_rx =
+                        ring_allocation_logic_rx(get_fd(), m_ring_alloc_log_rx, this);
+                    m_p_socket_stats->ring_alloc_logic_rx =
+                        m_ring_alloc_log_rx.get_ring_alloc_logic();
+                    m_p_socket_stats->ring_user_id_rx =
+                        m_ring_alloc_logic_rx.calc_res_key_by_logic();
+                    break;
+                }
+            }
+            ret = -1;
+            errno = EINVAL;
+            break;
         default:
             pass_to_os_always = true;
             supported = false;

--- a/src/core/xlio_extra.h
+++ b/src/core/xlio_extra.h
@@ -58,6 +58,27 @@
 #define SCM_XLIO_NVME_PD         2823
 #define SO_XLIO_EXT_VLAN_TAG     2824
 
+/**
+ * @def SO_XLIO_ISOLATE
+ * Socket isolation option groups sockets under specified policy.
+ *
+ * Supported policies:
+ *   - SO_XLIO_ISOLATE_DEFAULT - default behavior according to XLIO configuration.
+ *
+ *   - SO_XLIO_ISOLATE_SAFE - isolate sockets from the default sockets and guarantee thread
+ *     safety regardless of XLIO configuration (note: this option doesn't change socket API
+ *     thread safety model). This policy is mostly effective in XLIO_TCP_CTL_THREAD=delegate
+ *     configuration.
+ *
+ * Current limitations:
+ *   - SO_XLIO_ISOLATE option is supported only by TCP sockets
+ *   - SO_XLIO_ISOLATE must be called according to thread safety model and XLIO configuration
+ *   - SO_XLIO_ISOLATE may be called after socket() syscall and before either listen() or connect()
+ */
+#define SO_XLIO_ISOLATE         2825
+#define SO_XLIO_ISOLATE_DEFAULT 0
+#define SO_XLIO_ISOLATE_SAFE    1
+
 enum { CMSG_XLIO_IOCTL_USER_ALLOC = 2900 };
 
 /*
@@ -251,6 +272,7 @@ typedef enum {
     RING_LOGIC_PER_CORE = 30, //!< RING_LOGIC_PER_CORE
     RING_LOGIC_PER_CORE_ATTACH_THREADS = 31, //!< RING_LOGIC_PER_CORE_ATTACH_THREADS
     RING_LOGIC_PER_OBJECT = 32, //!< RING_LOGIC_PER_OBJECT
+    RING_LOGIC_ISOLATE = 33, //!< RING_LOGIC_ISOLATE
     RING_LOGIC_LAST //!< RING_LOGIC_LAST
 } ring_logic_t;
 

--- a/tests/extra_api/socket_isolation.c
+++ b/tests/extra_api/socket_isolation.c
@@ -1,0 +1,277 @@
+/*
+ * Copyright © 2019-2023 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <assert.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+
+#include <mellanox/xlio_extra.h>
+
+#ifndef ARRAY_SIZE
+#define ARRAY_SIZE(arr) (sizeof(arr) / sizeof(arr[0]))
+#endif /* ARRAY_SIZE */
+
+#define HELLO_MSG "Hello"
+
+static struct xlio_api_t *xlio_api = NULL;
+
+static void server(const char *server_ip)
+{
+    char buf[64];
+    struct sockaddr_in addr;
+    ssize_t len;
+    int sock;
+    int sock2;
+    int sock3;
+    int sock_in;
+    int sock_in2;
+    int val = SO_XLIO_ISOLATE_SAFE;
+    int rc;
+
+    /*
+     * Socket create
+     */
+
+    sock = socket(AF_INET, SOCK_STREAM, 0);
+    assert(sock >= 0);
+    sock2 = socket(AF_INET, SOCK_STREAM, 0);
+    assert(sock2 >= 0);
+    sock3 = socket(AF_INET, SOCK_STREAM, 0);
+    assert(sock3 >= 0);
+
+    rc = setsockopt(sock, SOL_SOCKET, SO_XLIO_ISOLATE, &val, sizeof(val));
+    assert(rc == 0);
+
+    /*
+     * Socket bind
+     */
+
+    memset(&addr, 0, sizeof(addr));
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = inet_addr(server_ip);
+    addr.sin_port = htons(8080);
+
+    rc = bind(sock, (struct sockaddr *)&addr, sizeof(addr));
+    assert(rc == 0);
+
+    addr.sin_port = htons(8081);
+    rc = bind(sock2, (struct sockaddr *)&addr, sizeof(addr));
+    assert(rc == 0);
+
+    addr.sin_port = htons(8082);
+    rc = bind(sock3, (struct sockaddr *)&addr, sizeof(addr));
+    assert(rc == 0);
+
+    rc = setsockopt(sock2, SOL_SOCKET, SO_XLIO_ISOLATE, &val, sizeof(val));
+    assert(rc == 0);
+
+    /*
+     * Socket listen
+     */
+
+    rc = listen(sock, 5);
+    assert(rc == 0);
+
+    rc = listen(sock2, 5);
+    assert(rc == 0);
+
+    rc = listen(sock3, 5);
+    assert(rc == 0);
+
+    rc = setsockopt(sock3, SOL_SOCKET, SO_XLIO_ISOLATE, &val, sizeof(val));
+    assert(rc == -1);
+    assert(errno == EINVAL);
+
+    /*
+     * Check rings
+     */
+
+    int xlio_ring_fds[3];
+    int xlio_ring_fds2[3];
+    int xlio_ring_fds3[3];
+    rc = xlio_api->get_socket_rings_fds(sock, xlio_ring_fds, ARRAY_SIZE(xlio_ring_fds));
+    assert(rc == 1);
+    rc = xlio_api->get_socket_rings_fds(sock2, xlio_ring_fds2, ARRAY_SIZE(xlio_ring_fds2));
+    assert(rc == 1);
+    rc = xlio_api->get_socket_rings_fds(sock3, xlio_ring_fds3, ARRAY_SIZE(xlio_ring_fds3));
+    assert(rc == 1);
+    assert(xlio_ring_fds[0] == xlio_ring_fds2[0]);
+    assert(xlio_ring_fds[0] != xlio_ring_fds3[0]);
+
+    /*
+     * Socket accept
+     */
+
+    do {
+        sock_in = accept(sock, NULL, NULL);
+    } while (sock_in == -1 && errno == EINTR);
+    assert(sock_in >= 0);
+
+    do {
+        sock_in2 = accept(sock2, NULL, NULL);
+    } while (sock_in2 == -1 && errno == EINTR);
+    assert(sock_in2 >= 0);
+
+    /*
+     * Socket read / write
+     */
+
+    len = write(sock_in, HELLO_MSG, sizeof(HELLO_MSG));
+    assert(len > 0);
+
+    do {
+        len = read(sock_in, buf, sizeof(buf));
+    } while (len == -1 && errno == EINTR);
+    assert(len > 0);
+    assert(len == sizeof(HELLO_MSG));
+    assert(strncmp(buf, HELLO_MSG, strlen(HELLO_MSG)) == 0);
+
+    /*
+     * Socket close
+     */
+
+    sleep(1);
+
+    rc = close(sock_in);
+    assert(rc == 0);
+    rc = close(sock_in2);
+    assert(rc == 0);
+    rc = close(sock);
+    assert(rc == 0);
+    rc = close(sock2);
+    assert(rc == 0);
+    rc = close(sock3);
+    assert(rc == 0);
+}
+
+static void client(const char *server_ip)
+{
+    char buf[64];
+    struct sockaddr_in addr;
+    ssize_t len;
+    int sock;
+    int sock2;
+    int val = SO_XLIO_ISOLATE_SAFE;
+    int valdef = SO_XLIO_ISOLATE_DEFAULT;
+    int rc;
+
+    sock = socket(AF_INET, SOCK_STREAM, 0);
+    assert(sock >= 0);
+    sock2 = socket(AF_INET, SOCK_STREAM, 0);
+    assert(sock2 >= 0);
+
+    rc = setsockopt(sock, SOL_SOCKET, SO_XLIO_ISOLATE, &val, sizeof(val));
+    assert(rc == 0);
+    rc = setsockopt(sock, SOL_SOCKET, SO_XLIO_ISOLATE, &valdef, sizeof(valdef));
+    assert(rc == -1);
+    assert(errno == EINVAL);
+
+    memset(&addr, 0, sizeof(addr));
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = inet_addr(server_ip);
+    addr.sin_port = htons(8080);
+
+    rc = connect(sock, (struct sockaddr *)&addr, sizeof(addr));
+    assert(rc == 0);
+
+    addr.sin_port = htons(8081);
+    rc = connect(sock2, (struct sockaddr *)&addr, sizeof(addr));
+    assert(rc == 0);
+
+    rc = setsockopt(sock2, SOL_SOCKET, SO_XLIO_ISOLATE, &val, sizeof(val));
+    assert(rc == -1);
+    assert(errno == EINVAL);
+
+    int xlio_ring_fds[3];
+    int xlio_ring_fds2[3];
+    rc = xlio_api->get_socket_rings_fds(sock, xlio_ring_fds, ARRAY_SIZE(xlio_ring_fds));
+    assert(rc == 1);
+    rc = xlio_api->get_socket_rings_fds(sock2, xlio_ring_fds2, ARRAY_SIZE(xlio_ring_fds2));
+    assert(rc == 1);
+    assert(xlio_ring_fds[0] != xlio_ring_fds2[0]);
+
+    len = write(sock, HELLO_MSG, sizeof(HELLO_MSG));
+    assert(len > 0);
+
+    do {
+        len = read(sock, buf, sizeof(buf));
+    } while (len == -1 && errno == EINTR);
+    assert(len > 0);
+    assert(len == sizeof(HELLO_MSG));
+    assert(strncmp(buf, HELLO_MSG, strlen(HELLO_MSG)) == 0);
+
+    sleep(1);
+
+    rc = close(sock);
+    assert(rc == 0);
+    rc = close(sock2);
+    assert(rc == 0);
+}
+
+static void usage(const char *name)
+{
+    printf("Usage: %s <-s|-c> <server-ip>\n", name);
+    printf(" -s         server mode\n");
+    printf(" -c         client mode\n");
+    printf(" server-ip  IPv4 address to listen/connect to\n");
+    exit(1);
+}
+
+int main(int argc, char **argv)
+{
+    if (argc != 3) {
+        usage(argc > 0 ? argv[0] : "a.out");
+    }
+
+    xlio_api = xlio_get_api();
+    if (xlio_api == NULL) {
+        printf("Extra API not found. Run under XLIO.\n");
+        return 1;
+    }
+
+    if (strcmp(argv[1], "-s") == 0) {
+        server(argv[2]);
+    } else if (strcmp(argv[1], "-c") == 0) {
+        client(argv[2]);
+    } else {
+        usage(argv[0]);
+    }
+
+    printf("Success.\n");
+    return 0;
+}


### PR DESCRIPTION
## Description
Add socket isolation option to setsockopt() which allows XLIO to isolate specific sockets with some policy.

Currently, XLIO supports SO_XLIO_ISOLATE_SAFE logic which isolates sockets with a separate global thread-safe ring per interface. This allows to work with the sockets in multiple threads in a thread-unsafe configuration (e.g. delegated TCP timers mode).

In the future, SO_XLIO_ISOLATE interface can be extended with other logic.

##### What
Add socket isolation option to force thread-safety for specific sockets.

##### Why ?
Avoid races in thread-unsafe environment when some sockets need to be used in multiple threads.

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

