### PR TITLE
issue: 3854806 Fixing TX buffers return order in TCP socket destruction

### DIFF
--- a/src/core/dev/ring_simple.cpp
+++ b/src/core/dev/ring_simple.cpp
@@ -872,6 +872,7 @@ void ring_simple::init_tx_buffers(uint32_t count)
 {
     request_more_tx_buffers(PBUF_RAM, count, m_tx_lkey);
     m_tx_num_bufs = m_tx_pool.size();
+    m_p_ring_stat->simple.n_tx_num_bufs = m_tx_num_bufs;
 }
 
 void ring_simple::inc_cq_moderation_stats(size_t sz_data)
@@ -896,8 +897,10 @@ mem_buf_desc_t *ring_simple::get_tx_buffers(pbuf_type type, uint32_t n_num_mem_b
              */
             if (type == PBUF_ZEROCOPY) {
                 m_zc_num_bufs += count;
+                m_p_ring_stat->simple.n_zc_num_bufs = m_zc_num_bufs;
             } else {
                 m_tx_num_bufs += count;
+                m_p_ring_stat->simple.n_tx_num_bufs = m_tx_num_bufs;
             }
         }
 
@@ -932,12 +935,14 @@ void ring_simple::return_to_global_pool()
                  m_tx_num_bufs >= RING_TX_BUFS_COMPENSATE * 2)) {
         int return_bufs = m_tx_pool.size() / 2;
         m_tx_num_bufs -= return_bufs;
+        m_p_ring_stat->simple.n_tx_num_bufs = m_tx_num_bufs;
         g_buffer_pool_tx->put_buffers_thread_safe(&m_tx_pool, return_bufs);
     }
     if (unlikely(m_zc_pool.size() > (m_zc_num_bufs / 2) &&
                  m_zc_num_bufs >= RING_TX_BUFS_COMPENSATE * 2)) {
         int return_bufs = m_zc_pool.size() / 2;
         m_zc_num_bufs -= return_bufs;
+        m_p_ring_stat->simple.n_zc_num_bufs = m_zc_num_bufs;
         g_buffer_pool_zc->put_buffers_thread_safe(&m_zc_pool, return_bufs);
     }
 }

--- a/src/core/sock/sockinfo_tcp.cpp
+++ b/src/core/sock/sockinfo_tcp.cpp
@@ -546,10 +546,7 @@ sockinfo_tcp::~sockinfo_tcp()
         g_bind_no_port->release_port(m_bound, m_connected);
     }
 
-    destructor_helper();
-
-    // Release preallocated buffers
-    tcp_tx_preallocted_buffers_free(&m_pcb);
+    destructor_helper_tcp();
 
     if (m_tcp_seg_in_use) {
         si_tcp_logwarn("still %d tcp segs in use!", m_tcp_seg_in_use);
@@ -588,6 +585,14 @@ sockinfo_tcp::~sockinfo_tcp()
     si_tcp_logdbg("sock closed");
 
     xlio_socket_event(XLIO_SOCKET_EVENT_TERMINATED, 0);
+}
+
+void sockinfo_tcp::destructor_helper_tcp()
+{
+    // Release preallocated buffers
+    tcp_tx_preallocted_buffers_free(&m_pcb);
+
+    destructor_helper();
 }
 
 void sockinfo_tcp::clean_socket_obj()
@@ -2731,7 +2736,7 @@ int sockinfo_tcp::connect(const sockaddr *__to, socklen_t __tolen)
                     ntohs(m_connected.get_in_port()), m_pcb.is_ipv6, sockinfo_tcp::connect_lwip_cb);
     if (err != ERR_OK) {
         // todo consider setPassthrough and go to OS
-        destructor_helper();
+        destructor_helper_tcp();
         m_conn_state = TCP_CONN_FAILED;
         errno = ECONNREFUSED;
         si_tcp_logerr("bad connect, err=%d", err);
@@ -2769,7 +2774,7 @@ int sockinfo_tcp::connect(const sockaddr *__to, socklen_t __tolen)
         int keep_errno = errno;
         tcp_close(&m_pcb);
 
-        destructor_helper();
+        destructor_helper_tcp();
         unlock_tcp_con();
         si_tcp_logdbg("Blocking connect error, m_sock_state=%d", static_cast<int>(m_sock_state));
 
@@ -3058,7 +3063,7 @@ int sockinfo_tcp::listen(int backlog)
             si_tcp_logdbg("failed to add user's fd to internal epfd errno=%d (%m)", errno);
         } else {
             si_tcp_logerr("failed to add user's fd to internal epfd errno=%d (%m)", errno);
-            destructor_helper();
+            destructor_helper_tcp();
             passthrough_unlock("Fallback the connection to os");
             return 0;
         }

