### PR TITLE
issue: 3792731 Fix -Walloc-size-larger-than warning

### DIFF
--- a/src/core/dev/ib_ctx_handler.cpp
+++ b/src/core/dev/ib_ctx_handler.cpp
@@ -257,7 +257,7 @@ dpcp::adapter *ib_ctx_handler::set_dpcp_adapter()
         goto err;
     }
 
-    dpcp_lst = new (std::nothrow) dpcp::adapter_info[adapters_num];
+    dpcp_lst = new (std::nothrow) dpcp::adapter_info[static_cast<unsigned>(adapters_num)];
     if (!dpcp_lst) {
         ibch_logerr("failed allocating memory for devices");
         goto err;


### PR DESCRIPTION
## Description

The false positive warning is generated during linking phase. Cast array size to 32bit type to suppress the warning.

The warning appears in --enable-lto configuration likely due to inlined new[] operator and generated to the underlying malloc() call.

##### What
Fix false positive warning.

##### Why ?
Fix false positive warning.

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

