### PR TITLE
issue: HPCINFRA-1798 Switch Style step to clang-16 based container

### DIFF
--- a/.ci/matrix_job.yaml
+++ b/.ci/matrix_job.yaml
@@ -188,7 +188,7 @@ steps:
   - name: Style
     enable: ${do_style}
     containerSelector:
-      - "{name: 'toolbox', category: 'tool'}"
+      - "{name: 'xlio_static.tidy', category: 'tool', variant: 1}"
     agentSelector:
       - "{nodeLabel: 'skip-agent'}"
     run: |

--- a/contrib/jenkins_tests/style.sh
+++ b/contrib/jenkins_tests/style.sh
@@ -4,8 +4,6 @@ source $(dirname $0)/globals.sh
 
 echo "Checking for codying style ..."
 
-do_module "dev/clang-9.0.1"
-
 cd $WORKSPACE
 
 rm -rf $style_dir
@@ -65,8 +63,6 @@ else
     rm -rf ${style_tap}.backup
 fi
 rc=$(($rc+$nerrors))
-
-module unload "dev/clang-9.0.1"
 
 do_archive "${style_dir}/*.diff"
 


### PR DESCRIPTION
## Description
This change switches the "Style" step in the CI to a docker container having clang v16 in it

##### What
This change switches the "Style" step in the CI to a docker container having clang v16 in it

##### Why ?
In the style CI job we need to switch clang-format 9 to clang-format 15: [HPCINFRA-1798](https://jirasw.nvidia.com/browse/HPCINFRA-1798)

##### How ?
Re-point the "Style" job to a newer container image

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [X] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

