### PR TITLE
issue: 3786434 Remove C23 feature from public xlio_extra.h

### DIFF
--- a/src/core/sock/sockinfo_tcp.h
+++ b/src/core/sock/sockinfo_tcp.h
@@ -89,6 +89,14 @@ enum tcp_conn_state_e {
     TCP_CONN_RESETED
 };
 
+enum xlio_express_flags : uint32_t {
+    XLIO_EXPRESS_OP_TYPE_DESC,
+    XLIO_EXPRESS_OP_TYPE_FILE_ZEROCOPY,
+    XLIO_EXPRESS_OP_TYPE_MASK = 0x000fu,
+    XLIO_EXPRESS_MSG_MORE,
+    XLIO_EXPRESS_MSG_MASK = 0x00f0u,
+};
+
 struct socket_option_t {
     const int level;
     const int optname;

--- a/src/core/xlio_extra.h
+++ b/src/core/xlio_extra.h
@@ -640,12 +640,4 @@ static inline struct xlio_api_t *xlio_get_api()
     return api_ptr;
 }
 
-enum xlio_express_flags : uint32_t {
-    XLIO_EXPRESS_OP_TYPE_DESC,
-    XLIO_EXPRESS_OP_TYPE_FILE_ZEROCOPY,
-    XLIO_EXPRESS_OP_TYPE_MASK = 0x000fu,
-    XLIO_EXPRESS_MSG_MORE,
-    XLIO_EXPRESS_MSG_MASK = 0x00f0u,
-};
-
 #endif /* XLIO_EXTRA_H */


### PR DESCRIPTION
## Description
Enum with underlying type is C++ or C23 feature. Move the enum definition to an internal header, because currently, it's unused in public API.

##### What
Move C++/C23 enum from the public header to an internal.

##### Why ?
Fix compilation of some C programs which use extra API.

## Change type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

