### PR TITLE
issue: 3875155 Fix cppcheck skipping files from scanning

### DIFF
--- a/src/core/lwip/err.h
+++ b/src/core/lwip/err.h
@@ -38,13 +38,7 @@
 extern "C" {
 #endif
 
-/** Define LWIP_ERR_T in cc.h if you want to use
- *  a different type for your platform (must be signed). */
-#ifdef LWIP_ERR_T
-typedef LWIP_ERR_T err_t;
-#else /* LWIP_ERR_T */
 typedef s8_t err_t;
-#endif /* LWIP_ERR_T*/
 
 /* Definitions for error constants. */
 

--- a/src/core/lwip/opt.h
+++ b/src/core/lwip/opt.h
@@ -214,7 +214,7 @@
 
 /* Platform endianness */
 #if !defined(__BYTE_ORDER__) || !defined(__ORDER_LITTLE_ENDIAN__) || !defined(__ORDER_BIG_ENDIAN__)
-#error "__BYTE_ORDER__ or __ORDER_..._ENDIAN__ is not defined"
+#warning "__BYTE_ORDER__ or __ORDER_..._ENDIAN__ is not defined"
 #endif /* __BYTE_ORDER__ */
 
 /* Define generic types used in lwIP */

--- a/src/core/util/vtypes.h
+++ b/src/core/util/vtypes.h
@@ -55,7 +55,7 @@
 #endif
 
 #if !defined(__BYTE_ORDER__) || !defined(__ORDER_LITTLE_ENDIAN__) || !defined(__ORDER_BIG_ENDIAN__)
-#error "__BYTE_ORDER__ or __ORDER_..._ENDIAN__ is not defined"
+#warning "__BYTE_ORDER__ or __ORDER_..._ENDIAN__ is not defined"
 #endif
 
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__


### PR DESCRIPTION
## Description
cppcheck skips most of the files from scanning and returns successfully. This potentially hides issues that can be detected in CI.

Replace `#error` with `#warning` in the endianness check to allow cppcheck to find a working configuration.

`#warning` still fails the compilation process, so we won't miss a wrong endianness configuration.

##### What
Replace `#error` with `#warning` in the endianness check to allow cppcheck to find a working configuration.

##### Why ?
Fix cppcheck job in CI.

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

