### PR TITLE
issue: 3818038 Remove BlueFlame doorbell method

### DIFF
--- a/src/core/dev/hw_queue_tx.cpp
+++ b/src/core/dev/hw_queue_tx.cpp
@@ -600,7 +600,7 @@ inline int hw_queue_tx::fill_wqe(xlio_ibv_send_wr *pswr)
     int max_inline_len = get_max_inline_data();
 
     // assume packet is full inline
-    if (likely(data_len <= max_inline_len && xlio_send_wr_opcode(*pswr) == XLIO_IBV_WR_SEND)) {
+    if (data_len <= max_inline_len && xlio_send_wr_opcode(*pswr) == XLIO_IBV_WR_SEND) {
         uint8_t *data_addr = sga.get_data(&inline_len); // data for inlining in ETH header
         data_len -= inline_len;
         hwqtx_logfunc(

--- a/src/core/dev/hw_queue_tx.h
+++ b/src/core/dev/hw_queue_tx.h
@@ -264,8 +264,7 @@ private:
     inline int fill_wqe_lso(xlio_ibv_send_wr *pswr);
     inline int fill_inl_segment(sg_array &sga, uint8_t *cur_seg, uint8_t *data_addr,
                                 int max_inline_len, int inline_len);
-    inline void ring_doorbell(int db_method, int num_wqebb, int num_wqebb_top = 0,
-                              bool skip_comp = false);
+    inline void ring_doorbell(int num_wqebb, bool skip_comp = false);
 
     struct xlio_rate_limit_t m_rate_limit;
     xlio_ib_mlx5_qp_t m_mlx5_qp;
@@ -279,7 +278,6 @@ private:
     struct mlx5_eth_wqe (*m_sq_wqes)[] = nullptr;
     struct mlx5_eth_wqe *m_sq_wqe_hot = nullptr;
     uint8_t *m_sq_wqes_end = nullptr;
-    enum { MLX5_DB_METHOD_BF, MLX5_DB_METHOD_DB } m_db_method;
 
     const uint32_t m_n_sysvar_tx_num_wr_to_signal;
     uint32_t m_tx_num_wr;

--- a/src/core/ib/mlx5/ib_mlx5.cpp
+++ b/src/core/ib/mlx5/ib_mlx5.cpp
@@ -69,8 +69,6 @@ int xlio_ib_mlx5_get_qp_tx(xlio_ib_mlx5_qp_t *mlx5_qp)
     mlx5_qp->sq.wqe_cnt = dqp.sq.wqe_cnt;
     mlx5_qp->sq.stride = dqp.sq.stride;
     mlx5_qp->bf.reg = dqp.bf.reg;
-    mlx5_qp->bf.size = dqp.bf.size;
-    mlx5_qp->bf.offset = 0;
 #if defined(DEFINED_DV_RAW_QP_HANDLES)
     mlx5_qp->tisn = dqp.tisn;
     mlx5_qp->sqn = dqp.sqn;

--- a/src/core/ib/mlx5/ib_mlx5.h
+++ b/src/core/ib/mlx5/ib_mlx5.h
@@ -80,8 +80,6 @@ typedef struct xlio_ib_mlx5_qp {
     } sq;
     struct {
         void *reg;
-        uint32_t size;
-        uint32_t offset;
     } bf;
     uint32_t tisn;
     uint32_t sqn;


### PR DESCRIPTION
## Description
rdma-core limits number of UARs per context to 16 by default. After
creating 16 QPs, XLIO receives duplicates of blueflame registers for
each subsequent QP. As results, blueflame doorbell method can write WQEs
concurrently without serialization and this leads to data corruption.

BlueFlame can make impact on throughput since copy to the blueflame
register is expensive. It can improve latency in some low latency
scenarios, however, XLIO targets high traffic/PPS rates.
Removing blueflame method slightly improves performance in some
scenarios.

BlueFlame can be returned in the future to improve low-latency
scenarios, however, it will need some rework to avoid the data
corruption.

##### What
Remove BlueFlame doorbell method

##### Why ?
Fix data corruption for multi-threaded applications with over 16 QPs. Minor throughput/RPS improvement in some scenarios.

## Change type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

