### PR TITLE
issue: 3704820 Fix strides in WQE for NGINX master

### DIFF
--- a/src/core/util/sys_vars.cpp
+++ b/src/core/util/sys_vars.cpp
@@ -691,8 +691,8 @@ void mce_sys_var::update_multi_process_params()
             tx_segs_pool_batch_tcp = 256;
             rx_num_wr = 1;
             strq_strides_compensation_level = 32;
-            strq_stride_size_bytes = 512;
-            strq_stride_num_per_rwqe = 32;
+            strq_stride_size_bytes = STRQ_MIN_STRIDE_SIZE_BYTES;
+            strq_stride_num_per_rwqe = STRQ_MIN_STRIDES_NUM;
             tx_buf_size = 0;
             rx_buf_size = 0;
         }


### PR DESCRIPTION
PRM allows minimum of 512 RX strides per WQE.
Adjust minimum value for NGINX master process from 32 to 512.
Using also minimum stride size allowed - 64 instead of 512.

## Change type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