--- a/src/core/sock/sockinfo_tcp.h
+++ b/src/core/sock/sockinfo_tcp.h
@@ -212,6 +212,7 @@ public:
     // otherwise
     bool prepare_to_close(bool process_shutdown = false) override;
     void create_dst_entry();
+    void destructor_helper_tcp();
     bool prepare_dst_to_send(bool is_accepted_socket = false);
 
     int fcntl(int __cmd, unsigned long int __arg) override;

--- a/src/core/util/xlio_stats.h
+++ b/src/core/util/xlio_stats.h
@@ -382,6 +382,8 @@ typedef struct {
             uint64_t n_tx_dev_mem_byte_count;
             uint64_t n_tx_dev_mem_oob;
             uint32_t n_tx_dev_mem_allocated;
+            uint32_t n_tx_num_bufs;
+            uint32_t n_zc_num_bufs;
         } simple;
         struct {
             char s_tap_name[IFNAMSIZ];

--- a/src/stats/stats_reader.cpp
+++ b/src/stats/stats_reader.cpp
@@ -358,6 +358,12 @@ void update_delta_ring_stat(ring_stats_t *p_curr_ring_stats, ring_stats_t *p_pre
             (p_curr_ring_stats->simple.n_tx_dropped_wqes -
              p_prev_ring_stats->simple.n_tx_dropped_wqes) /
             delay;
+        p_prev_ring_stats->simple.n_tx_num_bufs =
+            (p_curr_ring_stats->simple.n_tx_num_bufs - p_prev_ring_stats->simple.n_tx_num_bufs) /
+            delay;
+        p_prev_ring_stats->simple.n_zc_num_bufs =
+            (p_curr_ring_stats->simple.n_zc_num_bufs - p_prev_ring_stats->simple.n_zc_num_bufs) /
+            delay;
 #ifdef DEFINED_UTLS
         p_prev_ring_stats->n_tx_tls_contexts =
             (p_curr_ring_stats->n_tx_tls_contexts - p_prev_ring_stats->n_tx_tls_contexts) / delay;
@@ -548,6 +554,11 @@ void print_ring_stats(ring_instance_block_t *p_ring_inst_arr)
                            p_ring_stats->simple.n_tx_dev_mem_pkt_count,
                            p_ring_stats->simple.n_tx_dev_mem_oob, post_fix);
                 }
+
+                printf(FORMAT_STATS_32bit,
+                       "TX buffers inflight:", p_ring_stats->simple.n_tx_num_bufs);
+                printf(FORMAT_STATS_32bit,
+                       "TX ZC buffers inflight:", p_ring_stats->simple.n_zc_num_bufs);
             }
         }
     }
@@ -1789,6 +1800,8 @@ void zero_ring_stats(ring_stats_t *p_ring_stats)
         p_ring_stats->simple.n_tx_dev_mem_byte_count = 0;
         p_ring_stats->simple.n_tx_dev_mem_pkt_count = 0;
         p_ring_stats->simple.n_tx_dev_mem_oob = 0;
+        p_ring_stats->simple.n_tx_num_bufs = 0;
+        p_ring_stats->simple.n_zc_num_bufs = 0;
     }
 }
 


### PR DESCRIPTION
## Description
When TCP socket is destroyed it frees the preallocated buffers after dst_entry is deleted. This returns the buffers to the global pool directly and breaks m_tx_num_bufs,m_zc_num_bufs ring counters.

##### What
1. Move the preallocated buffers cleanup before dst_entry destruction.
2. Add ring stats for m_tx_num_bufs and m_zc_num_bufs.

##### Why ?
Functionality

## Change type
What kind of change does this PR introduce?
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

