### PR TITLE
issue: 3183915 Fix clang-analyzer warnings

### DIFF
--- a/src/core/dev/ib_ctx_handler.cpp
+++ b/src/core/dev/ib_ctx_handler.cpp
@@ -281,8 +281,13 @@ dpcp::adapter *ib_ctx_handler::set_dpcp_adapter()
         goto err;
     }
 
+    /*
+     * get_adapter_info_lst() returns number of adapters in response to NULL or
+     * 0 arguments along with DPCP_ERR_OUT_OF_RANGE error. On success, the
+     * number of actual adapters is not set, so we need a separate call here.
+     */
     status = p_provider->get_adapter_info_lst(NULL, adapters_num);
-    if (0 == adapters_num) {
+    if (dpcp::DPCP_ERR_OUT_OF_RANGE != status || 0 == adapters_num) {
         ibch_logdbg("found no adapters status = %d", status);
         goto err;
     }

--- a/src/core/dev/net_device_val.cpp
+++ b/src/core/dev/net_device_val.cpp
@@ -552,18 +552,17 @@ const std::string net_device_val::to_str_ex() const
 
 void net_device_val::print_val() const
 {
+#if (MAX_DEFINED_LOG_LEVEL >= DEFINED_VLOG_DEBUG)
     nd_logdbg("%s", to_str_ex().c_str());
 
     nd_logdbg("  IPv4 list: %s", (m_ipv4.empty() ? "empty " : ""));
     std::for_each(m_ipv4.begin(), m_ipv4.end(), [this](const std::unique_ptr<ip_data> &ip) {
-        NOT_IN_USE(ip); // Suppress --enable-opt-log=high warning
         nd_logdbg("    inet: %s/%d flags: 0x%X scope: 0x%x", ip->local_addr.to_str(AF_INET).c_str(),
                   ip->prefixlen, ip->flags, ip->scope);
     });
 
     nd_logdbg("  IPv6 list: %s", (m_ipv6.empty() ? "empty " : ""));
     std::for_each(m_ipv6.begin(), m_ipv6.end(), [this](const std::unique_ptr<ip_data> &ip) {
-        NOT_IN_USE(ip); // Suppress --enable-opt-log=high warning
         nd_logdbg("    inet6: %s/%d flags: 0x%X scope: 0x%x",
                   ip->local_addr.to_str(AF_INET6).c_str(), ip->prefixlen, ip->flags, ip->scope);
     });
@@ -582,10 +581,10 @@ void net_device_val::print_val() const
     nd_logdbg("  ring list: %s", (m_h_ring_map.empty() ? "empty " : ""));
     for (auto ring_iter = m_h_ring_map.begin(); ring_iter != m_h_ring_map.end(); ++ring_iter) {
         ring *cur_ring = ring_iter->second.first;
-        NOT_IN_USE(cur_ring); // Suppress --enable-opt-log=high warning
         nd_logdbg("    %d: %p: parent %p ref %d", cur_ring->get_if_index(), cur_ring,
                   cur_ring->get_parent(), ring_iter->second.second);
     }
+#endif /* MAX_DEFINED_LOG_LEVEL */
 }
 
 void net_device_val::set_slave_array()

--- a/src/core/dev/net_device_val.cpp
+++ b/src/core/dev/net_device_val.cpp
@@ -1387,23 +1387,23 @@ void net_device_val_eth::parse_prio_egress_map()
 
     nl_sock *socket = nl_socket_alloc();
     if (!socket) {
-        nd_logdbg("unable to allocate socket socket %s", strerror(errno));
+        nd_logdbg("unable to allocate a netlink socket");
         goto out;
     }
     nl_socket_set_local_port(socket, 0);
     ret = nl_connect(socket, NETLINK_ROUTE);
     if (ret < 0) {
-        nd_logdbg("unable to connect to libnl socket %d %s", ret, strerror(errno));
+        nd_logdbg("unable to connect to libnl socket %d (errno=%d)", ret, errno);
         goto out;
     }
     ret = rtnl_link_alloc_cache(socket, AF_UNSPEC, &cache);
-    if (!cache) {
-        nd_logdbg("unable to create libnl cache %d %s", ret, strerror(errno));
+    if (ret < 0 || !cache) {
+        nd_logdbg("unable to create libnl cache %d (errno=%d)", ret, errno);
         goto out;
     }
     link = rtnl_link_get_by_name(cache, get_ifname());
     if (!link) {
-        nd_logdbg("unable to get libnl link %d %s", ret, strerror(errno));
+        nd_logdbg("unable to find libnl link");
         goto out;
     }
     map = rtnl_link_vlan_get_egress_map(link, &len);

--- a/src/core/dev/qp_mgr.cpp
+++ b/src/core/dev/qp_mgr.cpp
@@ -405,11 +405,12 @@ void qp_mgr::release_rx_buffers()
     }
     m_last_posted_rx_wr_id = 0; // Clear the posted WR_ID flag, we just clear the entire RQ
     qp_logdbg("draining completed with a total of %d wce's on rx cq_mgr", total_ret);
+    NOT_IN_USE(total_ret); // Suppress --enable-opt-log=high warning
 }
 
 void qp_mgr::release_tx_buffers()
 {
-    int ret = 0;
+    int ret;
     uint64_t poll_sn = 0;
     qp_logdbg("draining tx cq_mgr %p", m_p_cq_mgr_tx);
     while (m_p_cq_mgr_tx && m_qp &&
@@ -417,6 +418,7 @@ void qp_mgr::release_tx_buffers()
            (errno != EIO && !m_p_ib_ctx_handler->is_removed())) {
         qp_logdbg("draining completed on tx cq_mgr (%d wce)", ret);
     }
+    NOT_IN_USE(ret); // Suppress --enable-opt-log=high warning
 }
 
 void qp_mgr::trigger_completion_for_all_sent_packets()

