### PR TITLE
issue: 3858121 Fixing socket stats corruption on termination

### DIFF
--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -262,6 +262,8 @@ static int free_libxlio_resources()
 
     vlog_printf(VLOG_DEBUG, "Stopping logger module\n");
 
+    sock_stats::destroy_instance();
+
     sock_redirect_exit();
 
     vlog_stop();
@@ -1047,7 +1049,7 @@ static void do_global_ctors_helper()
     *g_p_vlogger_level = g_vlogger_level;
     *g_p_vlogger_details = g_vlogger_details;
 
-    sock_stats::instance().init_sock_stats(safe_mce_sys().stats_fd_num_max);
+    sock_stats::init_instance(safe_mce_sys().stats_fd_num_max);
 
     g_global_stat_static.init();
     xlio_stats_instance_create_global_block(&g_global_stat_static);

--- a/src/core/sock/sock_stats.h
+++ b/src/core/sock/sock_stats.h
@@ -42,16 +42,20 @@
 
 class sock_stats {
 public:
+    static void init_instance(size_t max_stats);
+    static void destroy_instance();
     static sock_stats &instance();
-    static thread_local socket_stats_t t_dummy_stats;
 
-    void init_sock_stats(size_t max_stats);
     socket_stats_t *get_stats_obj();
     void return_stats_obj(socket_stats_t *stats);
 
+    static thread_local socket_stats_t t_dummy_stats;
+
 private:
     sock_stats() {}
+    void init_sock_stats(size_t max_stats);
 
+    static sock_stats *s_instance;
     std::mutex _stats_lock;
     socket_stats_t *_socket_stats_list = nullptr;
     std::vector<socket_stats_t> _socket_stats_vec;

--- a/src/core/sock/sockinfo_tcp.cpp
+++ b/src/core/sock/sockinfo_tcp.cpp
@@ -3610,7 +3610,10 @@ err_t sockinfo_tcp::syn_received_timewait_cb(void *arg, struct tcp_pcb *newpcb)
     new_sock->m_b_blocking = true;
 
     /* Dump statistics of the previous incarnation of the socket. */
-    print_full_stats(new_sock->m_p_socket_stats, nullptr, safe_mce_sys().stats_file);
+    if (new_sock->has_stats()) {
+        print_full_stats(new_sock->m_p_socket_stats, nullptr, safe_mce_sys().stats_file);
+    }
+
     new_sock->socket_stats_init();
 
     /* Reset zerocopy state */


### PR DESCRIPTION
## Description
When sock_stats was static its destructor was called before xlio_exit that destroys the internal-thread which destroys sockets. 

##### What
We should avoid having global objects with untrivial constructors/destructors, since there is no control of their execution order. 

##### Why ?
Functionality

## Change type
What kind of change does this PR introduce?
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

