### PR TITLE
issue: 3795997 Allow split segment with unacked q

### DIFF
--- a/src/core/lwip/tcp_out.c
+++ b/src/core/lwip/tcp_out.c
@@ -1813,7 +1813,8 @@ err_t tcp_output(struct tcp_pcb *pcb)
         }
 
         /* Split the segment in case of a small window */
-        if ((NULL == pcb->unacked) && (wnd) && ((seg->len + seg->seqno - pcb->lastack) > wnd)) {
+        if (wnd && ((NULL == pcb->unacked) || (wnd >= pcb->mss)) &&
+            ((seg->len + seg->seqno - pcb->lastack) > wnd)) {
             LWIP_ASSERT("tcp_output: no window for dummy packet", !LWIP_IS_DUMMY_SEGMENT(seg));
             tcp_split_segment(pcb, seg, wnd);
         }


### PR DESCRIPTION
When send window is not big enough for the required TCP segment to send, we may split the segment so it will fir into the window. Before this change - We didn't split the segment in the case we have unacked segments. The motivation was that we anticiapte to get ACK on the inflight segments, which will trigger the next send operation.
This flow count on RTT for receiving ACKs, which may be delayed depending on the remote side. When RTT is long - we would block sending although TCP send window allows it.

The change is to split TCP segments although we have unacked data, in case the send window is big enough (mss).

## Change type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

