### PR TITLE
issue: 3832212 Print a deprecation warning for XLIO_TX/RX_BUFS

### DIFF
--- a/src/core/util/sys_vars.cpp
+++ b/src/core/util/sys_vars.cpp
@@ -2001,6 +2001,15 @@ void mce_sys_var::get_env_params()
         }
         multilock = (multilock_t)temp;
     }
+
+    std::vector<const char *> deprecated_params = {SYS_VAR_TX_NUM_BUFS, SYS_VAR_RX_NUM_BUFS};
+    for (const char *param : deprecated_params) {
+        env_ptr = getenv(param);
+        if (env_ptr) {
+            vlog_printf(VLOG_WARNING,
+                        "%s is deprecated and will be removed in the future versions\n", param);
+        }
+    }
 }
 
 void set_env_params()


### PR DESCRIPTION
## Description
Parameters XLIO_TX_BUFS and XLIO_RX_BUFS are deprecated and will be removed in the future.

##### What
Print a deprecation warning if user sets XLIO_TX_BUFS or XLIO_RX_BUFS.

##### Why ?
Warn user about future parameters removal.

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

