### PR TITLE
issue-HPCINFRA-2196 [CI]: move HW-dependent tests to k8s

### DIFF
--- a/.ci/dockerfiles/Dockerfile.ub2204
+++ b/.ci/dockerfiles/Dockerfile.ub2204
@@ -39,10 +39,8 @@ RUN apt-get update && \
         iproute2 gdb \
         curl \
         libcap-dev \
+        librdmacm-dev \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
-
-RUN mkdir -p /opt/mellanox/rivermax && \
-    curl -o /opt/mellanox/rivermax/rivermax.lic https://urm.nvidia.com/artifactory/sw-rivermax-generic-local/license/rivermax.lic
 
 RUN pip3 install --trusted-host pypi.org --trusted-host pypi.python.org --trusted-host files.pythonhosted.org --upgrade pip && \
     pip3 install wheel && \
@@ -56,9 +54,6 @@ RUN echo "${_LOGIN} ALL=(ALL) NOPASSWD: ALL\nroot ALL=(ALL) NOPASSWD: ALL" >> /e
     useradd -u "$_UID" -g "$_GID" -s /bin/bash -m -d ${_HOME} "$_LOGIN" && \
     usermod -aG sudo $_LOGIN && \
     chown -R ${_LOGIN} ${_HOME}
-
-# W/A for libvma installation issue under docker environment
-RUN touch /etc/init.d/vma && chmod +x /etc/init.d/vma
 
 ENV MODULEPATH /hpc/local/etc/modulefiles
 SHELL ["/bin/bash"]

--- a/.ci/dockerfiles/Dockerfile.ub2204
+++ b/.ci/dockerfiles/Dockerfile.ub2204
@@ -1,0 +1,67 @@
+FROM ubuntu:22.04
+ARG _UID=6213
+ARG _GID=101
+ARG _LOGIN=swx-jenkins
+ARG _HOME=/var/home/$_LOGIN
+ARG http_proxy=http://10.210.9.1:3128/
+ARG https_proxy=http://10.210.9.1:3128/
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y \
+        sudo \
+        automake \
+        default-jdk \
+        dh-make \
+        g++ \
+        git \
+        libcap2 \
+        libnuma-dev \
+        libtool \
+        make \
+        maven \
+        udev \
+        wget \
+        vim \
+        cpio \
+        net-tools \
+        iputils-ping \
+        environment-modules \
+        libibverbs-dev \
+        libfile-fcntllock-perl \
+        chrpath flex gfortran graphviz dpatch libgfortran5 tcl bison tk swig \
+        libnl-route-3-dev libnl-3-dev kmod python3 lsof pciutils ethtool libmnl0 pkg-config \
+        lsb-release \
+        python3-pip \
+        libavahi-compat-libdnssd-dev \
+        doxygen graphviz \
+        iproute2 gdb \
+        curl \
+        libcap-dev \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /opt/mellanox/rivermax && \
+    curl -o /opt/mellanox/rivermax/rivermax.lic https://urm.nvidia.com/artifactory/sw-rivermax-generic-local/license/rivermax.lic
+
+RUN pip3 install --trusted-host pypi.org --trusted-host pypi.python.org --trusted-host files.pythonhosted.org --upgrade pip && \
+    pip3 install wheel && \
+    pip3 install cmake conan~=2.0.5
+
+RUN echo "Host *\n\tHostkeyAlgorithms +ssh-rsa\n\tPubkeyAcceptedAlgorithms +ssh-rsa" >> /etc/ssh/ssh_config
+
+RUN echo "${_LOGIN} ALL=(ALL) NOPASSWD: ALL\nroot ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \
+    mkdir -p $_HOME && \
+    groupadd -f -g "$_GID" "$_LOGIN" && \
+    useradd -u "$_UID" -g "$_GID" -s /bin/bash -m -d ${_HOME} "$_LOGIN" && \
+    usermod -aG sudo $_LOGIN && \
+    chown -R ${_LOGIN} ${_HOME}
+
+# W/A for libvma installation issue under docker environment
+RUN touch /etc/init.d/vma && chmod +x /etc/init.d/vma
+
+ENV MODULEPATH /hpc/local/etc/modulefiles
+SHELL ["/bin/bash"]
+
+USER "$_LOGIN"
+ENTRYPOINT [ "/bin/bash", "--login", "--rcfile", "/etc/bashrc", "-c" ]

--- a/.ci/matrix_job.yaml
+++ b/.ci/matrix_job.yaml
@@ -11,7 +11,7 @@ kubernetes:
   privileged: false
   cloud: swx-k8s-spray
   nodeSelector: 'beta.kubernetes.io/os=linux'