--- a/src/core/dev/ring_bond.cpp
+++ b/src/core/dev/ring_bond.cpp
@@ -166,7 +166,6 @@ void ring_bond::restart()
                 int fd = -1;
                 int rc = 0;
                 size_t i, j, k;
-                NOT_IN_USE(rc); // Suppress --enable-opt-log=high warning
 
                 if (slaves.empty()) {
                     ring_rx_fds_array =
@@ -261,6 +260,7 @@ void ring_bond::restart()
                         }
                     }
                 }
+                NOT_IN_USE(rc); // Suppress --enable-opt-log=high warning
             }
         }
     } else {

--- a/src/core/dev/time_converter.cpp
+++ b/src/core/dev/time_converter.cpp
@@ -64,7 +64,8 @@ uint32_t time_converter::get_single_converter_status(struct ibv_context *ctx)
     memset(&device_attr, 0, sizeof(device_attr));
     device_attr.comp_mask = XLIO_IBV_DEVICE_ATTR_HCA_CORE_CLOCK;
 
-    if ((rval = xlio_ibv_query_device(ctx, &device_attr)) || !device_attr.hca_core_clock) {
+    rval = xlio_ibv_query_device(ctx, &device_attr);
+    if (rval || !device_attr.hca_core_clock) {
         ibchtc_logdbg(
             "time_converter::get_single_converter_status :Error in querying hca core clock "
             "(xlio_ibv_query_device() return value=%d ) (ibv context %p) (errno=%d %m)\n",
@@ -76,7 +77,8 @@ uint32_t time_converter::get_single_converter_status(struct ibv_context *ctx)
     xlio_ts_values queried_values;
     memset(&queried_values, 0, sizeof(queried_values));
     queried_values.comp_mask = XLIO_IBV_VALUES_MASK_RAW_CLOCK;
-    if ((rval = xlio_ibv_query_values(ctx, &queried_values)) || !xlio_get_ts_val(queried_values)) {
+    rval = xlio_ibv_query_values(ctx, &queried_values);
+    if (rval || !xlio_get_ts_val(queried_values)) {
         ibchtc_logdbg(
             "time_converter::get_single_converter_status :Error in querying hw clock, can't convert"
             " hw time to system time (xlio_ibv_query_values() return value=%d ) (ibv context %p) "

--- a/src/core/event/event_handler_manager.cpp
+++ b/src/core/event/event_handler_manager.cpp
@@ -530,6 +530,7 @@ void event_handler_manager::priv_prepare_ibverbs_async_event_queue(event_handler
         cnt++;
     }
     evh_logdbg("Emptied %d Events", cnt);
+    NOT_IN_USE(cnt); // Suppress --enable-opt-log=high warning
 }
 
 void event_handler_manager::priv_register_ibverbs_events(ibverbs_reg_info_t &info)

--- a/src/core/sock/sockinfo_ulp.cpp
+++ b/src/core/sock/sockinfo_ulp.cpp
@@ -784,7 +784,11 @@ ssize_t sockinfo_tcp_ops_tls::tx(xlio_tx_call_attr_t &tx_arg)
                     ret = -1;
                 }
                 if (rec) {
-                    rec->put();
+                    /* rec->put() is a right approach to destroy the record. However, clang-analyzer
+                     * generates a false positive memory leak warning. Call destructor explicitly to
+                     * suppress the warning.
+                     */
+                    delete rec;
                 }
                 goto done;
             }

--- a/src/core/util/match.cpp
+++ b/src/core/util/match.cpp
@@ -288,13 +288,14 @@ static int match_ip_addr_and_port(transport_t my_transport, struct use_family_ru
     unsigned short port_first;
     unsigned short port_second;
     int match = 1;
-    char addr_buf_first[MAX_ADDR_STR_LEN];
-    const char *addr_str_first;
-    char addr_buf_second[MAX_ADDR_STR_LEN];
-    const char *addr_str_second;
-    char rule_str[512];
 
+#if (MAX_DEFINED_LOG_LEVEL >= DEFINED_VLOG_DEBUG)
     if (g_vlogger_level >= VLOG_DEBUG) {
+        char addr_buf_first[MAX_ADDR_STR_LEN];
+        const char *addr_str_first;
+        char addr_buf_second[MAX_ADDR_STR_LEN];
+        const char *addr_str_second;
+        char rule_str[512];
 
         get_rule_str(rule, rule_str, sizeof(rule_str));
 
@@ -332,6 +333,7 @@ static int match_ip_addr_and_port(transport_t my_transport, struct use_family_ru
             match_logdbg("MATCH: matching %s:%d to %s => ", addr_str_first, port_first, rule_str);
         }
     }
+#endif /* MAX_DEFINED_LOG_LEVEL */
 
     /* We currently only support IPv4 and IPv4 embedded in IPv6 */
     if (rule->first.match_by_port) {

--- a/src/state_machine/sm.cpp
+++ b/src/state_machine/sm.cpp
@@ -202,6 +202,7 @@ int state_machine::process_sparse_table(sm_short_table_line_t *short_table,
 
     sm_logdbg("SM full table processing done. Allocated memory size of %d bytes",
               sm_table_entries_size);
+    (void)sm_table_entries_size; // Suppress --enable-opt-log=high warning
     return 0;
 }
 


### PR DESCRIPTION
## Description
Fix clang-analyzer warnings

##### What
Fix clang-analyzer warnings

##### Why ?
Code cleanup and ability to use clang-analyzer in manual/automation scripts.

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

