### PR TITLE
issue: 3949975 Fix -Wtemplate-id-cdtor in xlio_list

### DIFF
--- a/src/core/util/xlio_list.h
+++ b/src/core/util/xlio_list.h
@@ -112,7 +112,7 @@ public:
         }
     }
 
-    xlio_list_t<T, offset>(const xlio_list_t<T, offset> &other)
+    xlio_list_t(const xlio_list_t<T, offset> &other)
     {
         if (!other.empty()) {
             vlist_logwarn("Copy constructor is not supported for non-empty list! other.size=%zu",


### PR DESCRIPTION
## Description
Starting from gcc-14, it generates template-id-cdtor error on a constructor with a template id.

##### What
Fix gcc-14 build.

##### Why ?
Fix gcc-14 build.

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [x] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

