### PR TITLE
issue: 3813802 Fix warnings from newer cppcheck

### DIFF
--- a/src/core/dev/time_converter_rtc.cpp
+++ b/src/core/dev/time_converter_rtc.cpp
@@ -58,7 +58,7 @@ void time_converter_rtc::handle_timer_expired(void *)
 void time_converter_rtc::convert_hw_time_to_system_time(uint64_t hwtime, struct timespec *systime)
 {
     hwtime &= 0x7FFFFFFFFFFFFFFF;
-    systime->tv_nsec = (uint32_t)(hwtime & ~(0x3 << 30));
+    systime->tv_nsec = (uint32_t)(hwtime & ~(0x3UL << 30));
     systime->tv_sec = (uint32_t)(hwtime >> 32);
 
     ibchtc_logfine("hwtime: 	%09ld", hwtime);

--- a/src/core/event/event_handler_manager.cpp
+++ b/src/core/event/event_handler_manager.cpp
@@ -313,7 +313,6 @@ void *event_handler_thread(void *_p_tgtObject)
         } else {
             evh_logdbg("Internal thread affinity not set.");
         }
-        /* cppcheck-suppress resourceLeak */
     }
 
     void *ret = p_tgtObject->thread_loop();
@@ -544,8 +543,6 @@ void event_handler_manager::priv_register_ibverbs_events(ibverbs_reg_info_t &inf
         v.ibverbs_ev.fd = info.fd;
         v.ibverbs_ev.channel = info.channel;
 
-        /* coverity[uninit_use_in_call] */
-        /* cppcheck-suppress uninitStructMember */
         m_event_handler_map[info.fd] = v;
         i = m_event_handler_map.find(info.fd);
 
@@ -633,8 +630,6 @@ void event_handler_manager::priv_register_rdma_cm_events(rdma_cm_reg_info_t &inf
         map_value.rdma_cm_ev.map_rdma_cm_id[info.id] = info.handler;
         map_value.rdma_cm_ev.cma_channel = info.cma_channel;
 
-        /* coverity[uninit_use_in_call] */
-        /* cppcheck-suppress uninitStructMember */
         m_event_handler_map[info.fd] = map_value;
 
         update_epfd(info.fd, EPOLL_CTL_ADD, EPOLLIN | EPOLLPRI);
@@ -708,8 +703,6 @@ void event_handler_manager::priv_register_command_events(command_reg_info_t &inf
         map_value.type = EV_COMMAND;
         map_value.command_ev.cmd = info.cmd;
 
-        /* coverity[uninit_use_in_call] */
-        /* cppcheck-suppress uninitStructMember */
         m_event_handler_map[info.fd] = map_value;
         update_epfd(info.fd, EPOLL_CTL_ADD, EPOLLIN | EPOLLPRI);
     }

--- a/src/core/event/event_handler_manager.cpp
+++ b/src/core/event/event_handler_manager.cpp
@@ -538,7 +538,7 @@ void event_handler_manager::priv_register_ibverbs_events(ibverbs_reg_info_t &inf
     event_handler_map_t::iterator i;
     i = m_event_handler_map.find(info.fd);
     if (i == m_event_handler_map.end()) {
-        event_data_t v;
+        event_data_t v = {};
 
         v.type = EV_IBVERBS;
         v.ibverbs_ev.fd = info.fd;
@@ -626,7 +626,7 @@ void event_handler_manager::priv_register_rdma_cm_events(rdma_cm_reg_info_t &inf
     event_handler_map_t::iterator iter_fd = m_event_handler_map.find(info.fd);
     if (iter_fd == m_event_handler_map.end()) {
         evh_logdbg("Adding new channel (fd %d, id %p, handler %p)", info.fd, info.id, info.handler);
-        event_data_t map_value;
+        event_data_t map_value = {};
 
         map_value.type = EV_RDMA_CM;
         map_value.rdma_cm_ev.n_ref_count = 1;
@@ -703,7 +703,7 @@ void event_handler_manager::priv_register_command_events(command_reg_info_t &inf
     event_handler_map_t::iterator iter_fd = m_event_handler_map.find(info.fd);
     if (iter_fd == m_event_handler_map.end()) {
         evh_logdbg("Adding new channel (fd %d)", info.fd);
-        event_data_t map_value;
+        event_data_t map_value = {};
 
         map_value.type = EV_COMMAND;
         map_value.command_ev.cmd = info.cmd;

--- a/src/core/event/netlink_event.cpp
+++ b/src/core/event/netlink_event.cpp
@@ -32,9 +32,10 @@
 
 #include "netlink_event.h"
 #include "vlogger/vlogger.h"
+
 #include <netlink/route/neighbour.h>
 #include <netlink/route/link.h>
-#include "stdio.h"
+#include <stdio.h>
 
 #define TOSTR_MAX_SIZE 4096
 

--- a/src/core/infra/DemoSubject.h
+++ b/src/core/infra/DemoSubject.h
@@ -48,7 +48,6 @@ public:
     const std::string to_str() const
     {
         char s[20];
-        /* cppcheck-suppress wrongPrintfScanfArgNum */
         snprintf(s, sizeof(s), "%d.%d.%d.%d", NIPQUAD(m_key));
         return (std::string(s));
     }

--- a/src/core/lwip/cc_cubic.c
+++ b/src/core/lwip/cc_cubic.c
@@ -81,7 +81,8 @@
  */
 
 #include "cc_cubic.h"
-#include "errno.h"
+
+#include <errno.h>
 #include <string.h>
 
 #if TCP_CC_ALGO_MOD

--- a/src/core/netlink/test_main.cpp
+++ b/src/core/netlink/test_main.cpp
@@ -30,12 +30,13 @@
  * SOFTWARE.
  */
 
+#include <errno.h>
+#include <stdio.h>
+#include <sys/epoll.h>
+
 #include "core/infra/subject_observer.h"
 #include "netlink_wrapper.h"
 #include "neigh_info.h"
-#include <stdio.h>
-#include "errno.h"
-#include <sys/epoll.h>
 #include "vlogger/vlogger.h"
 #include "core/event/netlink_event.h"
 

--- a/src/core/proto/dst_entry.cpp
+++ b/src/core/proto/dst_entry.cpp
@@ -154,7 +154,6 @@ void dst_entry::init_members()
     m_sge = NULL;
     m_b_is_offloaded = true;
     m_b_is_initialized = false;
-    m_p_send_wqe = NULL;
     m_max_inline = 0;
     m_max_ip_payload_size = 0;
     m_max_udp_payload_size = 0;

--- a/src/core/proto/dst_entry.h
+++ b/src/core/proto/dst_entry.h
@@ -167,7 +167,6 @@ protected:
     uint8_t m_pcp;
     bool m_b_is_initialized;
 
-    xlio_ibv_send_wr *m_p_send_wqe;
     uint32_t m_max_inline;
     ring_user_id_t m_id;
     uint16_t m_max_ip_payload_size;

--- a/src/core/proto/ip_frag.cpp
+++ b/src/core/proto/ip_frag.cpp
@@ -38,23 +38,17 @@
 #include "core/event/event_handler_manager.h"
 #include "mem_buf_desc.h"
 
+#undef MODULE_NAME
+#define MODULE_NAME "ip_frag"
+
 //#define IP_FRAG_DEBUG 1
 
 #ifdef IP_FRAG_DEBUG
-#define frag_dbg(fmt, args...)                                                                     \
-    vlog_printf(VLOG_WARNING, "%s:%d : " fmt "\n", __FUNCTION__, __LINE__, ##args)
+#define frag_dbg __log_info_dbg
 #else
 #define frag_dbg(fmt, args...)
 #endif
-
-#define frag_err(fmt, args...)                                                                     \
-    vlog_printf(VLOG_ERROR, "%s:%d : " fmt "\n", __FUNCTION__, __LINE__, ##args)
-
-#define frag_panic(fmt, args...)                                                                   \
-    do {                                                                                           \
-        vlog_printf(VLOG_PANIC, "%s:%d : " fmt "\n", __FUNCTION__, __LINE__, ##args);              \
-        throw;                                                                                     \
-    } while (0)
+#define frag_panic __log_info_panic
 
 #ifdef IP_FRAG_DEBUG
 static int debug_drop_every_n_pkt = 0; // 0 - Disabled, 1/N is the number of packet dropped

--- a/src/core/proto/ip_frag.cpp
+++ b/src/core/proto/ip_frag.cpp
@@ -58,9 +58,9 @@ static int g_ip_frag_count_check = 0;
 #define MEMBUF_DEBUG_REF_INC(__p_desc__)                                                           \
     {                                                                                              \
         g_ip_frag_count_check++;                                                                   \
-        if (__p_desc__->n_ref_count != 0)                                                          \
+        if (__p_desc__->inc_ref_count() != 0) {                                                    \
             frag_panic("REF_INC: p=%p\n", __p_desc__);                                             \
-        __p_desc__->n_ref_count++;                                                                 \
+        }                                                                                          \
     }
 #define MEMBUF_DEBUG_REF_DEC(__p_desc__)                                                           \
     {                                                                                              \
@@ -73,9 +73,9 @@ static int g_ip_frag_count_check = 0;
 #define MEMBUF_DEBUG_REF_DEC_1(__p_desc__)                                                         \
     {                                                                                              \
         g_ip_frag_count_check--;                                                                   \
-        __p_desc__->n_ref_count--;                                                                 \
-        if (__p_desc__->n_ref_count != 0)                                                          \
+        if (__p_desc__->dec_ref_count() != 1) {                                                    \
             frag_panic("REF_DEC: p=%p\n", __p_desc__);                                             \
+        }                                                                                          \
     }
 #define PRINT_STATISTICS()                                                                         \
     {                                                                                              \

--- a/src/core/sock/sockinfo_tcp.cpp
+++ b/src/core/sock/sockinfo_tcp.cpp
@@ -3471,7 +3471,6 @@ err_t sockinfo_tcp::clone_conn_cb(void *arg, struct tcp_pcb **newpcb)
     new_sock = conn->accept_clone();
 
     if (new_sock) {
-        /* cppcheck-suppress autoVariables */
         *newpcb = (struct tcp_pcb *)(&new_sock->m_pcb);
         new_sock->m_pcb.my_container = (void *)new_sock;
         /* XXX We have to search for correct listen socket every time,

--- a/src/stats/stats_printer.cpp
+++ b/src/stats/stats_printer.cpp
@@ -106,7 +106,6 @@ void print_full_stats(socket_stats_t *p_si_stats, mc_grp_info_t *p_mc_grp_info, 
     if (p_si_stats->socket_type == SOCK_DGRAM) {
         fprintf(filename, ", MC Loop %s", p_si_stats->b_mc_loop ? "Enabled " : "Disabled");
         if (!p_si_stats->mc_tx_if.is_anyaddr()) {
-            /* cppcheck-suppress wrongPrintfScanfArgNum */
             fprintf(filename, ", MC IF = [%s]",
                     p_si_stats->mc_tx_if.to_str(p_si_stats->sa_family).c_str());
         }
@@ -117,13 +116,11 @@ void print_full_stats(socket_stats_t *p_si_stats, mc_grp_info_t *p_mc_grp_info, 
     // Bounded + Connected information
     //
     if (!p_si_stats->bound_if.is_anyaddr() || p_si_stats->bound_port) {
-        /* cppcheck-suppress wrongPrintfScanfArgNum */
         fprintf(filename, "- Local Address   = [%s:%d]\n",
                 p_si_stats->bound_if.to_str(p_si_stats->sa_family).c_str(),
                 ntohs(p_si_stats->bound_port));
     }
     if (!p_si_stats->connected_ip.is_anyaddr() || p_si_stats->connected_port) {
-        /* cppcheck-suppress wrongPrintfScanfArgNum */
         fprintf(filename, "- Foreign Address = [%s:%d]\n",
                 p_si_stats->connected_ip.to_str(p_si_stats->sa_family).c_str(),
                 ntohs(p_si_stats->connected_port));
@@ -131,7 +128,6 @@ void print_full_stats(socket_stats_t *p_si_stats, mc_grp_info_t *p_mc_grp_info, 
     if (p_mc_grp_info) {
         for (int grp_idx = 0; grp_idx < p_mc_grp_info->max_grp_num; grp_idx++) {
             if (p_si_stats->mc_grp_map.test(grp_idx)) {
-                /* cppcheck-suppress wrongPrintfScanfArgNum */
                 fprintf(filename, "- Member of = [%s]\n",
                         p_mc_grp_info->mc_grp_tbl[grp_idx].mc_grp.to_str().c_str());
             }
@@ -345,7 +341,6 @@ void print_netstat_like(socket_stats_t *p_si_stats, mc_grp_info_t *, FILE *file,
     //
     int len = 0;
     if (!p_si_stats->bound_if.is_anyaddr() || p_si_stats->bound_port) {
-        /* cppcheck-suppress wrongPrintfScanfArgNum */
         len = fprintf(file, "%s:%-5d", p_si_stats->bound_if.to_str(p_si_stats->sa_family).c_str(),
                       ntohs(p_si_stats->bound_port));
 
@@ -360,7 +355,6 @@ void print_netstat_like(socket_stats_t *p_si_stats, mc_grp_info_t *, FILE *file,
     fprintf(file, " ");
 
     if (!p_si_stats->connected_ip.is_anyaddr() || p_si_stats->connected_port) {
-        /* cppcheck-suppress wrongPrintfScanfArgNum */
         len =
             fprintf(file, "%s:%-5d", p_si_stats->connected_ip.to_str(p_si_stats->sa_family).c_str(),
                     ntohs(p_si_stats->connected_port));

--- a/src/stats/stats_reader.cpp
+++ b/src/stats/stats_reader.cpp
@@ -1214,7 +1214,6 @@ void print_mc_group_fds(mc_group_fds_t *mc_group_fds, int array_size)
     printf("------------------------------\n");
     for (int i = 0; i < array_size; i++) {
         char mcg_str[256];
-        /* cppcheck-suppress wrongPrintfScanfArgNum */
         sprintf(mcg_str, "[%s]", mc_group_fds[i].mc_grp.to_str().c_str());
         printf("%-22s", mcg_str);
         for (const auto &fd : mc_group_fds[i].fd_list) {

--- a/src/vlogger/vlogger.h
+++ b/src/vlogger/vlogger.h
@@ -107,7 +107,7 @@
 #define __log_panic(log_fmt, log_args...)                                                          \
     do {                                                                                           \
         VLOG_PRINTF(VLOG_PANIC, log_fmt, ##log_args);                                              \
-        throw;                                                                                     \
+        std::terminate();                                                                          \
     } while (0)
 #define __log_err(log_fmt, log_args...)                                                            \
     do {                                                                                           \
@@ -165,7 +165,7 @@
 #define __log_info_panic(log_fmt, log_args...)                                                     \
     do {                                                                                           \
         VLOG_PRINTF_INFO(VLOG_PANIC, log_fmt, ##log_args);                                         \
-        throw;                                                                                     \
+        std::terminate();                                                                          \
     } while (0)
 #define __log_info_err(log_fmt, log_args...)                                                       \
     do {                                                                                           \


### PR DESCRIPTION
## Description
cppcheck-2.13 generates new warnings. Current PR fixes majority of them.

##### What
Fix cppcheck warnings

##### Why ?
Fix cppcheck warnings

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

