### PR TITLE
issue: 3928407 Remove VLAs

### DIFF
--- a/config/m4/compiler.m4
+++ b/config/m4/compiler.m4
@@ -82,7 +82,7 @@ case $CC in
         CFLAGS="$CFLAGS -Wall -Werror -Wno-self-assign"
         CXXFLAGS="$CXXFLAGS -Wall -Werror"
         # workaround for clang w/o -Wnon-c-typedef-for-linkage
-        CXXFLAGS="$CXXFLAGS -Wno-unknown-warning-option -Wno-non-c-typedef-for-linkage -Wno-vla-cxx-extension"
+        CXXFLAGS="$CXXFLAGS -Wno-unknown-warning-option -Wno-non-c-typedef-for-linkage"
         ;;
     *)
         AC_MSG_RESULT([unknown])

--- a/src/core/dev/net_device_table_mgr.cpp
+++ b/src/core/dev/net_device_table_mgr.cpp
@@ -470,7 +470,7 @@ void net_device_table_mgr::global_ring_wait_for_notification_and_process_element
     uint64_t *p_poll_sn, void *pv_fd_ready_array /*=NULL*/)
 {
     ndtm_logfunc("");
-    int max_fd = 16;
+    constexpr int max_fd = 16;
     struct epoll_event events[max_fd];
 
     int res = SYSCALL(epoll_wait, global_ring_epfd_get(), events, max_fd, 0);

--- a/src/core/dev/net_device_val.h
+++ b/src/core/dev/net_device_val.h
@@ -263,7 +263,7 @@ private:
     resource_allocation_key *get_ring_key_redirection(resource_allocation_key *key);
     void ring_key_redirection_release(resource_allocation_key *key);
     void print_ips();
-    bool get_up_and_active_slaves(bool *up_and_active_slaves, size_t size);
+    bool get_up_and_active_slaves(); /* Returns true if a slave status is changed */
     void configure();
 
     /* See: RFC 3549 2.3.3.1. */

--- a/src/core/infra/sender.cpp
+++ b/src/core/infra/sender.cpp
@@ -6,7 +6,7 @@
 
 #include "core/infra/sender.h"
 
-neigh_send_data::neigh_send_data(iovec *iov, size_t sz, header *hdr, uint32_t mtu,
+neigh_send_data::neigh_send_data(const iovec *iov, size_t sz, header *hdr, uint32_t mtu,
                                  uint32_t packet_id)
     : m_header(hdr->copy())
     , m_mtu(mtu)

--- a/src/core/infra/sender.h
+++ b/src/core/infra/sender.h
@@ -17,7 +17,7 @@ class event;
 
 class neigh_send_data {
 public:
-    neigh_send_data(iovec *iov, size_t sz, header *hdr, uint32_t mtu, uint32_t packet_id);
+    neigh_send_data(const iovec *iov, size_t sz, header *hdr, uint32_t mtu, uint32_t packet_id);
 
     neigh_send_data(neigh_send_data &&snd_data);
 

--- a/src/core/proto/dst_entry.cpp
+++ b/src/core/proto/dst_entry.cpp
@@ -700,8 +700,7 @@ ssize_t dst_entry::pass_pkt_to_neigh(const iovec *p_iov, size_t sz_iov, uint32_t
     if (m_p_neigh_entry && dummy) {
         configure_eth_headers(m_header_neigh, *dummy, *dummy, m_p_net_dev_val->get_vlan());
 
-        neigh_send_data n_send_info(const_cast<iovec *>(p_iov), sz_iov, m_header_neigh,
-                                    get_route_mtu(), packet_id);
+        neigh_send_data n_send_info(p_iov, sz_iov, m_header_neigh, get_route_mtu(), packet_id);
         ret_val = m_p_neigh_entry->send(n_send_info);
     }
 

--- a/src/core/proto/dst_entry.h
+++ b/src/core/proto/dst_entry.h
@@ -67,8 +67,8 @@ public:
     bool prepare_to_send(struct xlio_rate_limit_t &rate_limit, bool skip_rules = false,
                          bool skip_resolve_ring = false);
     void generate_id();
-    virtual ssize_t fast_send(const iovec *p_iov, const ssize_t sz_iov, xlio_send_attr attr) = 0;
-    virtual ssize_t slow_send(const iovec *p_iov, const ssize_t sz_iov, xlio_send_attr attr,
+    virtual ssize_t fast_send(const iovec *p_iov, size_t sz_iov, xlio_send_attr attr) = 0;
+    virtual ssize_t slow_send(const iovec *p_iov, size_t sz_iov, xlio_send_attr attr,
                               struct xlio_rate_limit_t &rate_limit, int flags = 0,
                               sockinfo *sock = nullptr, tx_call_t call_type = TX_UNDEF) = 0;
 

--- a/src/core/proto/dst_entry_tcp.cpp
+++ b/src/core/proto/dst_entry_tcp.cpp
@@ -37,7 +37,7 @@ transport_t dst_entry_tcp::get_transport(const sock_addr &to)
     return TRANS_XLIO;
 }
 
-ssize_t dst_entry_tcp::fast_send(const iovec *p_iov, const ssize_t sz_iov, xlio_send_attr attr)
+ssize_t dst_entry_tcp::fast_send(const iovec *p_iov, size_t sz_iov, xlio_send_attr attr)
 {
     int ret = 0;
     void *p_pkt;
@@ -187,7 +187,7 @@ ssize_t dst_entry_tcp::fast_send(const iovec *p_iov, const ssize_t sz_iov, xlio_
          * needed for processing send wr completion (tx batching mode)
          */
         ib_ctx_handler *ib_ctx = m_p_ring->get_ctx(m_id);
-        for (int i = 0; i < sz_iov; ++i) {
+        for (size_t i = 0; i < sz_iov; ++i) {
             m_sge[i].addr = (uintptr_t)p_tcp_iov[i].iovec.iov_base;
             m_sge[i].length = p_tcp_iov[i].iovec.iov_len;
             if (is_zerocopy) {
@@ -228,7 +228,7 @@ ssize_t dst_entry_tcp::fast_send(const iovec *p_iov, const ssize_t sz_iov, xlio_
         // of the copy
         total_packet_len = m_header->m_aligned_l2_l3_len;
 
-        for (int i = 0; i < sz_iov; ++i) {
+        for (size_t i = 0; i < sz_iov; ++i) {
             memcpy(p_mem_buf_desc->p_buffer + total_packet_len, p_tcp_iov[i].iovec.iov_base,
                    p_tcp_iov[i].iovec.iov_len);
             total_packet_len += p_tcp_iov[i].iovec.iov_len;
@@ -266,7 +266,7 @@ out:
     return ret;
 }
 
-ssize_t dst_entry_tcp::slow_send(const iovec *p_iov, const ssize_t sz_iov, xlio_send_attr attr,
+ssize_t dst_entry_tcp::slow_send(const iovec *p_iov, size_t sz_iov, xlio_send_attr attr,
                                  struct xlio_rate_limit_t &rate_limit, int flags /*= 0*/,
                                  sockinfo *sock /*= 0*/, tx_call_t call_type /*= 0*/)
 {

--- a/src/core/proto/dst_entry_tcp.h
+++ b/src/core/proto/dst_entry_tcp.h
@@ -22,8 +22,8 @@ public:
                   resource_allocation_key &ring_alloc_logic);
     virtual ~dst_entry_tcp();
 
-    ssize_t fast_send(const iovec *p_iov, const ssize_t sz_iov, xlio_send_attr attr);
-    ssize_t slow_send(const iovec *p_iov, const ssize_t sz_iov, xlio_send_attr attr,
+    ssize_t fast_send(const iovec *p_iov, size_t sz_iov, xlio_send_attr attr);
+    ssize_t slow_send(const iovec *p_iov, size_t sz_iov, xlio_send_attr attr,
                       struct xlio_rate_limit_t &rate_limit, int flags = 0, sockinfo *sock = nullptr,
                       tx_call_t call_type = TX_UNDEF);
     ssize_t slow_send_neigh(const iovec *p_iov, size_t sz_iov,

--- a/src/core/proto/dst_entry_udp.cpp
+++ b/src/core/proto/dst_entry_udp.cpp
@@ -49,7 +49,7 @@ void dst_entry_udp::configure_headers()
 
 // Static function to server both neigh (slow) path and dst_entry (fast) path
 bool dst_entry_udp::fast_send_fragmented_ipv6(mem_buf_desc_t *p_mem_buf_desc, const iovec *p_iov,
-                                              const ssize_t sz_iov, xlio_wr_tx_packet_attr attr,
+                                              size_t sz_iov, xlio_wr_tx_packet_attr attr,
                                               size_t sz_udp_payload, int n_num_frags,
                                               xlio_ibv_send_wr *p_send_wqe, ring_user_id_t user_id,
                                               ibv_sge *p_sge, header *p_header,
@@ -168,7 +168,7 @@ bool dst_entry_udp::fast_send_fragmented_ipv6(mem_buf_desc_t *p_mem_buf_desc, co
     return true;
 }
 
-inline ssize_t dst_entry_udp::fast_send_not_fragmented(const iovec *p_iov, const ssize_t sz_iov,
+inline ssize_t dst_entry_udp::fast_send_not_fragmented(const iovec *p_iov, size_t sz_iov,
                                                        xlio_wr_tx_packet_attr attr,
                                                        size_t sz_udp_payload,
                                                        ssize_t sz_data_payload)
@@ -289,7 +289,7 @@ inline ssize_t dst_entry_udp::fast_send_not_fragmented(const iovec *p_iov, const
 }
 
 inline bool dst_entry_udp::fast_send_fragmented_ipv4(mem_buf_desc_t *p_mem_buf_desc,
-                                                     const iovec *p_iov, const ssize_t sz_iov,
+                                                     const iovec *p_iov, size_t sz_iov,
                                                      xlio_wr_tx_packet_attr attr,
                                                      size_t sz_udp_payload, int n_num_frags)
 {
@@ -396,7 +396,7 @@ inline bool dst_entry_udp::fast_send_fragmented_ipv4(mem_buf_desc_t *p_mem_buf_d
     return true;
 }
 
-ssize_t dst_entry_udp::fast_send_fragmented(const iovec *p_iov, const ssize_t sz_iov,
+ssize_t dst_entry_udp::fast_send_fragmented(const iovec *p_iov, size_t sz_iov,
                                             xlio_wr_tx_packet_attr attr, size_t sz_udp_payload,
                                             ssize_t sz_data_payload)
 {
@@ -448,7 +448,7 @@ ssize_t dst_entry_udp::fast_send_fragmented(const iovec *p_iov, const ssize_t sz
     return sz_data_payload;
 }
 
-ssize_t dst_entry_udp::fast_send(const iovec *p_iov, const ssize_t sz_iov, xlio_send_attr attr)
+ssize_t dst_entry_udp::fast_send(const iovec *p_iov, size_t sz_iov, xlio_send_attr attr)
 {
     /* Suppress flags that should not be used anymore
      * to avoid conflicts with XLIO_TX_PACKET_L3_CSUM and XLIO_TX_PACKET_L4_CSUM
@@ -467,7 +467,7 @@ ssize_t dst_entry_udp::fast_send(const iovec *p_iov, const ssize_t sz_iov, xlio_
     }
 }
 
-ssize_t dst_entry_udp::slow_send(const iovec *p_iov, const ssize_t sz_iov, xlio_send_attr attr,
+ssize_t dst_entry_udp::slow_send(const iovec *p_iov, size_t sz_iov, xlio_send_attr attr,
                                  struct xlio_rate_limit_t &rate_limit, int flags /*= 0*/,
                                  sockinfo *sock /*= 0*/, tx_call_t call_type /*= 0*/)
 {

--- a/src/core/proto/dst_entry_udp.h
+++ b/src/core/proto/dst_entry_udp.h
@@ -15,12 +15,12 @@ public:
                   resource_allocation_key &ring_alloc_logic);
     virtual ~dst_entry_udp();
 
-    ssize_t fast_send(const iovec *p_iov, const ssize_t sz_iov, xlio_send_attr attr);
-    ssize_t slow_send(const iovec *p_iov, const ssize_t sz_iov, xlio_send_attr attr,
+    ssize_t fast_send(const iovec *p_iov, size_t sz_iov, xlio_send_attr attr);
+    ssize_t slow_send(const iovec *p_iov, size_t sz_iov, xlio_send_attr attr,
                       struct xlio_rate_limit_t &rate_limit, int flags = 0, sockinfo *sock = nullptr,
                       tx_call_t call_type = TX_UNDEF);
     static bool fast_send_fragmented_ipv6(mem_buf_desc_t *p_mem_buf_desc, const iovec *p_iov,
-                                          const ssize_t sz_iov, xlio_wr_tx_packet_attr attr,
+                                          size_t sz_iov, xlio_wr_tx_packet_attr attr,
                                           size_t sz_udp_payload, int n_num_frags,
                                           xlio_ibv_send_wr *p_send_wqe, ring_user_id_t user_id,
                                           ibv_sge *p_sge, header *p_header,
@@ -42,18 +42,17 @@ private:
 
     inline uint32_t gen_packet_id_ip6() { return htonl(m_frag_tx_pkt_id++); }
 
-    inline ssize_t fast_send_not_fragmented(const iovec *p_iov, const ssize_t sz_iov,
+    inline ssize_t fast_send_not_fragmented(const iovec *p_iov, size_t sz_iov,
                                             xlio_wr_tx_packet_attr attr, size_t sz_udp_payload,
                                             ssize_t sz_data_payload);
     inline bool fast_send_fragmented_ipv4(mem_buf_desc_t *p_mem_buf_desc, const iovec *p_iov,
-                                          const ssize_t sz_iov, xlio_wr_tx_packet_attr attr,
+                                          size_t sz_iov, xlio_wr_tx_packet_attr attr,
                                           size_t sz_udp_payload, int n_num_frags);
     inline bool fast_send_fragmented_ipv6(mem_buf_desc_t *p_mem_buf_desc, const iovec *p_iov,
-                                          const ssize_t sz_iov, xlio_wr_tx_packet_attr attr,
+                                          size_t sz_iov, xlio_wr_tx_packet_attr attr,
                                           size_t sz_udp_payload, int n_num_frags);
-    ssize_t fast_send_fragmented(const iovec *p_iov, const ssize_t sz_iov,
-                                 xlio_wr_tx_packet_attr attr, size_t sz_udp_payload,
-                                 ssize_t sz_data_payload);
+    ssize_t fast_send_fragmented(const iovec *p_iov, size_t sz_iov, xlio_wr_tx_packet_attr attr,
+                                 size_t sz_udp_payload, ssize_t sz_data_payload);
 
     uint32_t m_frag_tx_pkt_id = 0U;
     const uint32_t m_n_sysvar_tx_bufs_batch_udp;

--- a/src/core/sock/sock-redirect.cpp
+++ b/src/core/sock/sock-redirect.cpp
@@ -483,7 +483,7 @@ static ssize_t sendfile_helper(sockinfo *p_socket_object, int in_fd, __off64_t *
 
         /* fallback on read() approach */
         if (totSent == 0) {
-            char buf[sysconf(_SC_PAGE_SIZE)];
+            std::vector<char> buf(sysconf(_SC_PAGE_SIZE));
             ssize_t toRead, numRead, numSent = 0;
 
             if (s->get_sock_stats()) {
@@ -491,8 +491,8 @@ static ssize_t sendfile_helper(sockinfo *p_socket_object, int in_fd, __off64_t *
             }
 
             while (count > 0) {
-                toRead = min(sizeof(buf), count);
-                numRead = pread(in_fd, buf, toRead, cur_offset + totSent);
+                toRead = min(buf.size(), count);
+                numRead = pread(in_fd, buf.data(), toRead, cur_offset + totSent);
                 if (numRead <= 0) {
                     if (numRead < 0 && totSent == 0) {
                         totSent = -1;
@@ -500,7 +500,7 @@ static ssize_t sendfile_helper(sockinfo *p_socket_object, int in_fd, __off64_t *
                     break;
                 }
 
-                piov[0].iov_base = (void *)buf;
+                piov[0].iov_base = (void *)buf.data();
                 piov[0].iov_len = numRead;
 
                 numSent = p_socket_object->tx(tx_arg);

--- a/src/core/sock/sockinfo_tcp.cpp
+++ b/src/core/sock/sockinfo_tcp.cpp
@@ -1678,12 +1678,12 @@ err_t sockinfo_tcp::ip_output(struct pbuf *p, struct tcp_seg *seg, void *v_p_con
 {
     sockinfo_tcp *p_si_tcp = (sockinfo_tcp *)(((struct tcp_pcb *)v_p_conn)->my_container);
     dst_entry *p_dst = p_si_tcp->m_p_connected_dst_entry;
-    int max_count = p_si_tcp->m_pcb.tso.max_send_sge;
-    tcp_iovec lwip_iovec[max_count];
+    unsigned count = 0;
+    unsigned max_count = std::min(p_si_tcp->m_pcb.tso.max_send_sge, 32U);
+    tcp_iovec lwip_iovec[32];
     xlio_send_attr attr = {
         (xlio_wr_tx_packet_attr)(flags | (!!p_si_tcp->is_xlio_socket() * XLIO_TX_SKIP_POLL)),
         p_si_tcp->m_pcb.mss, 0, nullptr};
-    int count = 0;
 
     if (unlikely(flags & XLIO_TX_PACKET_REXMIT)) {
         if (unlikely(inspect_socket_error_state(reinterpret_cast<const mem_buf_desc_t *>(seg->p),
@@ -1767,13 +1767,15 @@ send_iov:
 err_t sockinfo_tcp::ip_output_syn_ack(struct pbuf *p, struct tcp_seg *seg, void *v_p_conn,
                                       uint16_t flags)
 {
-    iovec iovec[64];
-    struct iovec *p_iovec = iovec;
+    iovec iov[32];
+    constexpr unsigned max_iov = ARRAY_SIZE(iov);
+
+    struct iovec *p_iov = iov;
     tcp_iovec tcp_iovec_temp; // currently we pass p_desc only for 1 size iovec, since for bigger
                               // size we allocate new buffers
     sockinfo_tcp *p_si_tcp = (sockinfo_tcp *)(((struct tcp_pcb *)v_p_conn)->my_container);
     dst_entry *p_dst = p_si_tcp->m_p_connected_dst_entry;
-    int count = 1;
+    unsigned count = 1;
     xlio_wr_tx_packet_attr attr;
 
     NOT_IN_USE(seg);
@@ -1784,17 +1786,17 @@ err_t sockinfo_tcp::ip_output_syn_ack(struct pbuf *p, struct tcp_seg *seg, void 
         tcp_iovec_temp.iovec.iov_len = p->len;
         tcp_iovec_temp.p_desc = (mem_buf_desc_t *)p;
         __log_dbg("p_desc=%p,p->len=%d ", p, p->len);
-        p_iovec = (struct iovec *)&tcp_iovec_temp;
+        p_iov = (struct iovec *)&tcp_iovec_temp;
     } else {
-        for (count = 0; count < 64 && p; ++count) {
-            iovec[count].iov_base = p->payload;
-            iovec[count].iov_len = p->len;
+        for (count = 0; count < max_iov && p; ++count) {
+            iov[count].iov_base = p->payload;
+            iov[count].iov_len = p->len;
             p = p->next;
         }
 
         // We don't expect pbuf chain at all
-        if (p) {
-            vlog_printf(VLOG_ERROR, "pbuf chain size > 64!!! silently dropped.\n");
+        if (unlikely(p)) {
+            vlog_printf(VLOG_ERROR, "pbuf chain size > %u!!! silently dropped.\n", max_iov);
             return ERR_OK;
         }
     }
@@ -1804,7 +1806,7 @@ err_t sockinfo_tcp::ip_output_syn_ack(struct pbuf *p, struct tcp_seg *seg, void 
         p_si_tcp->m_p_socket_stats->counters.n_tx_retransmits++;
     }
 
-    ((dst_entry_tcp *)p_dst)->slow_send_neigh(p_iovec, count, p_si_tcp->m_so_ratelimit);
+    ((dst_entry_tcp *)p_dst)->slow_send_neigh(p_iov, count, p_si_tcp->m_so_ratelimit);
 
     return ERR_OK;
 }

--- a/src/core/util/utils.cpp
+++ b/src/core/util/utils.cpp
@@ -139,7 +139,7 @@ int get_base_interface_name(const char *if_name, char *base_ifname, size_t sz_ba
                 }
             }
 
-            unsigned char tmp_mac[ADDR_LEN];
+            unsigned char tmp_mac[MAX_L2_ADDR_LEN];
             if (ADDR_LEN == get_local_ll_addr(ifa->ifa_name, tmp_mac, ADDR_LEN, false)) {
                 int size_to_compare = 0;
                 if (ADDR_LEN == ETH_ALEN) {

--- a/src/stats/stats_reader.cpp
+++ b/src/stats/stats_reader.cpp
@@ -2383,9 +2383,12 @@ void get_all_processes_pids(std::vector<int> &pids)
 int print_processes_stats(const std::vector<int> &pids)
 {
     const int SIZE = pids.size();
-
     int num_instances = 0;
-    sh_mem_info_t sh_mem_info[SIZE];
+
+    sh_mem_info_t *sh_mem_info = new sh_mem_info_t[SIZE];
+    if (!sh_mem_info) {
+        return 1;
+    }
 
     // 1. N * prepare shmem and indicate XLIO to update shmem
     for (int i = 0; i < SIZE; ++i) {
@@ -2405,6 +2408,7 @@ int print_processes_stats(const std::vector<int> &pids)
         complete_print_process_stats(sh_mem_info[i]);
     }
 
+    delete[] sh_mem_info;
     return 0;
 }
 


### PR DESCRIPTION
## Description
clang-18 generates a warning that VLA is a clang extension.

- Remove VLAs
- Remove clang warning suppression from the build system
- Refactor net_device_val::get_up_and_active_slaves()
- Fix types in fast_send/slow_send/neigh_send_data

##### What
Remove VLAs.

##### Why ?
Fix clang-18 build.

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

