### PR TITLE
issue: HPCINFRA-1798 Update code base to clang-format-16 style

### DIFF
--- a/.ci/matrix_job.yaml
+++ b/.ci/matrix_job.yaml
@@ -188,7 +188,7 @@ steps:
   - name: Style
     enable: ${do_style}
     containerSelector:
-      - "{name: 'toolbox', category: 'tool'}"
+      - "{name: 'xlio_static.tidy', category: 'tool', variant: 1}"
     agentSelector:
       - "{nodeLabel: 'skip-agent'}"
     run: |

--- a/contrib/jenkins_tests/style.conf
+++ b/contrib/jenkins_tests/style.conf
@@ -174,6 +174,12 @@ SpacesInSquareBrackets: false
 # Parse and format C++ constructs compatible with this standard.
 Standard:        Cpp11
 
+InsertBraces: true
+SpaceInEmptyBlock: false
+SpacesInLineCommentPrefix:
+  Minimum: 0
+  Maximum: -1
+
 TabWidth:        4
 UseTab:          Never
 ...

--- a/contrib/jenkins_tests/style.sh
+++ b/contrib/jenkins_tests/style.sh
@@ -4,8 +4,6 @@ source $(dirname $0)/globals.sh
 
 echo "Checking for codying style ..."
 
-do_module "dev/clang-9.0.1"
-
 cd $WORKSPACE
 
 rm -rf $style_dir
@@ -65,8 +63,6 @@ else
     rm -rf ${style_tap}.backup
 fi
 rc=$(($rc+$nerrors))
-
-module unload "dev/clang-9.0.1"
 
 do_archive "${style_dir}/*.diff"
 

--- a/src/core/ib/base/verbs_extra.cpp
+++ b/src/core/ib/base/verbs_extra.cpp
@@ -153,7 +153,10 @@ int priv_ibv_modify_qp_to_err(struct ibv_qp *qp)
     memset(&qp_attr, 0, sizeof(qp_attr));
     qp_attr.qp_state = IBV_QPS_ERR;
     BULLSEYE_EXCLUDE_BLOCK_START
-    IF_VERBS_FAILURE_EX(xlio_ibv_modify_qp(qp, &qp_attr, IBV_QP_STATE), EIO) { return -1; }
+    IF_VERBS_FAILURE_EX(xlio_ibv_modify_qp(qp, &qp_attr, IBV_QP_STATE), EIO)
+    {
+        return -1;
+    }
     ENDIF_VERBS_FAILURE;
     BULLSEYE_EXCLUDE_BLOCK_END
 
@@ -166,7 +169,10 @@ int priv_ibv_modify_qp_to_reset(struct ibv_qp *qp)
     memset(&qp_attr, 0, sizeof(qp_attr));
     qp_attr.qp_state = IBV_QPS_RESET;
     BULLSEYE_EXCLUDE_BLOCK_START
-    IF_VERBS_FAILURE(xlio_ibv_modify_qp(qp, &qp_attr, IBV_QP_STATE)) { return -1; }
+    IF_VERBS_FAILURE(xlio_ibv_modify_qp(qp, &qp_attr, IBV_QP_STATE))
+    {
+        return -1;
+    }
     ENDIF_VERBS_FAILURE;
     BULLSEYE_EXCLUDE_BLOCK_END
     return 0;
@@ -213,14 +219,20 @@ int priv_ibv_modify_qp_from_init_to_rts(struct ibv_qp *qp)
     memset(&qp_attr, 0, sizeof(qp_attr));
     qp_attr.qp_state = IBV_QPS_RTR;
     BULLSEYE_EXCLUDE_BLOCK_START
-    IF_VERBS_FAILURE(xlio_ibv_modify_qp(qp, &qp_attr, qp_attr_mask)) { return -2; }
+    IF_VERBS_FAILURE(xlio_ibv_modify_qp(qp, &qp_attr, qp_attr_mask))
+    {
+        return -2;
+    }
     ENDIF_VERBS_FAILURE;
     BULLSEYE_EXCLUDE_BLOCK_END
 
     qp_attr.qp_state = IBV_QPS_RTS;
 
     BULLSEYE_EXCLUDE_BLOCK_START
-    IF_VERBS_FAILURE(xlio_ibv_modify_qp(qp, &qp_attr, qp_attr_mask)) { return -3; }
+    IF_VERBS_FAILURE(xlio_ibv_modify_qp(qp, &qp_attr, qp_attr_mask))
+    {
+        return -3;
+    }
     ENDIF_VERBS_FAILURE;
     BULLSEYE_EXCLUDE_BLOCK_END
 