-  namespace: xlio-ci
+  namespace: 'xlio-ci'
   limits: '{memory: 8Gi, cpu: 7000m}'
   requests: '{memory: 8Gi, cpu: 7000m}'
 
@@ -69,7 +69,47 @@ runs_on_dockers:
      uri: '$arch/$name',
      tag: '20240703',
      build_args: '--no-cache',
-     category: 'tool'
+     category: 'tool',
+     }
+  - {file: '.ci/dockerfiles/Dockerfile.ub2204',
+     arch: 'x86_64',
+     name: 'xlio_tests.gtests',
+     uri: '$arch/$name',
+     tag: '20242905',
+     build_args: '--no-cache',
+     category: 'tool',
+     annotations: [{ key: 'k8s.v1.cni.cncf.io/networks', value: 'sriov-cx6dx-p2' }],
+     limits: '{memory: 8Gi, cpu: 8000m, mellanox.com/sriov_cx6dx_p2: 1}',
+     requests: '{memory: 8Gi, cpu: 8000m, mellanox.com/sriov_cx6dx_p2: 1}',
+     caps_add: '[ IPC_LOCK, SYS_RESOURCE ]',
+     runAsUser: '0',
+     runAsGroup: '0'
+     }
+  - {file: '.ci/dockerfiles/Dockerfile.ub2204',
+     arch: 'x86_64',
+     name: 'xlio_tests.test',
+     uri: '$arch/$name',
+     tag: '20242905',
+     build_args: '--no-cache',
+     category: 'tool',
+     annotations: [{ key: 'k8s.v1.cni.cncf.io/networks', value: 'sriov-cx6dx-p2' }],
+     limits: '{memory: 8Gi, cpu: 8000m, mellanox.com/sriov_cx6dx_p2: 1}',
+     requests: '{memory: 8Gi, cpu: 8000m, mellanox.com/sriov_cx6dx_p2: 1}',
+     runAsUser: '0',
+     runAsGroup: '0'
+     }
+  - {file: '.ci/dockerfiles/Dockerfile.ub2204',
+     arch: 'x86_64',
+     name: 'xlio_tests.valgrind',
+     uri: '$arch/$name',
+     tag: '20242905',
+     build_args: '--no-cache',
+     category: 'tool',
+     annotations: [{ key: 'k8s.v1.cni.cncf.io/networks', value: 'sriov-cx6dx-p2' }],
+     limits: '{memory: 8Gi, cpu: 8000m, mellanox.com/sriov_cx6dx_p2: 1}',
+     requests: '{memory: 8Gi, cpu: 8000m, mellanox.com/sriov_cx6dx_p2: 1}',
+     runAsUser: '0',
+     runAsGroup: '0'
      }
 
 runs_on_agents:
@@ -294,9 +334,9 @@ steps:
   - name: Test
     enable: ${do_test}
     containerSelector:
-      - "{name: 'skip-container'}"
+      - "{name: 'xlio_tests.test', category:'tool'}"
     agentSelector:
-      - "{nodeLabel: 'beni09'}"
+      - "{nodeLabel: 'skip-agent'}"
     run: |
       [ "x${do_test}" == "xtrue" ] && action=yes || action=no
       env WORKSPACE=$PWD TARGET=${flags} jenkins_test_run=${action} ./contrib/test_jenkins.sh
@@ -311,9 +351,9 @@ steps:
   - name: Gtest
     enable: ${do_gtest}
     containerSelector:
-      - "{name: 'skip-container'}"
+      - "{name: 'xlio_tests.gtests', category:'tool'}"
     agentSelector:
-      - "{nodeLabel: 'beni09'}"
+      - "{nodeLabel: 'skip-agent'}"
     run: |
       [ "x${do_gtest}" == "xtrue" ] && action=yes || action=no
       env WORKSPACE=$PWD TARGET=${flags} jenkins_test_gtest=${action} ./contrib/test_jenkins.sh
@@ -330,9 +370,9 @@ steps:
   - name: Valgrind
     enable: ${do_valgrind}
     containerSelector:
-      - "{name: 'skip-container'}"
+      - "{name: 'xlio_tests.valgrind', category:'tool'}"
     agentSelector:
-      - "{nodeLabel: 'beni09'}"
+      - "{nodeLabel: 'skip-agent'}"
     run: |
       [ "x${do_valgrind}" == "xtrue" ] && action=yes || action=no
       env WORKSPACE=$PWD TARGET=${flags} jenkins_test_vg=${action} ./contrib/test_jenkins.sh

--- a/.ci/matrix_job.yaml
+++ b/.ci/matrix_job.yaml
@@ -34,53 +34,53 @@ volumes:
   - {mountPath: /var/home/swx-jenkins, hostPath: /labhome/swx-jenkins}
 
 runs_on_dockers:
