### PR TITLE
issue: 3844385 Fix new TCP timers registration lock contention

### DIFF
--- a/src/core/sock/sockinfo_tcp.h
+++ b/src/core/sock/sockinfo_tcp.h
@@ -320,6 +320,8 @@ public:
     }
 
     bool is_incoming() override { return m_b_incoming; }
+    bool is_timer_registered() const { return m_timer_registered; }
+    void set_timer_registered(bool v) { m_timer_registered = v; }
 
     bool is_connected() { return m_sock_state == TCP_SOCK_CONNECTED_RDWR; }
 
@@ -618,6 +620,7 @@ private:
     bool m_xlio_thr;
     bool m_b_incoming;
     bool m_b_attached;
+    bool m_timer_registered = false;
     /* connection state machine */
     int m_conn_timeout;
     /* RCVBUF acconting */


### PR DESCRIPTION
## Description
Avoid calling register_socket_timer_event when a socket is already registered (TIME-WAIT). Although there is no functionality issue with that, it produces too high rate of posting events for internal-thread. This leads to lock contention inside internal-thread and degraded performance of HTTP CPS.

##### Why ?
HTTP CPS degradation.

## Change type
What kind of change does this PR introduce?
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

