### PR TITLE
issue: Fix big endian build

### DIFF
--- a/src/core/dev/hw_queue_tx.cpp
+++ b/src/core/dev/hw_queue_tx.cpp
@@ -50,9 +50,6 @@
 #define hwqtx_logfunc    __log_info_func
 #define hwqtx_logfuncall __log_info_funcall
 
-//#define ALIGN_WR_UP(_num_wr_)  (max(32, ((_num_wr_ + 0xf) & ~(0xf))))
-#define ALIGN_WR_DOWN(_num_wr_) (max(32, ((_num_wr_) & ~(0xf))))
-
 #if !defined(MLX5_ETH_INLINE_HEADER_SIZE)
 #define MLX5_ETH_INLINE_HEADER_SIZE 18
 #endif
@@ -60,7 +57,7 @@
 #define OCTOWORD 16
 #define WQEBB    64
 
-//#define DBG_DUMP_WQE	1
+//#define DBG_DUMP_WQE 1
 
 #ifdef DBG_DUMP_WQE
 #define dbg_dump_wqe(_addr, _size)                                                                 \

--- a/src/core/event/delta_timer.cpp
+++ b/src/core/event/delta_timer.cpp
@@ -48,7 +48,7 @@
 #define tmr_loginfo  __log_info
 #define tmr_logdbg   __log_dbg
 #define tmr_logfunc  __log_func
-//#define tmr_logfuncall	__log_funcall
+//#define tmr_logfuncall __log_funcall
 #define tmr_logfuncall(fmt, ...)
 
 #define IS_NODE_INVALID(_node_)                                                                    \

--- a/src/core/lwip/def.h
+++ b/src/core/lwip/def.h
@@ -32,8 +32,6 @@
 #ifndef __LWIP_DEF_H__
 #define __LWIP_DEF_H__
 
-/* arch.h might define NULL already */
-
 #include "core/lwip/opt.h"
 
 #ifdef __cplusplus
