### PR TITLE
issue: tidy up the default values in README

### DIFF
--- a/README
+++ b/README
@@ -513,7 +513,7 @@ Default value is 0 (Disabled)
 XLIO_UTLS_TX
 When this parameter is enabled, XLIO offloads TLS TX path through kTLS API if
 possible. See XLIO_UTLS_RX for details.
-Default value is 1 (Enable)
+Default value is 1 (Enabled)
 
 XLIO_LRO
 Large receive offload (LRO) is a technique for increasing inbound throughput of
@@ -584,7 +584,7 @@ When an application is running with multiple threads, on a limited number of
 cores, there is a need for each thread polling inside the XLIO (read, readv,
 recv & recvfrom) to yield the CPU to other polling thread so not to starve
 them from processing incoming packets.
-Default value is 0 (Disable)
+Default value is 0 (Disabled)
 
 XLIO_RX_PREFETCH_BYTES
 Size of receive buffer to prefetch into cache while processing ingress packets.
@@ -612,25 +612,25 @@ rate is controls in nano-second resolution to prevent CPU consumption because
 of over CQ polling. This will enable a more 'real time' monitoring of the
 sockets ready packet queue.
 Recommended value is 100-5000 (nsec)
-Default value is 0 (Disable)
+Default value is 0 (Disabled)
 
 XLIO_TCP_ABORT_ON_CLOSE
 This parameter controls how XLIO performs socket close operation. If enabled,
 XLIO sends RST segment and discards TCP state for the socket. Notice, in this
 scenario pending data segments may be unsent.
 If disabled, XLIO sends pending data segments and then FIN segment.
-Default: 0 (Disable)
+Default: 0 (Disabled)
 
 XLIO_RX_POLL_ON_TX_TCP
 This parameter enables/disables TCP RX polling during TCP TX operation for faster
 TCP ACK reception.
-Default: 0 (Disable)
+Default: 0 (Disabled)
 
 XLIO_TRIGGER_DUMMY_SEND_GETSOCKNAME
 This parameter triggers dummy packet send from getsockname(), this
 will warm up the caches.
 For more information regarding dummy send, see XLIO user manual document.
-Default: 0 (Disable)
+Default: 0 (Disabled)
 
 XLIO_SKIP_POLL_IN_RX
 Allow TCP socket to skip CQ polling in rx socket call.
@@ -650,7 +650,7 @@ rules. This can improve performance for a server with listen socket which
 accepts many connections.
 Outgoing TCP connections that are established with connect() syscall aren't
 affected by this option.
-Default: 0 (Disable)
+Default: 0 (Disabled)
 
 XLIO_UDP_3T_RULES
 This parameter can be relevant in case application uses connected udp sockets.
@@ -658,7 +658,7 @@ This parameter can be relevant in case application uses connected udp sockets.
 5 tuple flow steering rule when it is disabled.
 Enabling this option can reduce hardware flow steering resources.
 But when it is disabled application might see benefits in latency and cycles per packet.
-Default: 1 (Enable)
+Default: 1 (Enabled)
 
 XLIO_ETH_MC_L2_ONLY_RULES
 Use only L2 rules for Ethernet Multicast.

--- a/README
+++ b/README
@@ -159,7 +159,7 @@ Example:
  XLIO DETAILS: Num of neigh restart retries   1                          [XLIO_NEIGH_NUM_ERR_RETRIES]
  XLIO DETAILS: SocketXtreme mode              Disabled                   [XLIO_SOCKETXTREME]
  XLIO DETAILS: TSO support                    auto                       [XLIO_TSO]
- XLIO DETAILS: UTLS RX support                Enabled                    [XLIO_UTLS_RX]
+ XLIO DETAILS: UTLS RX support                Disabled                   [XLIO_UTLS_RX]
  XLIO DETAILS: UTLS TX support                Enabled                    [XLIO_UTLS_TX]
  XLIO DETAILS: LRO support                    auto                       [XLIO_LRO]
  XLIO DETAILS: BF (Blue Flame)                Enabled                    [XLIO_BF]
@@ -508,7 +508,7 @@ XLIO_UTLS_RX
 UTLS provides TLS data path acceleration. This is achieved by offloading Linux
 kTLS API. Refer to your TLS library documentation for kTLS support information.
 When this parameter is enabled, XLIO offloads TLS RX path if possible.
-Default value is 1 (Enable)
+Default value is 0 (Disabled)
 
 XLIO_UTLS_TX
 When this parameter is enabled, XLIO offloads TLS TX path through kTLS API if


### PR DESCRIPTION
## Description
Correct the default value of XLIO_UTLS_RX. Force a single convention for Enabled/Disabled .

##### What
Correct the default value of XLIO_UTLS_RX. Force a single convention for Enabled/Disabled .

##### Why ?
Tidy up the documentation.

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