-# mofed
-  - {name: 'ub20.04-mofed-x86_64', url: 'harbor.mellanox.com/swx-infra/x86_64/ubuntu20.04/builder:mofed-5.2-2.2.0.0', category: 'base', arch: 'x86_64'}
-  - {name: 'ub20.04-mofed-aarch64', url: 'harbor.mellanox.com/swx-infra/aarch64/ubuntu20.04/builder:mofed-5.2-1.0.4.0', category: 'base', arch: 'aarch64'}
-  - {name: 'ub22.04-mofed-x86_64', url: 'harbor.mellanox.com/hpcx/x86_64/ubuntu22.04/builder:mofed-5.7-0.1.1.0', category: 'base', arch: 'x86_64'}
-  - {name: 'rhel8.6-mofed-x86_64',  url: 'harbor.mellanox.com/hpcx/x86_64/rhel8.6/builder:mofed-5.6-0.4.5.0', category: 'base', arch: 'x86_64'}
-  - {name: 'ub24.04-mofed-x86_64', url: 'harbor.mellanox.com/hpcx/x86_64/ubuntu24.04/builder:mofed-24.04-0.6.6.0', category: 'base', arch: 'x86_64'}
-  - {name: 'ub24.04-mofed-aarch64', url: 'harbor.mellanox.com/hpcx/aarch64/ubuntu24.04/builder:mofed-24.04-0.6.6.0', category: 'base', arch: 'aarch64'}
-  #  - {name: 'oracle8.6-mofed-x86_64',  url: 'harbor.mellanox.com/rivermax/base_oraclelinux8.6:mofed-5.9-0.3.4.0', category: 'base', arch: 'x86_64'}
-# tool
-  - {name: 'toolbox', url: 'harbor.mellanox.com/hpcx/x86_64/rhel8.6/builder:inbox', category: 'tool', arch: 'x86_64'}
-  - {name: 'blackduck', url: 'harbor.mellanox.com/toolbox/ngci-centos:7.9.2009.2', category: 'tool', arch: 'x86_64'}
-  - {name: 'header-check', url: 'harbor.mellanox.com/toolbox/header_check:0.0.14', category: 'tool', arch: 'x86_64', tag: '0.0.14'}
-# static tests
-  - {file: '.ci/dockerfiles/Dockerfile.rhel8.6',
-     arch: 'x86_64',
-     name: 'xlio_static.cppcheck',
-     uri: '$arch/$name',
-     tag: '20240703',
-     build_args: '--no-cache',
-     category: 'tool'
-     }
-  - {file: '.ci/dockerfiles/Dockerfile.rhel8.6',
-     arch: 'x86_64',
-     name: 'xlio_static.csbuild',
-     uri: '$arch/$name',
-     tag: '20240703',
-     build_args: '--no-cache',
-     category: 'tool'
-     }
-  - {file: '.ci/dockerfiles/Dockerfile.rhel8.6',
-     arch: 'x86_64',
-     name: 'xlio_static.tidy',
-     uri: '$arch/$name',
-     tag: '20240703',
-     build_args: '--no-cache',
-     category: 'tool',
-     }
+# # mofed
+#   - {name: 'ub20.04-mofed-x86_64', url: 'harbor.mellanox.com/swx-infra/x86_64/ubuntu20.04/builder:mofed-5.2-2.2.0.0', category: 'base', arch: 'x86_64'}
+#   - {name: 'ub20.04-mofed-aarch64', url: 'harbor.mellanox.com/swx-infra/aarch64/ubuntu20.04/builder:mofed-5.2-1.0.4.0', category: 'base', arch: 'aarch64'}
+#   - {name: 'ub22.04-mofed-x86_64', url: 'harbor.mellanox.com/hpcx/x86_64/ubuntu22.04/builder:mofed-5.7-0.1.1.0', category: 'base', arch: 'x86_64'}
+#   - {name: 'rhel8.6-mofed-x86_64',  url: 'harbor.mellanox.com/hpcx/x86_64/rhel8.6/builder:mofed-5.6-0.4.5.0', category: 'base', arch: 'x86_64'}
+#   - {name: 'ub24.04-mofed-x86_64', url: 'harbor.mellanox.com/hpcx/x86_64/ubuntu24.04/builder:mofed-24.04-0.6.6.0', category: 'base', arch: 'x86_64'}
+#   - {name: 'ub24.04-mofed-aarch64', url: 'harbor.mellanox.com/hpcx/aarch64/ubuntu24.04/builder:mofed-24.04-0.6.6.0', category: 'base', arch: 'aarch64'}
+#   #  - {name: 'oracle8.6-mofed-x86_64',  url: 'harbor.mellanox.com/rivermax/base_oraclelinux8.6:mofed-5.9-0.3.4.0', category: 'base', arch: 'x86_64'}
+# # tool
+#   - {name: 'toolbox', url: 'harbor.mellanox.com/hpcx/x86_64/rhel8.6/builder:inbox', category: 'tool', arch: 'x86_64'}
+#   - {name: 'blackduck', url: 'harbor.mellanox.com/toolbox/ngci-centos:7.9.2009.2', category: 'tool', arch: 'x86_64'}
+#   - {name: 'header-check', url: 'harbor.mellanox.com/toolbox/header_check:0.0.14', category: 'tool', arch: 'x86_64', tag: '0.0.14'}
+# # static tests
+#   - {file: '.ci/dockerfiles/Dockerfile.rhel8.6',
+#      arch: 'x86_64',
+#      name: 'xlio_static.cppcheck',
+#      uri: '$arch/$name',
+#      tag: '20240703',
+#      build_args: '--no-cache',
+#      category: 'tool'
+#      }
+#   - {file: '.ci/dockerfiles/Dockerfile.rhel8.6',
+#      arch: 'x86_64',
+#      name: 'xlio_static.csbuild',
+#      uri: '$arch/$name',
+#      tag: '20240703',
+#      build_args: '--no-cache',
+#      category: 'tool'
+#      }
+#   - {file: '.ci/dockerfiles/Dockerfile.rhel8.6',
+#      arch: 'x86_64',
+#      name: 'xlio_static.tidy',
+#      uri: '$arch/$name',
+#      tag: '20240703',
+#      build_args: '--no-cache',
+#      category: 'tool',
+#      }
   - {file: '.ci/dockerfiles/Dockerfile.ub2204',
      arch: 'x86_64',
      name: 'xlio_tests.gtests',
      uri: '$arch/$name',
      tag: '20242905',
      build_args: '--no-cache',
-     category: 'tool',
-     annotations: [{ key: 'k8s.v1.cni.cncf.io/networks', value: 'sriov-cx6dx-p2' }],
-     limits: '{memory: 8Gi, cpu: 8000m, mellanox.com/sriov_cx6dx_p2: 1}',
-     requests: '{memory: 8Gi, cpu: 8000m, mellanox.com/sriov_cx6dx_p2: 1}',
+     category: 'base',
+     annotations: [{ key: 'k8s.v1.cni.cncf.io/networks', value: 'sriov-cx6dx-p1' }],
+     limits: '{memory: 8Gi, cpu: 8000m, mellanox.com/sriov_cx6dx_p1: 1}',
+     requests: '{memory: 8Gi, cpu: 8000m, mellanox.com/sriov_cx6dx_p1: 1}',
      caps_add: '[ IPC_LOCK, SYS_RESOURCE ]',
      runAsUser: '0',
      runAsGroup: '0'
@@ -91,7 +91,7 @@ runs_on_dockers:
      uri: '$arch/$name',
      tag: '20242905',
      build_args: '--no-cache',
-     category: 'tool',
+     category: 'base',
      annotations: [{ key: 'k8s.v1.cni.cncf.io/networks', value: 'sriov-cx6dx-p2' }],
      limits: '{memory: 8Gi, cpu: 8000m, mellanox.com/sriov_cx6dx_p2: 1}',
      requests: '{memory: 8Gi, cpu: 8000m, mellanox.com/sriov_cx6dx_p2: 1}',
@@ -104,7 +104,7 @@ runs_on_dockers:
      uri: '$arch/$name',
      tag: '20242905',
      build_args: '--no-cache',
-     category: 'tool',
+     category: 'base',
      annotations: [{ key: 'k8s.v1.cni.cncf.io/networks', value: 'sriov-cx6dx-p2' }],
      limits: '{memory: 8Gi, cpu: 8000m, mellanox.com/sriov_cx6dx_p2: 1}',
      requests: '{memory: 8Gi, cpu: 8000m, mellanox.com/sriov_cx6dx_p2: 1}',
@@ -112,8 +112,8 @@ runs_on_dockers:
      runAsGroup: '0'
      }
 
-runs_on_agents:
-  - {nodeLabel: 'beni09', category: 'base'}
+# runs_on_agents:
+#   - {nodeLabel: 'beni09', category: 'base'}
 
 matrix:
   axes:


### PR DESCRIPTION
## Description
Move Valgrind, gTests, Test steps to k8s cluster

##### What
This change moves the hw-dependent tests to the k8s cluster

##### Why ?
The HW host we're currently using for tests is highly utilized and shared with other projects, + we need to make changes that will affect others.

##### How ?
Adjust ci-demo part, add Dockerfile for tests

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