@@ -233,7 +245,10 @@ int priv_ibv_query_qp_state(struct ibv_qp *qp)
     struct ibv_qp_attr qp_attr;
     struct ibv_qp_init_attr qp_init_attr;
     BULLSEYE_EXCLUDE_BLOCK_START
-    IF_VERBS_FAILURE(ibv_query_qp(qp, &qp_attr, IBV_QP_STATE, &qp_init_attr)) { return -1; }
+    IF_VERBS_FAILURE(ibv_query_qp(qp, &qp_attr, IBV_QP_STATE, &qp_init_attr))
+    {
+        return -1;
+    }
     ENDIF_VERBS_FAILURE;
     BULLSEYE_EXCLUDE_BLOCK_END
     VALGRIND_MAKE_MEM_DEFINED(&qp_attr, sizeof(qp_attr));

--- a/src/core/infra/DemoObserver.cpp
+++ b/src/core/infra/DemoObserver.cpp
@@ -85,8 +85,9 @@ void Demo_Observer::update_subject_1(demo_subject_1_key_t key, demo_subject_1_va
     if (s1) {
         s1->update_val(value); // expected output: notification msg
         s1->notify_observers();
-    } else
+    } else {
         printf("subject corresponding to key wasn't found\n");
+    }
 }
 
 void Demo_Observer::get_subject_1(demo_subject_1_key_t key)
@@ -97,8 +98,9 @@ void Demo_Observer::get_subject_1(demo_subject_1_key_t key)
     if (s1) {
         s1->get_val(val_s1);
         printf("subject1: key = %c, val = %d\n", key, val_s1);
-    } else
+    } else {
         printf("subject corresponding to key wasn't found\n");
+    }
 }
 
 void Demo_Observer::update_subject_2(demo_subject_2_key_t key, demo_subject_2_value_t value)
@@ -108,8 +110,9 @@ void Demo_Observer::update_subject_2(demo_subject_2_key_t key, demo_subject_2_va
     if (s2) {
         s2->update_val(value); // expected output: notification msg
         s2->notify_observers();
-    } else
+    } else {
         printf("subject corresponding to key wasn't found\n");
+    }
 }
 
 void Demo_Observer::get_subject_2(demo_subject_2_key_t key)
