### PR TITLE
issue: 3664594 Return ETIMEDOUT err for timed out socket

### DIFF
--- a/src/core/lwip/tcp.c
+++ b/src/core/lwip/tcp.c
@@ -709,7 +709,7 @@ void tcp_slowtmr(struct tcp_pcb *pcb)
                                     pcb->remote_ip, pcb->is_ipv6);
 
                 ++pcb_remove;
-                err = ERR_ABRT;
+                err = ERR_TIMEOUT;
                 ++pcb_reset;
             }
 #if LWIP_TCP_KEEPALIVE

--- a/src/core/sock/sockinfo_tcp.cpp
+++ b/src/core/sock/sockinfo_tcp.cpp
@@ -2201,6 +2201,9 @@ int sockinfo_tcp::handle_rx_error(bool blocking)
             si_tcp_logdbg("RX on reseted socket");
             m_conn_state = TCP_CONN_FAILED;
             errno = ECONNRESET;
+        } else if (m_conn_state == TCP_CONN_TIMEOUT) {
+            si_tcp_logdbg("RX on timed out socket");
+            errno = ETIMEDOUT;
         } else {
             si_tcp_logdbg("RX on disconnected socket - EOF");
             ret = 0;


### PR DESCRIPTION
## Description
XLIO return 0 and errno 0 in case of Keep Alive timeout.
Kernel returns -1 and errno ETIMEOUT.

##### What
XLIO ignores lwip TIMEOUT error in sockinfo_tcp.
LWIP uses wrong err in case of keep-alive timeout (EABRT).

##### Why ?
API correctness

## Change type
What kind of change does this PR introduce?
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [X] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

