### PR TITLE
issue: 3514044 Fix null pointer dereference

### DIFF
--- a/src/core/dev/cq_mgr_rx.h
+++ b/src/core/dev/cq_mgr_rx.h
@@ -86,7 +86,7 @@ public:
     void configure(int cq_size);
 
     ibv_cq *get_ibv_cq_hndl() { return m_p_ibv_cq; }
-    int get_channel_fd() { return m_comp_event_channel->fd; }
+    int get_channel_fd() { return m_comp_event_channel ? m_comp_event_channel->fd : 0; }
 
     /**
      * Arm the managed CQ's notification channel


### PR DESCRIPTION
Accessing completion event channel for dummy RQ,
that was created automatically by ibv when we create QP.

## Change type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