@@ -120,8 +123,9 @@ void Demo_Observer::get_subject_2(demo_subject_2_key_t key)
     if (s2) {
         s2->get_val(val_s2);
         printf("subject2: key = %d, val = %d\n", key, val_s2);
-    } else
+    } else {
         printf("subject corresponding to key wasn't found\n");
+    }
 }
 
 bool Demo_Observer::start_test(Demo_Coll_Mgr1 *coll_for_subjects_1,

--- a/src/core/infra/sender.cpp
+++ b/src/core/infra/sender.cpp
@@ -83,7 +83,7 @@ neigh_send_data::neigh_send_data(neigh_send_data &&snd_data)
 neigh_send_data::~neigh_send_data()
 {
     if (m_iov.iov_base) {
-        delete[]((uint8_t *)m_iov.iov_base);
+        delete[] ((uint8_t *)m_iov.iov_base);
     }
 
     if (m_header) {

--- a/src/core/netlink/test_main.cpp
+++ b/src/core/netlink/test_main.cpp
@@ -157,8 +157,9 @@ int main(int argc, char *argv[])
     g_vlogger_level = 3;
     if (argv && argc > 1) {
         int tracelevel = atoi(argv[1]);
-        if (tracelevel > 0 && tracelevel <= 5)
+        if (tracelevel > 0 && tracelevel <= 5) {
             g_vlogger_level = tracelevel;
+        }
     }
     netlink_test();
     return 0;

--- a/src/core/util/chunk_list.h
+++ b/src/core/util/chunk_list.h
@@ -89,8 +89,9 @@ private:
             data = (T *)calloc(CHUNK_LIST_CONTAINER_SIZE, sizeof(T));
             if (!data || !(cont = new container(data))) {
                 // Memory allocation error
-                if (data)
+                if (data) {
                     free(data);
+                }
                 clist_logerr("Failed to allocate memory");
                 goto out;
             }
@@ -154,8 +155,9 @@ public:
     inline T front() const
     {
         // Check if the list is empty.
-        if (unlikely(empty()))
+        if (unlikely(empty())) {
             return NULL;
+        }
         return m_used_containers.front()->m_p_buffer[m_front];
     }
 

--- a/src/core/util/sys_vars.cpp
+++ b/src/core/util/sys_vars.cpp
@@ -290,12 +290,18 @@ const char *to_str(MODE option, const OPT (&options)[N])
     {                                                                                              \
         return option_x::from_int(option, def_value, options);                                     \
     }                                                                                              \
-    const char *to_str(mode_t option) { return option_x::to_str(option, options); }
+    const char *to_str(mode_t option)                                                              \
+    {                                                                                              \
+        return option_x::to_str(option, options);                                                  \
+    }
 
 #define AUTO_ON_OFF_IMPL                                                                           \
     {AUTO, "Auto", {"auto", NULL, NULL}}, {ON, "Enabled", {"on", "enabled", NULL}},                \
     {                                                                                              \
-        OFF, "Disabled", { "off", "disabled", NULL }                                               \
+        OFF, "Disabled",                                                                           \
+        {                                                                                          \
+            "off", "disabled", NULL                                                                \
+        }                                                                                          \
     }
 
 template <typename MODE> struct option_t {

--- a/src/utils/asm-arm64.h
+++ b/src/utils/asm-arm64.h
@@ -100,8 +100,9 @@ static inline void prefetch_range(void *addr, size_t len)
 {
     char *cp = (char *)addr;
     char *end = (char *)addr + len;
-    for (; cp < end; cp += L1_CACHE_BYTES)
+    for (; cp < end; cp += L1_CACHE_BYTES) {
         prefetch(cp);
+    }
 }
 
 #endif

--- a/tests/gtest/core/xlio_sockopt.cc
+++ b/tests/gtest/core/xlio_sockopt.cc
@@ -40,8 +40,7 @@
 
 #if defined(EXTRA_API_ENABLED) && (EXTRA_API_ENABLED == 1)
 
-class xlio_sockopt : public xlio_base {
-};
+class xlio_sockopt : public xlio_base {};
 
 /**
  * @test xlio_sockopt.ti_1

--- a/tests/gtest/mix/mix_list.cc
+++ b/tests/gtest/mix/mix_list.cc
@@ -45,8 +45,7 @@ struct element {
     int value;
 };
 
-class mix_list : public mix_base {
-};
+class mix_list : public mix_base {};
 
 TEST_F(mix_list, ti_1)
 {

--- a/tests/gtest/sock/sock_socket.cc
+++ b/tests/gtest/sock/sock_socket.cc
@@ -37,8 +37,7 @@
 
 #include "sock_base.h"
 
-class sock_socket : public sock_base {
-};
+class sock_socket : public sock_base {};
 
 /**
  * @test sock_socket.ti_1

--- a/tests/gtest/tcp/tcp_accept.cc
+++ b/tests/gtest/tcp/tcp_accept.cc
@@ -38,8 +38,7 @@
 #include "src/core/util/sock_addr.h"
 #include "tcp_base.h"
 
-class tcp_accept : public tcp_base {
-};
+class tcp_accept : public tcp_base {};
 
 /**
  * @test tcp_accept.mapped_ipv4_accept

--- a/tests/gtest/tcp/tcp_connect.cc
+++ b/tests/gtest/tcp/tcp_connect.cc
@@ -39,8 +39,7 @@
 #include <algorithm>
 #include "tcp_base.h"
 
-class tcp_connect : public tcp_base {
-};
+class tcp_connect : public tcp_base {};
 
 /**
  * @test tcp_connect.ti_1

--- a/tests/gtest/tcp/tcp_connect_nb.cc
+++ b/tests/gtest/tcp/tcp_connect_nb.cc
@@ -37,8 +37,7 @@
 
 #include "tcp_base.h"
 
-class tcp_connect_nb : public tcp_base {
-};
+class tcp_connect_nb : public tcp_base {};
 
 /**
  * @test tcp_connect_nb.ti_1

--- a/tests/gtest/tcp/tcp_event.cc
+++ b/tests/gtest/tcp/tcp_event.cc
@@ -37,8 +37,7 @@
 #include "common/cmn.h"
 #include "tcp_base.h"
 
-class tcp_event : public tcp_base {
-};
+class tcp_event : public tcp_base {};
 
 TEST_F(tcp_event, DISABLED_ti_1)
 {

--- a/tests/gtest/tcp/tcp_rfs.cc
+++ b/tests/gtest/tcp/tcp_rfs.cc
@@ -37,8 +37,7 @@
 
 #include "tcp_base.h"
 
-class tcp_rfs : public tcp_base {
-};
+class tcp_rfs : public tcp_base {};
 
 /**
  * @test tcp_rfs.single_rule_send

--- a/tests/gtest/tcp/tcp_send.cc
+++ b/tests/gtest/tcp/tcp_send.cc
@@ -37,8 +37,7 @@
 #include "common/base.h"
 #include "tcp_base.h"
 
-class tcp_send : public tcp_base {
-};
+class tcp_send : public tcp_base {};
 
 /**
  * @test tcp_send.ti_1

--- a/tests/gtest/tcp/tcp_sendto.cc
+++ b/tests/gtest/tcp/tcp_sendto.cc
@@ -37,8 +37,7 @@
 
 #include "tcp_base.h"
 
-class tcp_sendto : public tcp_base {
-};
+class tcp_sendto : public tcp_base {};
 
 /**
  * @test tcp_sendto.ti_1

--- a/tests/gtest/tcp/tcp_socket.cc
+++ b/tests/gtest/tcp/tcp_socket.cc
@@ -36,8 +36,7 @@
 #include "common/base.h"
 #include "tcp_base.h"
 
-class tcp_socket : public tcp_base {
-};
+class tcp_socket : public tcp_base {};
 
 /**
  * @test tcp_socket.ti_1_ipv4

--- a/tests/gtest/tcp/tcp_sockopt.cc
+++ b/tests/gtest/tcp/tcp_sockopt.cc
@@ -51,8 +51,7 @@
 
 #define HELLO_STR "hello"
 
-class tcp_sockopt : public tcp_base {
-};
+class tcp_sockopt : public tcp_base {};
 
 /**
  * @test tcp_sockopt.ti_1_getsockopt_tcp_info

--- a/tests/gtest/udp/udp_connect.cc
+++ b/tests/gtest/udp/udp_connect.cc
@@ -38,8 +38,7 @@
 #include "udp_base.h"
 #include "src/core/util/sock_addr.h"
 
-class udp_connect : public udp_base {
-};
+class udp_connect : public udp_base {};
 
 /**
  * @test udp_connect.ti_1

--- a/tests/gtest/udp/udp_recv.cc
+++ b/tests/gtest/udp/udp_recv.cc
@@ -38,8 +38,7 @@
 #include "src/core/util/sock_addr.h"
 #include "udp_base.h"
 
-class udp_recv : public udp_base {
-};
+class udp_recv : public udp_base {};
 
 /**
  * @test udp_recv.mapped_ipv4_recv

--- a/tests/gtest/udp/udp_rfs.cc
+++ b/tests/gtest/udp/udp_rfs.cc
@@ -37,8 +37,7 @@
 
 #include "udp_base.h"
 
-class udp_rfs : public udp_base {
-};
+class udp_rfs : public udp_base {};
 
 /**
  * @test udp_rfs.single_rule_send

--- a/tests/gtest/udp/udp_send.cc
+++ b/tests/gtest/udp/udp_send.cc
@@ -40,8 +40,7 @@
 #include "udp_base.h"
 #include "src/core/util/sock_addr.h"
 
-class udp_send : public udp_base {
-};
+class udp_send : public udp_base {};
 
 /**
  * @test udp_send.ti_1

--- a/tests/gtest/udp/udp_sendto.cc
+++ b/tests/gtest/udp/udp_sendto.cc
@@ -37,8 +37,7 @@
 #include "common/cmn.h"
 #include "udp_base.h"
 
-class udp_sendto : public udp_base {
-};
+class udp_sendto : public udp_base {};
 
 /**
  * @test udp_sendto.ti_1

--- a/tests/gtest/udp/udp_socket.cc
+++ b/tests/gtest/udp/udp_socket.cc
@@ -37,8 +37,7 @@
 
 #include "udp_base.h"
 
-class udp_socket : public udp_base {
-};
+class udp_socket : public udp_base {};
 
 /**
  * @test udp_socket.ti_1_ipv4

--- a/tests/gtest/xliod/xliod_bitmap.cc
+++ b/tests/gtest/xliod/xliod_bitmap.cc
@@ -40,8 +40,7 @@
 
 #include "tools/daemon/bitmap.h"
 
-class xliod_bitmap : public ::testing::Test {
-};
+class xliod_bitmap : public ::testing::Test {};
 
 TEST_F(xliod_bitmap, ti_1)
 {

--- a/tests/gtest/xliod/xliod_hash.cc
+++ b/tests/gtest/xliod/xliod_hash.cc
@@ -45,8 +45,7 @@ struct element {
     int value;
 };
 
-class xliod_hash : public ::testing::Test {
-};
+class xliod_hash : public ::testing::Test {};
 
 TEST_F(xliod_hash, ti_1)
 {


### PR DESCRIPTION
## Description
Starting from clang-format-15, it supports forced brackets insertion. With this feature we no longer need clang-tidy CI job and all the coding style can be checked more conveniently.

Note, It's rebased on top of #119 which moves the CI job to clang-16.

##### What
Move to clang-format-16

##### Why ?
Brackets insertion support and use more modern clang version which is easier to find in Linux distributions.

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [x] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