@@ -47,65 +45,7 @@ extern "C" {
 #define NULL ((void *)0)
 #endif
 
-/** Get the absolute difference between 2 u32_t values (correcting overflows)
- * 'a' is expected to be 'higher' (without overflow) than 'b'. */
-#define LWIP_U32_DIFF(a, b) (((a) >= (b)) ? ((a) - (b)) : (((a) + ((b) ^ 0xFFFFFFFF) + 1)))
-
-/* Endianess-optimized shifting of two u8_t to create one u16_t */
-#if BYTE_ORDER == LITTLE_ENDIAN
-#define LWIP_MAKE_U16(a, b) ((a << 8) | b)
-#else
-#define LWIP_MAKE_U16(a, b) ((b << 8) | a)
-#endif
-
-#ifndef LWIP_PLATFORM_BYTESWAP
-#define LWIP_PLATFORM_BYTESWAP 0
-#endif
-
-#ifndef LWIP_PREFIX_BYTEORDER_FUNCS
-/* workaround for naming collisions on some platforms */
-
-#ifdef htons
-#undef htons
-#endif /* htons */
-#ifdef htonl
-#undef htonl
-#endif /* htonl */
-#ifdef ntohs
-#undef ntohs
-#endif /* ntohs */
-#ifdef ntohl
-#undef ntohl
-#endif /* ntohl */
-
-#define htons(x) lwip_htons(x)
-#define ntohs(x) lwip_ntohs(x)
-#define htonl(x) lwip_htonl(x)
-#define ntohl(x) lwip_ntohl(x)
-#endif /* LWIP_PREFIX_BYTEORDER_FUNCS */
-
-#if BYTE_ORDER == BIG_ENDIAN
-#define lwip_htons(x) (x)
-#define lwip_ntohs(x) (x)
-#define lwip_htonl(x) (x)
-#define lwip_ntohl(x) (x)
-#define PP_HTONS(x)   (x)
-#define PP_NTOHS(x)   (x)
-#define PP_HTONL(x)   (x)
-#define PP_NTOHL(x)   (x)
-#else /* BYTE_ORDER != BIG_ENDIAN */
-#if LWIP_PLATFORM_BYTESWAP
-#define lwip_htons(x) LWIP_PLATFORM_HTONS(x)
-#define lwip_ntohs(x) LWIP_PLATFORM_HTONS(x)
-#define lwip_htonl(x) LWIP_PLATFORM_HTONL(x)
-#define lwip_ntohl(x) LWIP_PLATFORM_HTONL(x)
-#else /* LWIP_PLATFORM_BYTESWAP */
-u16_t lwip_htons(u16_t x);
-u16_t lwip_ntohs(u16_t x);
-u32_t lwip_htonl(u32_t x);
-u32_t lwip_ntohl(u32_t x);
-#endif /* LWIP_PLATFORM_BYTESWAP */
-
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 /* These macros should be calculated by the preprocessor and are used
    with compile-time constants only (so that there is no little-endian
    overhead at runtime). */
@@ -115,8 +55,12 @@ u32_t lwip_ntohl(u32_t x);
     ((((x)&0xff) << 24) | (((x)&0xff00) << 8) | (((x)&0xff0000UL) >> 8) |                          \
      (((x)&0xff000000UL) >> 24))
 #define PP_NTOHL(x) PP_HTONL(x)
-
-#endif /* BYTE_ORDER == BIG_ENDIAN */
+#else /* __BYTE_ORDER__ */
+#define PP_HTONS(x) (x)
+#define PP_NTOHS(x) (x)
+#define PP_HTONL(x) (x)
+#define PP_NTOHL(x) (x)
+#endif /* __BYTE_ORDER__ */
 
 static inline u32_t read32_be(const void *addr)
 {

--- a/src/core/lwip/opt.h
+++ b/src/core/lwip/opt.h
@@ -93,27 +93,18 @@
 
 /* Misc */
 
-// replace lwip byte swapping to optimized one
-#include <byteswap.h>
-
-#define LWIP_PLATFORM_BYTESWAP 1
-#define LWIP_PLATFORM_HTONS(x) bswap_16(x)
-#define LWIP_PLATFORM_HTONL(x) bswap_32(x)
-
-// enable LWIP DEBUG here
-#if 1
-//#define PBUF_DEBUG				LWIP_DBG_ON
-//#define TCP_DEBUG 				LWIP_DBG_ON
-//#define TCP_INPUT_DEBUG			LWIP_DBG_ON
-//#define TCP_FR_DEBUG				LWIP_DBG_ON
-//#define TCP_RTO_DEBUG 			LWIP_DBG_ON
-//#define TCP_CWND_DEBUG			LWIP_DBG_ON
-//#define TCP_WND_DEBUG 			LWIP_DBG_ON
-//#define TCP_OUTPUT_DEBUG			LWIP_DBG_ON
-//#define TCP_RST_DEBUG 			LWIP_DBG_ON
-//#define TCP_QLEN_DEBUG			LWIP_DBG_ON
-//#define TCP_TSO_DEBUG				LWIP_DBG_ON
-#endif
+// Enable LWIP DEBUG here
+//#define PBUF_DEBUG       LWIP_DBG_ON
+//#define TCP_DEBUG        LWIP_DBG_ON
+//#define TCP_INPUT_DEBUG  LWIP_DBG_ON
+//#define TCP_FR_DEBUG     LWIP_DBG_ON
+//#define TCP_RTO_DEBUG    LWIP_DBG_ON
+//#define TCP_CWND_DEBUG   LWIP_DBG_ON
+//#define TCP_WND_DEBUG    LWIP_DBG_ON
+//#define TCP_OUTPUT_DEBUG LWIP_DBG_ON
+//#define TCP_RST_DEBUG    LWIP_DBG_ON
+//#define TCP_QLEN_DEBUG   LWIP_DBG_ON
+//#define TCP_TSO_DEBUG    LWIP_DBG_ON
 
 /*
    ---------------------------------
@@ -221,10 +212,10 @@
 #define LWIP_TCP_KEEPALIVE 0
 #endif
 
-/* Define platform endianness */
-#ifndef BYTE_ORDER
-#define BYTE_ORDER LITTLE_ENDIAN
-#endif /* BYTE_ORDER */
+/* Platform endianness */
+#if !defined(__BYTE_ORDER__) || !defined(__ORDER_LITTLE_ENDIAN__) || !defined(__ORDER_BIG_ENDIAN__)
+#error "__BYTE_ORDER__ or __ORDER_..._ENDIAN__ is not defined"
+#endif /* __BYTE_ORDER__ */
 
 /* Define generic types used in lwIP */
 typedef uint8_t u8_t;

--- a/src/core/lwip/tcp_out.c
+++ b/src/core/lwip/tcp_out.c
@@ -2406,7 +2406,7 @@ void tcp_zero_window_probe(struct tcp_pcb *pcb)
     }
 
     /* The byte may be acknowledged without the window being opened. */
-    snd_nxt = lwip_ntohl(seg->tcphdr->seqno) + 1;
+    snd_nxt = ntohl(seg->tcphdr->seqno) + 1;
     if (TCP_SEQ_LT(pcb->snd_nxt, snd_nxt)) {
         pcb->snd_nxt = snd_nxt;
     }

--- a/src/core/util/vtypes.h
+++ b/src/core/util/vtypes.h
@@ -41,6 +41,7 @@
 
 #include "utils/types.h"
 #include "utils/bullseye.h"
+
 #ifndef IN
 #define IN
 #endif
@@ -53,7 +54,11 @@
 #define INOUT
 #endif
 
-#if __BYTE_ORDER == __LITTLE_ENDIAN
+#if !defined(__BYTE_ORDER__) || !defined(__ORDER_LITTLE_ENDIAN__) || !defined(__ORDER_BIG_ENDIAN__)
+#error "__BYTE_ORDER__ or __ORDER_..._ENDIAN__ is not defined"
+#endif
+
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 static inline uint64_t htonll(uint64_t x)
 {
     return bswap_64(x);
@@ -62,7 +67,7 @@ static inline uint64_t ntohll(uint64_t x)
 {
     return bswap_64(x);
 }
-#elif __BYTE_ORDER == __BIG_ENDIAN
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 static inline uint64_t htonll(uint64_t x)
 {
     return x;
@@ -72,7 +77,7 @@ static inline uint64_t ntohll(uint64_t x)
     return x;
 }
 #else
-#error __BYTE_ORDER is neither __LITTLE_ENDIAN nor __BIG_ENDIAN
+#error __BYTE_ORDER__ is neither __ORDER_LITTLE_ENDIAN__ nor __ORDER_BIG_ENDIAN__
 #endif
 
 #define likely(x)   __builtin_expect(!!(x), 1)
@@ -96,7 +101,7 @@ static inline uint64_t ntohll(uint64_t x)
     (uint8_t)(((ip) >> 24) & 0xff), (uint8_t)(((ip) >> 16) & 0xff), (uint8_t)(((ip) >> 8) & 0xff), \
         (uint8_t)((ip)&0xff)
 
-#if __BYTE_ORDER == __LITTLE_ENDIAN
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 
 /* The host byte order is the same as network byte order, so these functions are all just identity.
  */
@@ -104,13 +109,11 @@ static inline uint64_t ntohll(uint64_t x)
 #define NIPQUAD(ip) NETWORK_IP_PRINTQUAD_LITTLE_ENDIAN(ip)
 #define HIPQUAD(ip) HOST_IP_PRINTQUAD_LITTLE_ENDIAN(ip)
 
-#else
-#if __BYTE_ORDER == __BIG_ENDIAN
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 
 #define NIPQUAD(ip) HOST_IP_PRINTQUAD_LITTLE_ENDIAN(ip)
 #define HIPQUAD(ip) NETWORK_IP_PRINTQUAD_LITTLE_ENDIAN(ip)
 
-#endif
 #endif
 
 #define ETH_HW_ADDR_PRINT_FMT "%02x:%02x:%02x:%02x:%02x:%02x"

--- a/src/stats/stats_reader.cpp
+++ b/src/stats/stats_reader.cpp
@@ -133,25 +133,6 @@ typedef enum { e_K = 1024, e_M = 1048576 } units_t;
 #define SEC_TO_MICRO(n)         ((n)*1000000)
 #define TIME_DIFF_in_MICRO(start, end)                                                             \
     (SEC_TO_MICRO((end).tv_sec - (start).tv_sec) + (NANO_TO_MICRO((end).tv_nsec - (start).tv_nsec)))
-// printf formating when IP is in network byte ordering (for LITTLE_ENDIAN)
-#define NETWORK_IP_PRINTQUAD_LITTLE_ENDIAN(ip)                                                     \
-    (uint8_t)((ip)&0xff), (uint8_t)(((ip) >> 8) & 0xff), (uint8_t)(((ip) >> 16) & 0xff),           \
-        (uint8_t)(((ip) >> 24) & 0xff)
-
-// printf formating when IP is in host byte ordering (for LITTLE_ENDIAN)
-#define HOST_IP_PRINTQUAD_LITTLE_ENDIAN(ip)                                                        \
-    (uint8_t)(((ip) >> 24) & 0xff), (uint8_t)(((ip) >> 16) & 0xff), (uint8_t)(((ip) >> 8) & 0xff), \
-        (uint8_t)((ip)&0xff)
-
-#if __BYTE_ORDER == __LITTLE_ENDIAN
-/* The host byte order is the same as network byte order, so these functions are all just identity.
- */
-#define NIPQUAD(ip) NETWORK_IP_PRINTQUAD_LITTLE_ENDIAN(ip)
-#else
-#if __BYTE_ORDER == __BIG_ENDIAN
-#define NIPQUAD(ip) HOST_IP_PRINTQUAD_LITTLE_ENDIAN(ip)
-#endif
-#endif
 
 bool g_b_exit = false;
 struct sigaction g_sigact;
@@ -1242,8 +1223,6 @@ void show_mc_group_stats(mc_grp_info_t *p_mc_grp_info, socket_instance_block_t *
             socket_stats_t *p_si_stats = &p_instance[i].skt_stats;
             for (int grp_idx = 0; grp_idx < p_mc_grp_info->max_grp_num; grp_idx++) {
                 if (p_si_stats->mc_grp_map.test(grp_idx)) {
-                    // printf("fd %d Member of = [%d.%d.%d.%d]\n",p_si_stats->fd,
-                    // NIPQUAD(p_si_stats->mc_grp[grp_idx]));
                     add_fd_to_array(p_si_stats->fd, p_mc_grp_info->mc_grp_tbl[grp_idx].mc_grp,
                                     mc_group_fds, &array_size);
                 }


### PR DESCRIPTION
## Description

Compiler defines `__BYTE_ORDER__` and others, but XLIO uses wrong names in the macros. Preprocessor replaces undefined names with 0, so XLIO always builds little endian branch.

Fix the byte order names and fail a build if `__BYTE_ORDER__` is not defined. Otherwise, the build would be broken on a big endian system.

##### What
Use correct names for the byte order macros.

##### Why ?
Fix build on a big endian system.

## Change type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

