### PR TITLE
issue: 3829626 Fix seg fault in TCP timers

### DIFF
--- a/src/core/sock/sockinfo_tcp.cpp
+++ b/src/core/sock/sockinfo_tcp.cpp
@@ -5977,7 +5977,13 @@ void tcp_timers_collection::handle_timer_expired(void *user_data)
     sock_list &bucket = m_p_intervals[m_n_location];
     m_n_location = (m_n_location + 1) % m_n_intervals_size;
 
-    for (sockinfo_tcp *p_sock : bucket) {
+    auto iter = bucket.begin();
+    while (iter != bucket.end()) {
+        sockinfo_tcp *p_sock = *iter;
+        // Must inc iter first bacause handle_timer_expired can erase
+        // the socket that the iter points to, with delegated timers.
+        iter++;
+
         /* It is not guaranteed that the same sockinfo object is met once
          * in this loop.
          * So in case sockinfo object is destroyed other processing


### PR DESCRIPTION
Iterate over std::list of TCP sockets while
erasing socket during iteration.
Overcomed by increasing iterator before erase.

## Change type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

