### PR TITLE
issue: 3928006 Remove unused XLIO_BF

### DIFF
--- a/README
+++ b/README
@@ -162,7 +162,6 @@ Example:
  XLIO DETAILS: UTLS RX support                Disabled                   [XLIO_UTLS_RX]
  XLIO DETAILS: UTLS TX support                Enabled                    [XLIO_UTLS_TX]
  XLIO DETAILS: LRO support                    auto                       [XLIO_LRO]
- XLIO DETAILS: BF (Blue Flame)                Enabled                    [XLIO_BF]
  XLIO DETAILS: Src port stirde                2                          [XLIO_SRC_PORT_STRIDE]
  XLIO DETAILS: Size of UDP socket pool        0                          [XLIO_NGINX_UDP_POOL_SIZE]
  XLIO DETAILS: Number of Nginx workers        0                          [XLIO_NGINX_WORKERS_NUM]
@@ -981,10 +980,6 @@ This parameter indicates number of msec to wait between every UC ARP.
 XLIO_NEIGH_NUM_ERR_RETRIES
 This number indicates number of retries to restart neigh state machine in case neigh got ERROR event.
 Default value is 1
-
-XLIO_BF
-This flag enables / disables BF (Blue Flame) usage of the ConnectX
-Default value is 1 (Enabled)
 
 XLIO_FORK
 Control whether XLIO should support fork. Setting this flag on will cause XLIO to

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -813,8 +813,6 @@ void print_xlio_global_settings()
     VLOG_STR_PARAM_STRING("LRO support", option_3::to_str(safe_mce_sys().enable_lro),
                           option_3::to_str(MCE_DEFAULT_LRO), SYS_VAR_LRO,
                           option_3::to_str(safe_mce_sys().enable_lro));
-    VLOG_PARAM_STRING("BF (Blue Flame)", safe_mce_sys().handle_bf, MCE_DEFAULT_BF_FLAG, SYS_VAR_BF,
-                      safe_mce_sys().handle_bf ? "Enabled " : "Disabled");
 #ifdef DEFINED_UTLS
     VLOG_PARAM_STRING("UTLS RX support", safe_mce_sys().enable_utls_rx, MCE_DEFAULT_UTLS_RX,
                       SYS_VAR_UTLS_RX, safe_mce_sys().enable_utls_rx ? "Enabled " : "Disabled");

--- a/src/core/util/sys_vars.cpp
+++ b/src/core/util/sys_vars.cpp
@@ -876,7 +876,6 @@ void mce_sys_var::get_env_params()
 #endif /* DEFINED_UTLS */
     enable_lro = MCE_DEFAULT_LRO;
     handle_fork = MCE_DEFAULT_FORK_SUPPORT;
-    handle_bf = MCE_DEFAULT_BF_FLAG;
     close_on_dup2 = MCE_DEFAULT_CLOSE_ON_DUP2;
     mtu = MCE_DEFAULT_MTU;
 #if defined(DEFINED_NGINX)
@@ -1880,10 +1879,6 @@ void mce_sys_var::get_env_params()
         }
     }
 
-    if ((env_ptr = getenv(SYS_VAR_BF))) {
-        handle_bf = atoi(env_ptr) ? true : false;
-    }
-
     if ((env_ptr = getenv(SYS_VAR_FORK))) {
         handle_fork = atoi(env_ptr) ? true : false;
     }
@@ -2024,14 +2019,6 @@ void set_env_params()
      */
     setenv("MLX5_DEVICE_FATAL_CLEANUP", "1", 1);
     setenv("RDMAV_ALLOW_DISASSOC_DESTROY", "1", 1);
-
-    if (safe_mce_sys().handle_bf) {
-        setenv("MLX5_POST_SEND_PREFER_BF", "1", 1);
-    } else {
-        /* todo - these seem not to work if inline is on, since libmlx is doing (inl || bf) when
-         * deciding to bf*/
-        setenv("MLX5_POST_SEND_PREFER_BF", "0", 1);
-    }
 
     const char *ibv_alloc_type = "PREFER_CONTIG";
 

--- a/src/core/util/sys_vars.h
+++ b/src/core/util/sys_vars.h
@@ -465,7 +465,6 @@ public:
     char internal_thread_affinity_str[FILENAME_MAX];
     cpu_set_t internal_thread_affinity;
     bool internal_thread_arm_cq_enabled;
-    bool handle_bf;
     skip_poll_in_rx_t skip_poll_in_rx;
     multilock_t multilock;
 
@@ -661,7 +660,6 @@ extern mce_sys_var &safe_mce_sys();
 #define SYS_VAR_HEAP_METADATA_BLOCK       "XLIO_HEAP_METADATA_BLOCK"
 #define SYS_VAR_HUGEPAGE_SIZE             "XLIO_HUGEPAGE_SIZE"
 #define SYS_VAR_FORK                      "XLIO_FORK"
-#define SYS_VAR_BF                        "XLIO_BF"
 #define SYS_VAR_CLOSE_ON_DUP2             "XLIO_CLOSE_ON_DUP2"
 #define SYS_VAR_MTU                       "XLIO_MTU"
 #if defined(DEFINED_NGINX)
@@ -829,7 +827,6 @@ extern mce_sys_var &safe_mce_sys();
 #define MCE_DEFAULT_HUGEPAGE_SIZE                  (0)
 #define MCE_MAX_HUGEPAGE_SIZE                      (1ULL << 63ULL)
 #define MCE_DEFAULT_FORK_SUPPORT                   (true)
-#define MCE_DEFAULT_BF_FLAG                        (true)
 #define MCE_DEFAULT_CLOSE_ON_DUP2                  (true)
 #define MCE_DEFAULT_MTU                            (0)
 #if defined(DEFINED_NGINX)


### PR DESCRIPTION
## Description
Remove the XLIO_BF parameter as a leftover.

BlueFlame support has been removed. Besides, XLIO_BF was unused and an rdma-core specific env parameter was checked instead.

##### What
Remove the XLIO_BF parameter.

##### Why ?
Unused parameter.

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

