### PR TITLE
issue: 3788369 Second drop of Storage / XLIO socket API

### DIFF
--- a/src/core/dev/allocator.cpp
+++ b/src/core/dev/allocator.cpp
@@ -66,6 +66,7 @@ xlio_allocator::xlio_allocator(alloc_t alloc_func, free_t free_func)
     m_type = static_cast<alloc_mode_t>(safe_mce_sys().mem_alloc_type);
     m_data = nullptr;
     m_size = 0;
+    m_page_size = 0;
     m_memalloc = alloc_func;
     m_memfree = free_func;
     if (m_memalloc) {
@@ -155,7 +156,7 @@ void *xlio_allocator::alloc_huge(size_t size)
     __log_info_dbg("Allocating %zu bytes in huge tlb using mmap", size);
 
     size_t actual_size = size;
-    m_data = g_hugepage_mgr.alloc_hugepages(actual_size);
+    m_data = g_hugepage_mgr.alloc_hugepages(actual_size, m_page_size);
     if (!m_data && g_hugepage_mgr.get_default_hugepage() && m_type == ALLOC_TYPE_HUGEPAGES) {
         // Print a warning message on allocation error if hugepages are supported
         // and this is not a fallback from a different allocation method.
@@ -505,7 +506,7 @@ bool xlio_heap::expand(size_t size /*=0*/)
     m_latest_offset = 0;
 
     if (m_b_hw && g_user_memory_cb) {
-        g_user_memory_cb(data, size, 0);
+        g_user_memory_cb(data, size, block->page_size());
     }
 
     return true;

--- a/src/core/dev/allocator.h
+++ b/src/core/dev/allocator.h
@@ -61,8 +61,9 @@ public:
 
     void dealloc();
 
-    inline size_t size() { return m_size; }
-    inline void *data() { return m_data; }
+    size_t size() { return m_size; }
+    size_t page_size() { return m_page_size; }
+    void *data() { return m_data; }
 
 private:
     void print_hugepages_warning(size_t requested_size);
@@ -71,6 +72,7 @@ protected:
     alloc_mode_t m_type;
     void *m_data;
     size_t m_size;
+    size_t m_page_size;
 
 private:
     alloc_t m_memalloc;

--- a/src/core/dev/ring.cpp
+++ b/src/core/dev/ring.cpp
@@ -50,9 +50,6 @@ ring::ring()
 
 ring::~ring()
 {
-    if (m_p_group) {
-        m_p_group->del_ring(this);
-    }
     if (m_tcp_seg_list) {
         g_tcp_seg_pool->put_objs(m_tcp_seg_list);
     }

--- a/src/core/dev/ring.h
+++ b/src/core/dev/ring.h
@@ -258,9 +258,6 @@ public:
     struct tcp_seg *get_tcp_segs(uint32_t num);
     void put_tcp_segs(struct tcp_seg *seg);
 
-    void set_group(poll_group *grp) { m_p_group = grp; }
-    poll_group *get_group() const { return m_p_group; }
-
     ring_ec *socketxtreme_get_ecs(uint32_t num);
     void socketxtreme_put_ecs(struct ring_ec *ec);
 
@@ -275,7 +272,6 @@ protected:
     inline void set_parent(ring *parent) { m_parent = (parent ? parent : this); }
     inline void set_if_index(int if_index) { m_if_index = if_index; }
 
-    poll_group *m_p_group = nullptr;
     int *m_p_n_rx_channel_fds = nullptr;
     ring *m_parent = nullptr;
 

--- a/src/core/dev/ring_simple.cpp
+++ b/src/core/dev/ring_simple.cpp
@@ -90,6 +90,13 @@ ring_simple::ring_simple(int if_index, ring *parent, ring_type_t type, bool use_
     , m_gro_mgr(safe_mce_sys().gro_streams_max, MAX_GRO_BUFS)
 {
     net_device_val *p_ndev = g_p_net_device_table_mgr->get_net_device_val(m_parent->get_if_index());
+    BULLSEYE_EXCLUDE_BLOCK_START
+    if (!p_ndev) {
+        // Coverity warning suppression
+        throw_xlio_exception("Cannot find netdev for a ring");
+    }
+    BULLSEYE_EXCLUDE_BLOCK_END
+
     const slave_data_t *p_slave = p_ndev->get_slave(get_if_index());
 
     ring_logdbg("new ring_simple()");
@@ -209,10 +216,18 @@ ring_simple::~ring_simple()
 void ring_simple::create_resources()
 {
     net_device_val *p_ndev = g_p_net_device_table_mgr->get_net_device_val(m_parent->get_if_index());
+    BULLSEYE_EXCLUDE_BLOCK_START
+    if (!p_ndev) {
+        // Coverity warning suppression
+        throw_xlio_exception("Cannot find netdev for a ring");
+    }
+    BULLSEYE_EXCLUDE_BLOCK_END
+
     const slave_data_t *p_slave = p_ndev->get_slave(get_if_index());
 
     save_l2_address(p_slave->p_L2_addr);
     m_p_tx_comp_event_channel = ibv_create_comp_channel(m_p_ib_ctx->get_ibv_context());
+    BULLSEYE_EXCLUDE_BLOCK_START
     if (!m_p_tx_comp_event_channel) {
         VLOG_PRINTF_INFO_ONCE_THEN_ALWAYS(
             VLOG_ERROR, VLOG_DEBUG,
@@ -319,9 +334,7 @@ void ring_simple::create_resources()
 #endif
     ring_logdbg("ring attributes: m_flow_tag_enabled = %d", m_flow_tag_enabled);
 
-    m_p_rx_comp_event_channel = ibv_create_comp_channel(
-        m_p_ib_ctx->get_ibv_context()); // ODED TODO: Adjust the ibv_context to be the exact one in
-                                        // case of different devices
+    m_p_rx_comp_event_channel = ibv_create_comp_channel(m_p_ib_ctx->get_ibv_context());
     BULLSEYE_EXCLUDE_BLOCK_START
     if (!m_p_rx_comp_event_channel) {
         VLOG_PRINTF_INFO_ONCE_THEN_ALWAYS(

--- a/src/core/event/poll_group.cpp
+++ b/src/core/event/poll_group.cpp
@@ -182,7 +182,15 @@ void poll_group::close_socket(sockinfo_tcp *si, bool force /*=false*/)
 
     bool closed = si->prepare_to_close(force);
     if (closed) {
+        /*
+         * Current implementation forces TCP reset, so the socket is expected to be closable.
+         * Do a polling iteration to increase the chance that all the relevant WQEs are completed
+         * and XLIO emitted all the TX completion before the XLIO_SOCKET_EVENT_TERMINATED event.
+         *
+         * TODO Implement more reliable mechanism of deferred socket destruction if there are
+         * not completed TX operations.
+         */
+        poll();
         si->clean_socket_obj();
     }
-    // TODO If not closed, the socket will be destroyed after the last completion notification.
 }

--- a/src/core/event/poll_group.h
+++ b/src/core/event/poll_group.h
@@ -41,10 +41,11 @@
 
 /* Forward declarations */
 struct xlio_poll_group_attr;
-class ring;
 class event_handler_manager_local;
-class tcp_timers_collection;
+class ring;
+class ring_alloc_logic_attr;
 class sockinfo_tcp;
+class tcp_timers_collection;
 
 class poll_group {
 public:
@@ -57,8 +58,7 @@ public:
     void add_dirty_socket(sockinfo_tcp *si);
     void flush();
 
-    void add_ring(ring *);
-    void del_ring(ring *);
+    void add_ring(ring *rng, ring_alloc_logic_attr *attr);
 
     void add_socket(sockinfo_tcp *si);
     void close_socket(sockinfo_tcp *si, bool force = false);

--- a/src/core/event/poll_group.h
+++ b/src/core/event/poll_group.h
@@ -81,6 +81,7 @@ private:
     std::vector<sockinfo_tcp *> m_dirty_sockets;
 
     sock_fd_api_list_t m_sockets_list;
+    std::vector<std::pair<std::unique_ptr<ring_alloc_logic_attr>, net_device_val *>> m_rings_ref;
 };
 
 #endif /* XLIO_GROUP_H */

--- a/src/core/event/poll_group.h
+++ b/src/core/event/poll_group.h
@@ -36,6 +36,7 @@
 #include <memory>
 #include <vector>
 
+#include "sock/fd_collection.h"
 #include "xlio.h"
 
 /* Forward declarations */
@@ -59,6 +60,9 @@ public:
     void add_ring(ring *);
     void del_ring(ring *);
 
+    void add_socket(sockinfo_tcp *si);
+    void close_socket(sockinfo_tcp *si, bool force = false);
+
     unsigned get_flags() const { return m_group_flags; }
     event_handler_manager_local *get_event_handler() const { return m_event_handler.get(); }
     tcp_timers_collection *get_tcp_timers() const { return m_tcp_timers.get(); }
@@ -73,9 +77,10 @@ private:
     std::unique_ptr<event_handler_manager_local> m_event_handler;
     std::unique_ptr<tcp_timers_collection> m_tcp_timers;
 
+    unsigned m_group_flags;
     std::vector<sockinfo_tcp *> m_dirty_sockets;
 
-    unsigned m_group_flags;
+    sock_fd_api_list_t m_sockets_list;
 };
 
 #endif /* XLIO_GROUP_H */

--- a/src/core/event/poll_group.h
+++ b/src/core/event/poll_group.h
@@ -49,6 +49,7 @@ class poll_group {
 public:
     poll_group(const struct xlio_poll_group_attr *attr);
     ~poll_group();
+    static void destroy_all_groups();
 
     void poll();
 

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -52,6 +52,7 @@
 #include "util/xlio_stats.h"
 #include "util/utils.h"
 #include "event/event_handler_manager.h"
+#include "event/poll_group.h"
 #include "event/vlogger_timer_handler.h"
 #include "dev/buffer_pool.h"
 #include "dev/ib_ctx_handler_collection.h"
@@ -144,6 +145,8 @@ static int free_libxlio_resources()
     if (g_p_fd_collection_temp) {
         delete g_p_fd_collection_temp;
     }
+
+    poll_group::destroy_all_groups();
 
     if (g_p_lwip) {
         delete g_p_lwip;

--- a/src/core/sock/sock-extra.cpp
+++ b/src/core/sock/sock-extra.cpp
@@ -523,7 +523,7 @@ extern "C" int xlio_socket_connect(xlio_socket_t sock, const struct sockaddr *to
     sockinfo_tcp *si = reinterpret_cast<sockinfo_tcp *>(sock);
     int errno_save = errno;
 
-    int rc = XLIO_CALL(connect, si->get_fd(), to, tolen);
+    int rc = si->connect(to, tolen);
     rc = (rc == -1 && (errno == EINPROGRESS || errno == EAGAIN)) ? 0 : rc;
     if (rc == 0) {
         si->add_tx_ring_to_group();

--- a/src/core/sock/sock-extra.cpp
+++ b/src/core/sock/sock-extra.cpp
@@ -549,7 +549,11 @@ static void xlio_buf_free(struct xlio_buf *buf)
     mem_buf_desc_t *desc = reinterpret_cast<mem_buf_desc_t *>(buf);
     ring_slave *rng = desc->p_desc_owner;
 
-    (void)rng->reclaim_recv_single_buffer(desc);
+    desc->p_next_desc = nullptr;
+    bool ret = rng->reclaim_recv_buffers(desc);
+    if (unlikely(!ret)) {
+        g_buffer_pool_rx_ptr->put_buffer_after_deref_thread_safe(desc);
+    }
 }
 
 extern "C" void xlio_socket_buf_free(xlio_socket_t sock, struct xlio_buf *buf)

--- a/src/core/sock/sock-extra.cpp
+++ b/src/core/sock/sock-extra.cpp
@@ -507,15 +507,25 @@ extern "C" int xlio_socket_setsockopt(xlio_socket_t sock, int level, int optname
                                       const void *optval, socklen_t optlen)
 {
     sockinfo_tcp *si = reinterpret_cast<sockinfo_tcp *>(sock);
+    int errno_save = errno;
 
-    return XLIO_CALL(setsockopt, si->get_fd(), level, optname, optval, optlen);
+    int rc = si->setsockopt(level, optname, optval, optlen);
+    if (rc == 0) {
+        errno = errno_save;
+    }
+    return rc;
 }
 
 extern "C" int xlio_socket_bind(xlio_socket_t sock, const struct sockaddr *addr, socklen_t addrlen)
 {
     sockinfo_tcp *si = reinterpret_cast<sockinfo_tcp *>(sock);
+    int errno_save = errno;
 
-    return XLIO_CALL(bind, si->get_fd(), addr, addrlen);
+    int rc = si->bind(addr, addrlen);
+    if (rc == 0) {
+        errno = errno_save;
+    }
+    return rc;
 }
 
 extern "C" int xlio_socket_connect(xlio_socket_t sock, const struct sockaddr *to, socklen_t tolen)
@@ -538,12 +548,6 @@ extern "C" struct ibv_pd *xlio_socket_get_pd(xlio_socket_t sock)
     ib_ctx_handler *ctx = si->get_ctx();
 
     return ctx ? ctx->get_ibv_pd() : nullptr;
-}
-
-extern "C" int xlio_socket_fd(xlio_socket_t sock)
-{
-    sockinfo_tcp *si = reinterpret_cast<sockinfo_tcp *>(sock);
-    return si->get_fd();
 }
 
 static void xlio_buf_free(struct xlio_buf *buf)

--- a/src/core/sock/sock-extra.cpp
+++ b/src/core/sock/sock-extra.cpp
@@ -406,6 +406,9 @@ extern "C" int xlio_init_ex(const struct xlio_init_attr *attr)
         setenv(SYS_VAR_PROGRESS_ENGINE_INTERVAL, "0", 1);
     }
 
+    // Read the updated parameters. A global object could trigger the reading earlier.
+    safe_mce_sys().get_env_params();
+
     xlio_init();
 
     extern xlio_memory_cb_t g_user_memory_cb;

--- a/src/core/sock/sockinfo_tcp.cpp
+++ b/src/core/sock/sockinfo_tcp.cpp
@@ -397,7 +397,7 @@ sockinfo_tcp::sockinfo_tcp(int fd, int domain)
 void sockinfo_tcp::rx_add_ring_cb(ring *p_ring)
 {
     if (m_p_group) {
-        m_p_group->add_ring(p_ring);
+        m_p_group->add_ring(p_ring, &m_ring_alloc_log_rx);
     }
     sockinfo::rx_add_ring_cb(p_ring);
 }
@@ -433,7 +433,7 @@ void sockinfo_tcp::add_tx_ring_to_group()
 {
     ring *rng = get_tx_ring();
     if (m_p_group && rng) {
-        m_p_group->add_ring(rng);
+        m_p_group->add_ring(rng, &m_ring_alloc_log_tx);
     }
 }
 

--- a/src/core/sock/sockinfo_tcp.cpp
+++ b/src/core/sock/sockinfo_tcp.cpp
@@ -476,8 +476,9 @@ err_t sockinfo_tcp::rx_lwip_cb_xlio_socket(void *arg, struct tcp_pcb *pcb, struc
                                             reinterpret_cast<struct xlio_buf *>(ptmp));
             ptmp = ptmp->next;
         }
+    } else {
+        pbuf_free(p);
     }
-    pbuf_free(p);
 
     // TODO Stats
 

--- a/src/core/sock/sockinfo_tcp.h
+++ b/src/core/sock/sockinfo_tcp.h
@@ -408,6 +408,7 @@ public:
     void set_xlio_socket(const struct xlio_socket_attr *attr);
     void add_tx_ring_to_group();
     bool is_xlio_socket() { return m_p_group != nullptr; }
+    poll_group *get_poll_group() { return m_p_group; }
     void xlio_socket_event(int event, int value);
     static err_t rx_lwip_cb_xlio_socket(void *arg, struct tcp_pcb *tpcb, struct pbuf *p, err_t err);
     static void err_lwip_cb_xlio_socket(void *pcb_container, err_t err);

--- a/src/core/util/hugepage_mgr.cpp
+++ b/src/core/util/hugepage_mgr.cpp
@@ -118,7 +118,7 @@ void *hugepage_mgr::alloc_hugepages_helper(size_t &size, size_t hugepage)
     return ptr;
 }
 
-void *hugepage_mgr::alloc_hugepages(size_t &size)
+void *hugepage_mgr::alloc_hugepages(size_t &size, size_t &hugepage_size)
 {
     std::lock_guard<decltype(m_lock)> lock(m_lock);
 
@@ -149,6 +149,7 @@ void *hugepage_mgr::alloc_hugepages(size_t &size)
     }
     if (ptr) {
         size = actual_size;
+        hugepage_size = hugepage;
     }
 
     // Statistics

--- a/src/core/util/hugepage_mgr.h
+++ b/src/core/util/hugepage_mgr.h
@@ -66,7 +66,7 @@ public:
     size_t get_default_hugepage() { return m_default_hugepage; }
     bool is_hugepage_supported(size_t hugepage);
 
-    void *alloc_hugepages(size_t &size);
+    void *alloc_hugepages(size_t &size, size_t &hugepage_size);
     void dealloc_hugepages(void *ptr, size_t size);
 
     void print_report(bool short_report = false);

--- a/src/core/xlio.h
+++ b/src/core/xlio.h
@@ -488,12 +488,6 @@ void xlio_socket_flush(xlio_socket_t sock);
 void xlio_socket_buf_free(xlio_socket_t sock, struct xlio_buf *buf);
 void xlio_poll_group_buf_free(xlio_poll_group_t group, struct xlio_buf *buf);
 
-/*
- * Experimental level API.
- */
-
-int xlio_socket_fd(xlio_socket_t sock);
-
 #ifdef __cplusplus
 }
 #endif

--- a/tests/extra_api/xlio_socket_api.c
+++ b/tests/extra_api/xlio_socket_api.c
@@ -233,38 +233,7 @@ static void test_multi_groups(const char *ip)
     rc = xlio_socket_connect(sock3, (struct sockaddr *)&addr, sizeof(addr));
     assert(rc == 0);
 
-    int fd1_1 = xlio_socket_fd(sock1_1);
-    int fd1_2 = xlio_socket_fd(sock1_2);
-    int fd2 = xlio_socket_fd(sock2);
-    int fd3 = xlio_socket_fd(sock3);
-    assert(fd1_1 >= 0);
-    assert(fd1_2 >= 0);
-    assert(fd2 >= 0);
-    assert(fd3 >= 0);
-
-    assert(xlio_get_socket_rings_num(fd1_1) == 1);
-    assert(xlio_get_socket_rings_num(fd1_2) == 1);
-    assert(xlio_get_socket_rings_num(fd2) == 1);
-    assert(xlio_get_socket_rings_num(fd3) == 1);
-
-    int ring1_1;
-    int ring1_2;
-    int ring2;
-    int ring3;
-
-    rc = xlio_get_socket_rings_fds(fd1_1, &ring1_1, 1);
-    assert(rc == 1);
-    rc = xlio_get_socket_rings_fds(fd1_2, &ring1_2, 1);
-    assert(rc == 1);
-    rc = xlio_get_socket_rings_fds(fd2, &ring2, 1);
-    assert(rc == 1);
-    rc = xlio_get_socket_rings_fds(fd3, &ring3, 1);
-    assert(rc == 1);
-
-    assert(ring1_1 == ring1_2);
-    assert(ring1_1 != ring2);
-    assert(ring1_1 != ring3);
-    assert(ring2 != ring3);
+    /* TODO There is no API to check expected internal ring distribution. */
 
     /* Wait for ERROR events (ECONREFUSED). */
     while (g_test_events < 4) {


### PR DESCRIPTION
## Description
XLIO socket API is a performance oriented API.

Note, rebased on top of #115
Begins at `issue: 3788369 Remove m_required_send_block introduced by NVME offload`

##### What
Productization of the 1st drop.

##### Why ?
Productization of the 1st drop.

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

