### PR TITLE
issue: HPCINFRA-1321 Switch cppcheck to a docker

### DIFF
--- a/.ci/dockerfiles/Dockerfile.rhel8.6
+++ b/.ci/dockerfiles/Dockerfile.rhel8.6
@@ -1,0 +1,26 @@
+FROM harbor.mellanox.com/hpcx/x86_64/rhel8.6/core:latest
+ARG _UID=6213
+ARG _GID=101
+ARG _LOGIN=swx-jenkins
+ARG _HOME=/var/home/$_LOGIN
+
+RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
+ && yum install -y cppcheck \
+ && yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm \
+ && yum install -y csbuild clang-tools-extra sudo curl autoconf automake make libtool \
+    libnl3-devel libnl3 rdma-core-devel rdma-core bc \
+ && yum clean all
+
+RUN pip3 install -U pip --no-cache-dir \
+ && pip3 install compiledb --no-cache-dir
+
+RUN echo "${_LOGIN} ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \
+    echo "root ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \
+    mkdir -p ${_HOME} && \
+    groupadd -f -g "$_GID" "$_LOGIN" && \
+    useradd -u "$_UID" -g "$_GID" -s /bin/bash -m -d ${_HOME} "${_LOGIN}" && \
+    chown -R ${_LOGIN} ${_HOME} && \
+    mkdir /build && chown -R ${_LOGIN} /build
+
+USER "$_LOGIN"
+ENTRYPOINT [ "/bin/bash", "--login", "--rcfile", "/etc/bashrc", "-c" ]

--- a/.ci/matrix_job.yaml
+++ b/.ci/matrix_job.yaml
@@ -61,6 +61,14 @@ runs_on_dockers:
      build_args: '--no-cache',
      category: 'tool'
      }
+  - {file: '.ci/dockerfiles/Dockerfile.rhel8.6',
+     arch: 'x86_64',
+     name: 'xlio_static.tidy',
+     uri: '$arch/$name',
+     tag: '20240703',
+     build_args: '--no-cache',
+     category: 'tool'
+     }
 
 runs_on_agents:
   - {nodeLabel: 'beni09', category: 'base'}
@@ -267,9 +275,9 @@ steps:
   - name: Tidy
     enable: ${do_tidy}
     containerSelector:
-      - "{name: 'skip-container'}"
+      - "{name: 'xlio_static.tidy', category: 'tool', variant: 1}"
     agentSelector:
-      - "{nodeLabel: 'beni09'}"
+      - "{nodeLabel: 'skip-agent'}"
     run: |
       [ "x${do_tidy}" == "xtrue" ] && action=yes || action=no
       env WORKSPACE=$PWD TARGET=${flags} jenkins_test_tidy=${action} ./contrib/test_jenkins.sh

--- a/.ci/matrix_job.yaml
+++ b/.ci/matrix_job.yaml
@@ -4,13 +4,14 @@ job: LIBXLIO
 step_allow_single_selector: false
 
 registry_host: harbor.mellanox.com
-registry_auth: swx-storage
+registry_auth: 1daaea28-800e-425f-a91f-3bd3e9136eea
+registry_path: /swx-infra/media
 
 kubernetes:
   privileged: false
   cloud: swx-k8s-spray
   nodeSelector: 'beta.kubernetes.io/os=linux'
-
+  namespace: xlio-ci
   limits: '{memory: 8Gi, cpu: 7000m}'
   requests: '{memory: 8Gi, cpu: 7000m}'
 
@@ -32,9 +33,6 @@ volumes:
   # User profile for release
   - {mountPath: /var/home/swx-jenkins, hostPath: /labhome/swx-jenkins}
 
-env:
-  build_dockers: false
-
 runs_on_dockers:
 # mofed
   - {name: 'ub20.04-mofed-x86_64', url: 'harbor.mellanox.com/swx-infra/x86_64/ubuntu20.04/builder:mofed-5.2-2.2.0.0', category: 'base', arch: 'x86_64'}
@@ -46,6 +44,15 @@ runs_on_dockers:
   - {name: 'toolbox', url: 'harbor.mellanox.com/hpcx/x86_64/rhel8.6/builder:inbox', category: 'tool', arch: 'x86_64'}
   - {name: 'blackduck', url: 'harbor.mellanox.com/toolbox/ngci-centos:7.9.2009.2', category: 'tool', arch: 'x86_64'}
   - {name: 'header-check', url: 'harbor.mellanox.com/toolbox/header_check:0.0.14', category: 'tool', arch: 'x86_64', tag: '0.0.14'}
