### PR TITLE
[TLS] Update DEK usage according to dpcp 1.1.44

### DIFF
--- a/config/m4/utls.m4
+++ b/config/m4/utls.m4
@@ -45,29 +45,28 @@ AC_ARG_ENABLE([utls],
     [enable_utls=auto]
 )
 
-prj_cv_dpcp_1_1_3=0
+prj_cv_dpcp_1_1_44=0
 AS_IF([test "$prj_cv_dpcp" -ne 0],
     [
     AC_LANG_PUSH([C++])
     AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <mellanox/dpcp.h>]],
          [[dpcp::tis* _tis;
-           dpcp::dek* _dek;
-           int key_type = (int)dpcp::DEK_ATTR_TLS;
+           dpcp::tls_dek* _dek;
            int tis_bit = (int)dpcp::TIS_ATTR_TLS;
            (void)_tis; (void)_dek;
-           (void)key_type; (void)tis_bit;]])],
-         [prj_cv_dpcp_1_1_3=1])
+           (void)tis_bit;]])],
+         [prj_cv_dpcp_1_1_44=1])
     AC_LANG_POP()
     ])
 
-AS_IF([test "$prj_cv_dpcp_1_1_3" -eq 0],
+AS_IF([test "$prj_cv_dpcp_1_1_44" -eq 0],
     [
     AS_IF([test "x$enable_utls" == xauto],
         [enable_utls=no])
     AS_IF([test "x$enable_utls" == xyes],
         [
         AC_MSG_CHECKING([for utls support])
-        AC_MSG_ERROR([utls requires dpcp 1.1.3 or later, see --with-dpcp])
+        AC_MSG_ERROR([utls requires dpcp 1.1.44 or later, see --with-dpcp])
         ])
     ])
 

--- a/src/core/dev/qp_mgr_eth_mlx5.h
+++ b/src/core/dev/qp_mgr_eth_mlx5.h
@@ -114,9 +114,9 @@ public:
     void post_dump_wqe(xlio_tis *tis, void *addr, uint32_t len, uint32_t lkey, bool first) override;
 
 #if defined(DEFINED_UTLS)
-    std::unique_ptr<dpcp::dek> get_new_dek(const void *key, uint32_t key_size_bytes);
-    std::unique_ptr<dpcp::dek> get_dek(const void *key, uint32_t key_size_bytes);
-    void put_dek(std::unique_ptr<dpcp::dek> &&dek_obj);
+    std::unique_ptr<dpcp::tls_dek> get_new_tls_dek(const void *key, uint32_t key_size_bytes);
+    std::unique_ptr<dpcp::tls_dek> get_tls_dek(const void *key, uint32_t key_size_bytes);
+    void put_tls_dek(std::unique_ptr<dpcp::tls_dek> &&dek_obj);
 #endif
 
     void reset_inflight_zc_buffers_ctx(void *ctx) override;
@@ -225,8 +225,8 @@ private:
     std::vector<xlio_tir *> m_tls_tir_cache;
 
 #if defined(DEFINED_UTLS)
-    std::list<std::unique_ptr<dpcp::dek>> m_dek_get_cache;
-    std::list<std::unique_ptr<dpcp::dek>> m_dek_put_cache;
+    std::list<std::unique_ptr<dpcp::tls_dek>> m_tls_dek_get_cache;
+    std::list<std::unique_ptr<dpcp::tls_dek>> m_tls_dek_put_cache;
 #endif
 };
 #endif // defined(DEFINED_DIRECT_VERBS)


### PR DESCRIPTION
RM: 3705189

DESC: DEK API was changed in dpcp version 1.1.44
      Need to update usage of dpcp::dek

