### PR TITLE
issue: 3777348 Improvements for TCP flow unnecessary cache access.

### DIFF
--- a/src/core/dev/ring_slave.cpp
+++ b/src/core/dev/ring_slave.cpp
@@ -600,7 +600,7 @@ bool ring_slave::rx_process_buffer(mem_buf_desc_t *p_rx_wc_buf_desc, void *pv_fd
         si = static_cast<sockinfo *>(
             g_p_fd_collection->get_sockfd(p_rx_wc_buf_desc->rx.flow_tag_id - 1));
 
-        if (likely((si) && si->flow_tag_enabled())) {
+        if (likely(si)) {
             // will process packets with set flow_tag_id and enabled for the socket
             if (p_eth_h->h_proto == NET_ETH_P_8021Q) {
                 // Handle VLAN header as next protocol

--- a/src/core/dev/ring_slave.cpp
+++ b/src/core/dev/ring_slave.cpp
@@ -47,11 +47,13 @@
 // AF_INET address 0.0.0.0:0, used for 3T flow spec keys.
 static const sock_addr s_sock_addrany;
 
+static thread_local lock_dummy t_lock_dummy_ring;
+
 static lock_base *get_new_lock(const char *name, bool real_lock)
 {
     return (real_lock
                 ? static_cast<lock_base *>(multilock::create_new_lock(MULTILOCK_RECURSIVE, name))
-                : static_cast<lock_base *>(new lock_dummy()));
+                : static_cast<lock_base *>(&t_lock_dummy_ring));
 }
 
 ring_slave::ring_slave(int if_index, ring *parent, ring_type_t type, bool use_locks)

--- a/src/core/dev/ring_slave.cpp
+++ b/src/core/dev/ring_slave.cpp
@@ -646,10 +646,6 @@ bool ring_slave::rx_process_buffer(mem_buf_desc_t *p_rx_wc_buf_desc, void *pv_fd
             if (likely(protocol == IPPROTO_TCP)) {
                 struct tcphdr *p_tcp_h = (struct tcphdr *)((uint8_t *)p_ip_h + ip_hdr_len);
 
-                // Update the L3 and L4 info
-                p_rx_wc_buf_desc->rx.src.set_ip_port(family, saddr, p_tcp_h->source);
-                p_rx_wc_buf_desc->rx.dst.set_ip_port(family, daddr, p_tcp_h->dest);
-
                 // Update packet descriptor with datagram base address and length
                 p_rx_wc_buf_desc->rx.frag.iov_base = (uint8_t *)p_tcp_h + sizeof(struct tcphdr);
                 p_rx_wc_buf_desc->rx.frag.iov_len = ip_payload_len - sizeof(struct tcphdr);

--- a/src/core/sock/sockinfo.cpp
+++ b/src/core/sock/sockinfo.cpp
@@ -84,8 +84,6 @@ const char *sockinfo::setsockopt_so_opt_to_str(int opt)
         return "SO_XLIO_RING_ALLOC_LOGIC";
     case SO_MAX_PACING_RATE:
         return "SO_MAX_PACING_RATE";
-    case SO_XLIO_FLOW_TAG:
-        return "SO_XLIO_FLOW_TAG";
     case SO_XLIO_SHUTDOWN_RX:
         return "SO_XLIO_SHUTDOWN_RX";
     case IPV6_V6ONLY:
@@ -442,34 +440,6 @@ int sockinfo::setsockopt(int __level, int __optname, const void *__optval, sockl
                 errno = EINVAL;
             }
             break;
-        case SO_XLIO_FLOW_TAG:
-            if (__optval) {
-                if (__optlen == sizeof(uint32_t)) {
-                    if (set_flow_tag(*(uint32_t *)__optval)) {
-                        si_logdbg("SO_XLIO_FLOW_TAG, set "
-                                  "socket fd: %d to flow id: %d",
-                                  m_fd, m_flow_tag_id);
-                        // not supported in OS
-                        ret = SOCKOPT_INTERNAL_XLIO_SUPPORT;
-                    } else {
-                        ret = SOCKOPT_NO_XLIO_SUPPORT;
-                        errno = EINVAL;
-                    }
-                } else {
-                    ret = SOCKOPT_NO_XLIO_SUPPORT;
-                    errno = EINVAL;
-                    si_logdbg("SO_XLIO_FLOW_TAG, bad length "
-                              "expected %zu got %d",
-                              sizeof(uint32_t), __optlen);
-                    break;
-                }
-            } else {
-                ret = SOCKOPT_NO_XLIO_SUPPORT;
-                errno = EINVAL;
-                si_logdbg("SO_XLIO_FLOW_TAG - NOT HANDLED, "
-                          "optval == NULL");
-            }
-            break;
 
         case SO_REUSEADDR:
             if (__optval && __optlen == sizeof(int)) {
@@ -751,14 +721,6 @@ int sockinfo::getsockopt(int __level, int __optname, void *__optval, socklen_t *
         case SO_XLIO_USER_DATA:
             if (*__optlen == sizeof(m_fd_context)) {
                 *(void **)__optval = m_fd_context;
-                ret = 0;
-            } else {
-                errno = EINVAL;
-            }
-            break;
-        case SO_XLIO_FLOW_TAG:
-            if (*__optlen >= sizeof(uint32_t)) {
-                *(uint32_t *)__optval = m_flow_tag_id;
                 ret = 0;
             } else {
                 errno = EINVAL;

--- a/src/core/sock/sockinfo.h
+++ b/src/core/sock/sockinfo.h
@@ -335,7 +335,6 @@ public:
     sa_family_t get_family() { return m_family; }
     bool get_reuseaddr(void) { return m_reuseaddr; }
     bool get_reuseport(void) { return m_reuseport; }
-    bool flow_tag_enabled(void) { return m_flow_tag_enabled; }
     int get_rx_epfd(void) { return m_rx_epfd; }
     bool is_blocking(void) { return m_b_blocking; }
     bool flow_in_reuse(void) { return m_reuseaddr | m_reuseport; }
@@ -476,7 +475,6 @@ protected:
     sockinfo_state m_state = SOCKINFO_OPENED; // socket current state
     uint8_t m_n_tsing_flags = 0U;
     bool m_has_stats = false;
-    bool m_flow_tag_enabled = false; // for this socket
     bool m_b_rcvtstamp = false;
     bool m_b_zc = false;
     bool m_b_blocking = true;
@@ -594,7 +592,6 @@ bool sockinfo::set_flow_tag(uint32_t flow_tag_id)
 {
     if (flow_tag_id && (flow_tag_id != FLOW_TAG_MASK)) {
         m_flow_tag_id = flow_tag_id;
-        m_flow_tag_enabled = true;
         return true;
     }
     m_flow_tag_id = FLOW_TAG_MASK;

--- a/src/core/sock/sockinfo.h
+++ b/src/core/sock/sockinfo.h
@@ -499,7 +499,6 @@ protected:
 
     // End of second cache line
 
-    wakeup_pipe m_sock_wakeup_pipe;
     rfs *m_rfs_ptr = nullptr;
     struct {
         /* Use std::deque in current design as far as it allows pushing
@@ -509,6 +508,8 @@ protected:
         struct ring_ec *ec;
         std::deque<struct ring_ec> ec_cache;
     } m_socketxtreme;
+
+    wakeup_pipe m_sock_wakeup_pipe;
 
     // End of fourth cache line
 public:

--- a/src/core/sock/sockinfo_tcp.cpp
+++ b/src/core/sock/sockinfo_tcp.cpp
@@ -2191,8 +2191,6 @@ err_t sockinfo_tcp::rx_lwip_cb_socketxtreme(void *arg, struct tcp_pcb *pcb, stru
     conn->rx_lwip_process_chained_pbufs(p);
     conn->rx_lwip_cb_socketxtreme_helper(p);
 
-    io_mux_call::update_fd_array(conn->m_iomux_ready_fd_array, conn->m_fd);
-
     /*
      * RCVBUFF Accounting: tcp_recved here(stream into the 'internal' buffer) only if the user
      * buffer is not 'filled'

--- a/src/core/sock/sockinfo_tcp.cpp
+++ b/src/core/sock/sockinfo_tcp.cpp
@@ -262,10 +262,10 @@ inline void sockinfo_tcp::reuse_buffer(mem_buf_desc_t *buff)
     if (likely(m_p_rx_ring)) {
         m_rx_reuse_buff.n_buff_num += buff->rx.n_frags;
         m_rx_reuse_buff.rx_reuse.push_back(buff);
-        if (m_rx_reuse_buff.n_buff_num < m_n_sysvar_rx_num_buffs_reuse) {
+        if (m_rx_reuse_buff.n_buff_num < m_rx_num_buffs_reuse) {
             return;
         }
-        if (m_rx_reuse_buff.n_buff_num >= 2 * m_n_sysvar_rx_num_buffs_reuse) {
+        if (m_rx_reuse_buff.n_buff_num >= 2 * m_rx_num_buffs_reuse) {
             if (m_p_rx_ring->reclaim_recv_buffers(&m_rx_reuse_buff.rx_reuse)) {
                 m_rx_reuse_buff.n_buff_num = 0;
             } else {
@@ -3118,7 +3118,7 @@ int sockinfo_tcp::accept_helper(struct sockaddr *__addr, socklen_t *__addrlen,
 {
     sockinfo_tcp *ns;
     // todo do one CQ poll and go to sleep even if infinite polling was set
-    int poll_count = m_n_sysvar_rx_poll_num; // do one poll and go to sleep (if blocking)
+    int poll_count = safe_mce_sys().rx_poll_num; // do one poll and go to sleep (if blocking)
     int ret;
 
     si_tcp_logfuncall("");
@@ -5172,7 +5172,7 @@ int sockinfo_tcp::rx_wait_helper(int &poll_count, bool blocking)
         return -1;
     }
 
-    if (poll_count < m_n_sysvar_rx_poll_num || m_n_sysvar_rx_poll_num == -1) {
+    if (poll_count < safe_mce_sys().rx_poll_num || safe_mce_sys().rx_poll_num == -1) {
         return 0;
     }
 

--- a/src/core/sock/sockinfo_tcp.cpp
+++ b/src/core/sock/sockinfo_tcp.cpp
@@ -2113,7 +2113,15 @@ inline void sockinfo_tcp::rx_lwip_process_chained_pbufs(pbuf *p)
         p_curr_desc->rx.frag.iov_base = p->payload;
         p_curr_desc->rx.frag.iov_len = p->len;
         p_curr_desc->p_next_desc = reinterpret_cast<mem_buf_desc_t *>(p->next);
-        process_timestamps(p_curr_desc);
+    }
+
+    // To avoid redundant checking for every packet a seperate loop runs
+    // only in case timestamps are needed.
+    if (m_b_rcvtstamp || m_n_tsing_flags) {
+        for (auto *p_curr_desc = p_first_desc; p_curr_desc;
+             p_curr_desc = p_curr_desc->p_next_desc) {
+            process_timestamps(p_curr_desc);
+        }
     }
 
     p_first_desc->set_ref_count(head_ref);

--- a/src/core/sock/sockinfo_tcp.cpp
+++ b/src/core/sock/sockinfo_tcp.cpp
@@ -84,6 +84,7 @@ extern global_stats_t g_global_stat_static;
 tcp_timers_collection *g_tcp_timers_collection = nullptr;
 thread_local thread_local_tcp_timers g_thread_local_tcp_timers;
 bind_no_port *g_bind_no_port = nullptr;
+static thread_local lock_dummy t_lock_dummy_socket;
 
 /*
  * The following socket options are inherited by a connected TCP socket from the listening socket:
@@ -163,7 +164,7 @@ static lock_base *get_new_tcp_lock()
     return (
         safe_mce_sys().tcp_ctl_thread != option_tcp_ctl_thread::CTL_THREAD_DELEGATE_TCP_TIMERS
             ? static_cast<lock_base *>(multilock::create_new_lock(MULTILOCK_RECURSIVE, "tcp_con"))
-            : static_cast<lock_base *>(new lock_dummy));
+            : static_cast<lock_base *>(&t_lock_dummy_socket));
 }
 
 inline void sockinfo_tcp::lwip_pbuf_init_custom(mem_buf_desc_t *p_desc)

--- a/src/core/sock/sockinfo_tcp.h
+++ b/src/core/sock/sockinfo_tcp.h
@@ -533,7 +533,7 @@ private:
         m_rx_reuse_buf_postponed = false;
 
         if (m_p_rx_ring) {
-            if (m_rx_reuse_buff.n_buff_num >= m_n_sysvar_rx_num_buffs_reuse) {
+            if (m_rx_reuse_buff.n_buff_num >= m_rx_num_buffs_reuse) {
                 if (m_p_rx_ring->reclaim_recv_buffers(&m_rx_reuse_buff.rx_reuse)) {
                     m_rx_reuse_buff.n_buff_num = 0;
                 } else {
@@ -545,7 +545,7 @@ private:
             while (iter != m_rx_ring_map.end()) {
                 descq_t *rx_reuse = &iter->second->rx_reuse_info.rx_reuse;
                 int &n_buff_num = iter->second->rx_reuse_info.n_buff_num;
-                if (n_buff_num >= m_n_sysvar_rx_num_buffs_reuse) {
+                if (n_buff_num >= m_rx_num_buffs_reuse) {
                     if (iter->first->reclaim_recv_buffers(rx_reuse)) {
                         n_buff_num = 0;
                     } else {

--- a/src/core/sock/sockinfo_udp.cpp
+++ b/src/core/sock/sockinfo_udp.cpp
@@ -150,7 +150,7 @@ inline int sockinfo_udp::rx_wait(bool blocking)
         }
 
         loops++;
-        if (!blocking || m_n_sysvar_rx_poll_num != -1) {
+        if (!blocking || safe_mce_sys().rx_poll_num != -1) {
             loops_to_go--;
         }
         if (m_loops_timer.is_timeout()) {
@@ -2571,7 +2571,7 @@ void sockinfo_udp::rx_add_ring_cb(ring *p_ring)
 
     // Now that we got at least 1 CQ attached start polling the CQs
     if (m_b_blocking) {
-        m_loops_to_go = m_n_sysvar_rx_poll_num;
+        m_loops_to_go = safe_mce_sys().rx_poll_num;
     } else {
         m_loops_to_go = 1; // Force single CQ poll in case of non-blocking socket
     }
@@ -2601,7 +2601,7 @@ void sockinfo_udp::set_blocking(bool is_blocked)
         // Set the high CQ polling RX_POLL value
         // depending on where we have mapped offloaded MC gorups
         if (m_rx_ring_map.size() > 0) {
-            m_loops_to_go = m_n_sysvar_rx_poll_num;
+            m_loops_to_go = safe_mce_sys().rx_poll_num;
         } else {
             m_loops_to_go = safe_mce_sys().rx_poll_num_init;
         }

--- a/src/core/sock/sockinfo_udp.cpp
+++ b/src/core/sock/sockinfo_udp.cpp
@@ -2195,8 +2195,11 @@ ssize_t sockinfo_udp::tx(xlio_tx_call_attr_t &tx_arg)
                                          tx_arg.opcode);
         }
 
-        if (unlikely(p_dst_entry->try_migrate_ring_tx(m_lock_snd))) {
-            m_p_socket_stats->counters.n_tx_migrations++;
+        // Condition for cache optimization
+        if (unlikely(safe_mce_sys().ring_migration_ratio_tx > 0)) {
+            if (unlikely(p_dst_entry->try_migrate_ring_tx(m_lock_snd))) {
+                m_p_socket_stats->counters.n_tx_migrations++;
+            }
         }
 
         // TODO ALEXR - still need to handle "is_dropped" in send path

--- a/src/core/sock/sockinfo_udp.h
+++ b/src/core/sock/sockinfo_udp.h
@@ -188,7 +188,7 @@ public:
     void set_params_for_socket_pool() override
     {
         m_is_for_socket_pool = true;
-        set_m_n_sysvar_rx_num_buffs_reuse(safe_mce_sys().nginx_udp_socket_pool_rx_num_buffs_reuse);
+        set_rx_num_buffs_reuse(safe_mce_sys().nginx_udp_socket_pool_rx_num_buffs_reuse);
     }
     bool is_closable() override { return !m_is_for_socket_pool; }
 #else
@@ -257,7 +257,7 @@ private:
         while (iter != m_rx_ring_map.end()) {
             descq_t *rx_reuse = &iter->second->rx_reuse_info.rx_reuse;
             int &n_buff_num = iter->second->rx_reuse_info.n_buff_num;
-            if (n_buff_num >= m_n_sysvar_rx_num_buffs_reuse) {
+            if (n_buff_num >= m_rx_num_buffs_reuse) {
                 if (iter->first->reclaim_recv_buffers(rx_reuse)) {
                     n_buff_num = 0;
                 } else {

--- a/src/core/xlio_extra.h
+++ b/src/core/xlio_extra.h
@@ -50,7 +50,6 @@
 #define SO_XLIO_GET_API          2800
 #define SO_XLIO_USER_DATA        2801
 #define SO_XLIO_RING_ALLOC_LOGIC 2810
-#define SO_XLIO_FLOW_TAG         2820
 #define SO_XLIO_SHUTDOWN_RX      2821
 #define SO_XLIO_PD               2822
 #define SCM_XLIO_PD              SO_XLIO_PD


### PR DESCRIPTION
## Description
This PR is based on PR 110 (issue: 3777348 Move socket statistics to a global storage)
This PR starts from commit: issue: 3777348 Removing m_flow_tag_enabled check

##### What
Avoid unnecessary cache lines access.
Descriptions of each change are in the commits.
Recommend to review by commits.

##### Why ?
Improve performance.

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [X] Code follows the style de facto guidelines of this project
- [X] Comments have been inserted in hard to understand places
- [X] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