+# static tests
+  - {file: '.ci/dockerfiles/Dockerfile.rhel8.6',
+     arch: 'x86_64',
+     name: 'xlio_static.cppcheck',
+     uri: '$arch/$name',
+     tag: '20240703',
+     build_args: '--no-cache',
+     category: 'tool'
+     }
 
 runs_on_agents:
   - {nodeLabel: 'beni09', category: 'base'}
@@ -218,9 +225,9 @@ steps:
   - name: Cppcheck
     enable: ${do_cppcheck}
     containerSelector:
-      - "{name: 'skip-container'}"
+      - "{name: 'xlio_static.cppcheck', category: 'tool', variant: 1}"
     agentSelector:
-      - "{nodeLabel: 'beni09'}"
+      - "{nodeLabel: 'skip-agent'}"
     run: |
       [ "x${do_cppcheck}" == "xtrue" ] && action=yes || action=no
       env WORKSPACE=$PWD TARGET=${flags} jenkins_test_cppcheck=${action} ./contrib/test_jenkins.sh

--- a/.ci/matrix_job.yaml
+++ b/.ci/matrix_job.yaml
@@ -53,6 +53,14 @@ runs_on_dockers:
      build_args: '--no-cache',
      category: 'tool'
      }
+  - {file: '.ci/dockerfiles/Dockerfile.rhel8.6',
+     arch: 'x86_64',
+     name: 'xlio_static.csbuild',
+     uri: '$arch/$name',
+     tag: '20240703',
+     build_args: '--no-cache',
+     category: 'tool'
+     }
 
 runs_on_agents:
   - {nodeLabel: 'beni09', category: 'base'}
@@ -242,9 +250,9 @@ steps:
   - name: Csbuild
     enable: ${do_csbuild}
     containerSelector:
-      - "{name: 'skip-container'}"
+      - "{name: 'xlio_static.csbuild', category: 'tool', variant: 1}"
     agentSelector:
-      - "{nodeLabel: 'beni09'}"
+      - "{nodeLabel: 'skip-agent'}"
     run: |
       [ "x${do_csbuild}" == "xtrue" ] && action=yes || action=no
       env WORKSPACE=$PWD TARGET=${flags} jenkins_test_csbuild=${action} ./contrib/test_jenkins.sh

--- a/contrib/jenkins_tests/cppcheck.sh
+++ b/contrib/jenkins_tests/cppcheck.sh
@@ -7,26 +7,10 @@ echo "Checking for cppcheck ..."
 tool_app=cppcheck
 
 # This unit requires cppcheck so check for existence
-if [ $(command -v ${tool_app} >/dev/null 2>&1 || echo $?) ]; then
-    set +e
-    eval "timeout -s SIGKILL 20s https://github.com/danmar/cppcheck.git cppcheck " > /dev/null 2>&1
-    if [ $? -eq 0 ]; then
-        eval "cd cppcheck && checkout 2.1 " > /dev/null 2>&1
-        if [ $? -eq 0 ]; then
-            eval "make $make_opt FILESDIR=$PWD HAVE_RULES=yes " > /dev/null 2>&1
-            if [ $? -eq 0 ]; then
-                tool_app=$PWD/cppcheck
-            fi
-        fi
-        cd ..
-    fi
-    set -e
-
     if [ $(command -v ${tool_app} >/dev/null 2>&1 || echo $?) ]; then
         echo "[SKIP] cppcheck tool does not exist"
         exit 1
     fi
-fi
 
 echo $(${tool_app} --version)
 

--- a/contrib/jenkins_tests/tidy.sh
+++ b/contrib/jenkins_tests/tidy.sh
@@ -13,6 +13,8 @@ source $(dirname $0)/globals.sh
 
 echo "Checking for tidy ..."
 
+git config --global --add safe.directory $WORKSPACE
+
 cd $WORKSPACE
 
 rm -rf $tidy_dir


### PR DESCRIPTION
## Description
We're going to move static tests from a dedicated server to docker containers to reduce CI timings 

##### What
Switch Cppcheck, Csbuild and Tidy steps of the CI to run in docker containers in a parallel mode

##### Why ?
CI currently takes too long, a majority of the time is consumed by static tests running on a physical machine

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [X] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

