### PR TITLE
issue: 3829626 Fix new TCP timers registration for reused sockets

### DIFF
--- a/src/core/sock/sockinfo.cpp
+++ b/src/core/sock/sockinfo.cpp
@@ -190,18 +190,18 @@ sockinfo::~sockinfo()
 
 void sockinfo::socket_stats_init()
 {
-    if (!m_p_socket_stats) { // This check is for listen sockets.
+    if (!m_has_stats) { // This check is for listen sockets.
         m_p_socket_stats = sock_stats::instance().get_stats_obj();
         if (!m_p_socket_stats) {
             m_p_socket_stats = &sock_stats::t_dummy_stats;
             return;
         }
 
+        m_has_stats = true;
         // Save stats as local copy and allow state publisher to copy from this location
         xlio_stats_instance_create_socket_block(m_p_socket_stats);
     }
 
-    m_has_stats = true;
     m_p_socket_stats->reset();
     m_p_socket_stats->fd = m_fd;
     m_p_socket_stats->inode = fd2inode(m_fd);

--- a/src/core/sock/sockinfo_tcp.cpp
+++ b/src/core/sock/sockinfo_tcp.cpp
@@ -6037,6 +6037,11 @@ void tcp_timers_collection::add_new_timer(sockinfo_tcp *sock)
         return;
     }
 
+    // A reused time-wait socket wil try to add a timer although it is already registered.
+    if (m_sock_remove_map.find(sock) != m_sock_remove_map.end()) {
+        return;
+    }
+
     sock_list &bucket = m_p_intervals[m_n_next_insert_bucket];
     bucket.emplace_back(sock);
     m_sock_remove_map.emplace(sock, std::make_tuple(m_n_next_insert_bucket, --(bucket.end())));
@@ -6065,6 +6070,10 @@ void tcp_timers_collection::remove_timer(sockinfo_tcp *sock)
         }
 
         __log_dbg("TCP socket [%p] timer was removed", sock);
+    } else {
+        // Listen sockets are not added to timers.
+        // As part of socket general unregister and destroy they will get here and will no be found.
+        __log_dbg("TCP socket [%p] timer was not found (listen socket)", sock);
     }
 }
 


### PR DESCRIPTION
## Description
This issue is introduced in Simplify TCP timers commit of vNext
Another issue that was noticed is with reused sockets statistics pool from Statistics global pool commit.

##### What
1. Reused sockets are added more than once to the timer list. . See commit description.
2. Reused sockets initialized statistics incorrectly. See commit description.

##### Why ?
Fix reused socket timer registration and statistics.

## Change type
What kind of change does this PR introduce?
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [X] Code follows the style de facto guidelines of this project
- [X] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

