### PR TITLE
issue: 3795997 Control TSO max payload size

### DIFF
--- a/src/core/dev/ring_simple.cpp
+++ b/src/core/dev/ring_simple.cpp
@@ -261,6 +261,11 @@ void ring_simple::create_resources()
             const xlio_ibv_tso_caps *caps =
                 &xlio_get_tso_caps(m_p_ib_ctx->get_ibv_device_attr_ex());
             if (ibv_is_qpt_supported(caps->supported_qpts, IBV_QPT_RAW_PACKET)) {
+                if (caps->max_tso && (caps->max_tso > MCE_DEFAULT_MAX_TSO_SIZE)) {
+                    ring_logwarn("max_tso cap (=%u) is higher than default TSO size (=%u). "
+                                 "Increase XLIO_MAX_TSO_SIZE to get full TSO potential.",
+                                 caps->max_tso, MCE_DEFAULT_MAX_TSO_SIZE);
+                }
                 m_tso.max_payload_sz = caps->max_tso;
                 /* ETH(14) + IP(20) + TCP(20) + TCP OPTIONS(40) */
                 m_tso.max_header_sz = 94;

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -805,6 +805,8 @@ void print_xlio_global_settings()
     VLOG_STR_PARAM_STRING("TSO support", option_3::to_str(safe_mce_sys().enable_tso),
                           option_3::to_str(MCE_DEFAULT_TSO), SYS_VAR_TSO,
                           option_3::to_str(safe_mce_sys().enable_tso));
+    VLOG_PARAM_STRING("TSO max size", safe_mce_sys().max_tso_sz, MCE_DEFAULT_MAX_TSO_SIZE,
+                      SYS_VAR_MAX_TSO_SIZE, option_size::to_str(safe_mce_sys().max_tso_sz));
     VLOG_STR_PARAM_STRING("LRO support", option_3::to_str(safe_mce_sys().enable_lro),
                           option_3::to_str(MCE_DEFAULT_LRO), SYS_VAR_LRO,
                           option_3::to_str(safe_mce_sys().enable_lro));

--- a/src/core/sock/sockinfo_tcp.cpp
+++ b/src/core/sock/sockinfo_tcp.cpp
@@ -875,8 +875,9 @@ bool sockinfo_tcp::prepare_dst_to_send(bool is_accepted_socket /* = false */)
              * so it is a time to provide TSO information to PCB
              */
             auto *ring = m_p_connected_dst_entry->get_ring();
-            m_pcb.tso.max_buf_sz = std::min(safe_mce_sys().tx_buf_size, ring->get_max_payload_sz());
-            m_pcb.tso.max_payload_sz = ring->get_max_payload_sz();
+            uint32_t max_tso_sz = std::min(ring->get_max_payload_sz(), safe_mce_sys().max_tso_sz);
+            m_pcb.tso.max_buf_sz = std::min(safe_mce_sys().tx_buf_size, max_tso_sz);
+            m_pcb.tso.max_payload_sz = max_tso_sz;
             m_pcb.tso.max_header_sz = ring->get_max_header_sz();
             m_pcb.tso.max_send_sge = ring->get_max_send_sge();
         }

--- a/src/core/util/sys_vars.cpp
+++ b/src/core/util/sys_vars.cpp
@@ -837,6 +837,7 @@ void mce_sys_var::get_env_params()
     progress_engine_wce_max = MCE_DEFAULT_PROGRESS_ENGINE_WCE_MAX;
     cq_keep_qp_full = MCE_DEFAULT_CQ_KEEP_QP_FULL;
     qp_compensation_level = MCE_DEFAULT_QP_COMPENSATION_LEVEL;
+    max_tso_sz = MCE_DEFAULT_MAX_TSO_SIZE;
     user_huge_page_size = MCE_DEFAULT_USER_HUGE_PAGE_SIZE;
     internal_thread_arm_cq_enabled = MCE_DEFAULT_INTERNAL_THREAD_ARM_CQ_ENABLED;
 
@@ -1890,6 +1891,10 @@ void mce_sys_var::get_env_params()
 
     if ((env_ptr = getenv(SYS_VAR_TSO))) {
         enable_tso = option_3::from_str(env_ptr, MCE_DEFAULT_TSO);
+    }
+
+    if ((env_ptr = getenv(SYS_VAR_MAX_TSO_SIZE))) {
+        max_tso_sz = option_size::from_str(env_ptr);
     }
 
     if ((enable_tso != option_3::OFF) && (ring_migration_ratio_tx != -1)) {

--- a/src/core/util/sys_vars.h
+++ b/src/core/util/sys_vars.h
@@ -434,6 +434,7 @@ public:
     uint32_t progress_engine_wce_max;
     bool cq_keep_qp_full;
     uint32_t qp_compensation_level;
+    uint32_t max_tso_sz;
     size_t user_huge_page_size;
 
     bool offloaded_sockets;
@@ -637,6 +638,7 @@ extern mce_sys_var &safe_mce_sys();
 #define SYS_VAR_PROGRESS_ENGINE_WCE_MAX   "XLIO_PROGRESS_ENGINE_WCE_MAX"
 #define SYS_VAR_CQ_KEEP_QP_FULL           "XLIO_CQ_KEEP_QP_FULL"
 #define SYS_VAR_QP_COMPENSATION_LEVEL     "XLIO_QP_COMPENSATION_LEVEL"
+#define SYS_VAR_MAX_TSO_SIZE              "XLIO_MAX_TSO_SIZE"
 #define SYS_VAR_USER_HUGE_PAGE_SIZE       "XLIO_USER_HUGE_PAGE_SIZE"
 #define SYS_VAR_OFFLOADED_SOCKETS         "XLIO_OFFLOADED_SOCKETS"
 #define SYS_VAR_TIMER_RESOLUTION_MSEC     "XLIO_TIMER_RESOLUTION_MSEC"
@@ -861,6 +863,7 @@ extern mce_sys_var &safe_mce_sys();
 #define MCE_MAX_CQ_POLL_BATCH               (128)
 #define MCE_DEFAULT_SOCKETXTREME            (false)
 #define MCE_DEFAULT_TSO                     (option_3::AUTO)
+#define MCE_DEFAULT_MAX_TSO_SIZE            (256 * 1024)
 #ifdef DEFINED_UTLS
 #define MCE_DEFAULT_UTLS_RX                        (false)
 #define MCE_DEFAULT_UTLS_TX                        (true)


### PR DESCRIPTION
Added new env parameter - XLIO_MAX_TSO_SIZE.
It allows the user to control the maximum size of TSO, instead of taking the maximum cap by HW.
The default size is 256KB (maximum by current HW).
Values higher than HW capabilities won't be taken into account.

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

