### PR TITLE
issue: 3928453 Improve buffer pools statistics and report

### DIFF
--- a/README
+++ b/README
@@ -1059,9 +1059,9 @@ Note that usage of Mutex might increase latency.
 Default: 0 (Spin)
 
 XLIO_PRINT_REPORT
-Print a report in human readable format in case of runtime errors. The report is
-printed during termination phase. It can be missed if the process is killed with
-SIGKILL signal.
+Print a human readable report of resources usage at exit. The report is printed
+during termination phase. Therefore, It can be missed if the process is killed
+with the SIGKILL signal.
 Default: 0 (Disabled)
 
 XLIO Monitoring & Performance Counters

--- a/src/core/dev/buffer_pool.cpp
+++ b/src/core/dev/buffer_pool.cpp
@@ -129,6 +129,7 @@ bool buffer_pool::expand(size_t count)
         }
     }
     m_n_buffers_created += count;
+    m_p_bpool_stat->n_buffer_pool_created = m_n_buffers_created;
     return true;
 }
 

--- a/src/core/dev/buffer_pool.h
+++ b/src/core/dev/buffer_pool.h
@@ -79,7 +79,7 @@ public:
     void register_memory(ib_ctx_handler *p_ib_ctx_h);
     void print_val_tbl();
     void print_report(vlog_levels_t log_level = VLOG_DEBUG);
-    static void print_report_on_errors(vlog_levels_t log_level);
+    static void print_full_report(vlog_levels_t log_level);
 
     uint32_t find_lkey_by_ib_ctx_thread_safe(ib_ctx_handler *p_ib_ctx_h);
 

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -196,7 +196,7 @@ static int free_libxlio_resources()
     g_socketxtreme_ec_pool = NULL;
 
     if (safe_mce_sys().print_report) {
-        buffer_pool::print_report_on_errors(VLOG_INFO);
+        buffer_pool::print_full_report(VLOG_INFO);
     }
 
     if (g_buffer_pool_zc) {

--- a/src/core/util/xlio_stats.h
+++ b/src/core/util/xlio_stats.h
@@ -408,6 +408,7 @@ typedef struct {
     uint32_t n_buffer_pool_size;
     uint32_t n_buffer_pool_no_bufs;
     uint32_t n_buffer_pool_expands;
+    uint32_t n_buffer_pool_created;
 } bpool_stats_t;
 
 typedef struct {

--- a/src/stats/stats_reader.cpp
+++ b/src/stats/stats_reader.cpp
@@ -656,6 +656,8 @@ void print_bpool_stats(bpool_instance_block_t *p_bpool_inst_arr)
                 printf("\tBUFFER_POOL=[%u]\n", i);
             }
             printf(FORMAT_STATS_32bit, "Size:", p_bpool_stats->n_buffer_pool_size);
+            printf(FORMAT_STATS_32bit, "Buffers in use:",
+                   p_bpool_stats->n_buffer_pool_created - p_bpool_stats->n_buffer_pool_size);
             printf(FORMAT_STATS_32bit, "No buffers error:", p_bpool_stats->n_buffer_pool_no_bufs);
             if (p_bpool_stats->n_buffer_pool_expands) {
                 printf(FORMAT_STATS_32bit, "Expands:", p_bpool_stats->n_buffer_pool_expands);


### PR DESCRIPTION
## Description
XLIO_PRINT_REPORT now prints all the buffer pools reports unconditionally and shows number of the expands.
xlio_stats prints also "in use" buffers along with the free buffers. There total number of allocation buffers is "in use" + "free".

##### What
Improve buffer pools statistics and report.

##### Why ?
User experience and system observability improvements.

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

