### PR TITLE
issue: 3933912 Fix epoll ready list iteration

### DIFF
--- a/src/core/proto/mem_buf_desc.h
+++ b/src/core/proto/mem_buf_desc.h
@@ -79,7 +79,7 @@ public:
         , sz_buffer(size)
         , sz_data(0)
         , p_desc_owner(nullptr)
-        , unused_padding(0)
+        , unused_padding {0}
     {
         memset(&lwip_pbuf, 0, sizeof(lwip_pbuf));
         clear_transport_data();
@@ -236,7 +236,7 @@ public:
 
     atomic_t n_ref_count; // number of interested receivers (sockinfo) [can be modified only in
                           // cq_mgr_rx context]
-    uint64_t unused_padding; // Align the structure to the cache line boundary
+    uint64_t unused_padding[2]; // Align the structure to the cache line boundary
 };
 
 typedef xlio_list_t<mem_buf_desc_t, mem_buf_desc_t::buffer_node_offset> descq_t;


### PR DESCRIPTION
## Description
The recent xlio_list change introduced a bug into epoll ready list iteration: a socket can be removed from the list before getting the next item. This leads to iteration over a removed item causing endless loop.

As a fix, remember 'si_next' before removing a socket from the list.

Also align mem_buf_desc_t to the cache line boundary.

##### What
Fix epoll ready list iteration

##### Why ?
Bugfix.

## Change type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

