### PR TITLE
[DOCA] Add doca_mmap support for memory registration

### DIFF
--- a/src/core/dev/buffer_pool.cpp
+++ b/src/core/dev/buffer_pool.cpp
@@ -195,10 +195,10 @@ buffer_pool::~buffer_pool()
     xlio_stats_instance_remove_bpool_block(m_p_bpool_stat);
 }
 
-void buffer_pool::register_memory(ib_ctx_handler *p_ib_ctx_h)
+void buffer_pool::register_memory()
 {
-    if (!m_allocator_data.register_memory(p_ib_ctx_h)) {
-        __log_info_err("Failed to register memory for p_ib_ctx_h=%p", p_ib_ctx_h);
+    if (!m_allocator_data.register_memory()) {
+        __log_info_err("Failed to register memory");
     }
 }
 

--- a/src/core/dev/buffer_pool.h
+++ b/src/core/dev/buffer_pool.h
@@ -76,13 +76,13 @@ public:
                 free_t free_func = nullptr);
     ~buffer_pool();
 
-    void register_memory(ib_ctx_handler *p_ib_ctx_h);
+    void register_memory();
     void print_val_tbl();
     void print_report(vlog_levels_t log_level = VLOG_DEBUG);
     static void print_report_on_errors(vlog_levels_t log_level);
 
     uint32_t find_lkey_by_ib_ctx_thread_safe(ib_ctx_handler *p_ib_ctx_h);
-
+    doca_mmap *get_doca_mmap() const { return m_allocator_data.get_doca_mmap(); }
     /**
      * Get buffers from the pool - thread safe
      * @parma pDeque List to put the buffers.

--- a/src/core/dev/cq_mgr_rx.cpp
+++ b/src/core/dev/cq_mgr_rx.cpp
@@ -83,6 +83,7 @@ cq_mgr_rx::cq_mgr_rx(ring_simple *p_ring, ib_ctx_handler *p_ib_ctx_handler, int 
     , m_comp_event_channel(p_comp_event_channel)
     , m_n_sysvar_qp_compensation_level(safe_mce_sys().qp_compensation_level)
     , m_rx_lkey(g_buffer_pool_rx_rwqe->find_lkey_by_ib_ctx_thread_safe(m_p_ib_ctx_handler))
+    , m_p_doca_mmap(g_buffer_pool_rx_rwqe->get_doca_mmap())
     , m_b_sysvar_cq_keep_qp_full(safe_mce_sys().cq_keep_qp_full)
 {
     BULLSEYE_EXCLUDE_BLOCK_START

--- a/src/core/dev/cq_mgr_rx.cpp
+++ b/src/core/dev/cq_mgr_rx.cpp
@@ -257,36 +257,9 @@ void cq_mgr_rx::add_hqrx(hw_queue_rx *hqrx_ptr)
 
     m_debt = 0;
 
-    /*doca_error_t rc = doca_mmap_create(&temp_doca_mmap);
-    if (DOCA_IS_ERROR(rc)) {
-        PRINT_DOCA_ERR(cq_logerr, rc, "doca_mmap_create");
-    }
-
-    rc = doca_mmap_set_max_num_devices(temp_doca_mmap, 1U);
-    if (DOCA_IS_ERROR(rc)) {
-        PRINT_DOCA_ERR(cq_logerr, rc, "doca_mmap_set_max_num_devices");
-    }
-
-    rc = doca_mmap_add_dev(temp_doca_mmap, m_p_ib_ctx_handler->get_doca_device());
-    if (DOCA_IS_ERROR(rc)) {
-        PRINT_DOCA_ERR(cq_logerr, rc, "doca_mmap_add_dev");
-    }
-
-    size_t alloc_size = 32 * 16384;
-    xlio_allocator_heap temp_heap(false);
-    void *memptr = temp_heap.alloc(alloc_size);
-
-    rc = doca_mmap_set_memrange(temp_doca_mmap, memptr, 32 * 16384);
-    if (DOCA_IS_ERROR(rc)) {
-        PRINT_DOCA_ERR(cq_logerr, rc, "doca_mmap_set_memrange");
-    }
-
-    rc = doca_mmap_start(temp_doca_mmap);
-    if (DOCA_IS_ERROR(rc)) {
-        PRINT_DOCA_ERR(cq_logerr, rc, "doca_mmap_start");
-    }
-
-    rc = doca_buf_inventory_create(32U, &temp_doca_inventory);
+    /*
+    g_buffer_pool_rx_rwqe->get_buffers_thread_safe(temp_desc_list, m_p_ring, 32, m_rx_lkey);
+    doca_error_t rc = doca_buf_inventory_create(32U, &temp_doca_inventory);
     if (DOCA_IS_ERROR(rc)) {
         PRINT_DOCA_ERR(cq_logerr, rc, "doca_buf_inventory_create");
     }
@@ -297,8 +270,9 @@ void cq_mgr_rx::add_hqrx(hw_queue_rx *hqrx_ptr)
     }
 
     for (int i = 0; i < 32; ++i) {
-        rc = doca_buf_inventory_buf_get_by_addr(temp_doca_inventory, temp_doca_mmap,
-                                                (uint8_t *)memptr + (i * 16384), 16384,
+        mem_buf_desc_t *mem_buf = temp_desc_list.get_and_pop_front();
+        rc = doca_buf_inventory_buf_get_by_addr(temp_doca_inventory, m_p_doca_mmap,
+                                                mem_buf->p_buffer, mem_buf->sz_buffer,
                                                 temp_doca_bufs + i);
         if (DOCA_IS_ERROR(rc)) {
             PRINT_DOCA_ERR(cq_logerr, rc, "doca_buf_inventory_buf_get_by_data");

--- a/src/core/dev/cq_mgr_rx.h
+++ b/src/core/dev/cq_mgr_rx.h
@@ -223,6 +223,7 @@ private:
     bool m_b_notification_armed = false;
     const uint32_t m_n_sysvar_qp_compensation_level;
     const uint32_t m_rx_lkey;
+    doca_mmap *m_p_doca_mmap;
     const bool m_b_sysvar_cq_keep_qp_full;
     cq_stats_t m_cq_stat_static;
     static atomic_t m_n_cq_id_counter_rx;

--- a/src/core/dev/cq_mgr_rx.h
+++ b/src/core/dev/cq_mgr_rx.h
@@ -77,7 +77,6 @@ class cq_mgr_rx {
 
 public:
     doca_buf_inventory *temp_doca_inventory = nullptr;
-    doca_mmap *temp_doca_mmap = nullptr;
     doca_buf *temp_doca_bufs[32];
     doca_eth_rxq_task_recv *temp_doca_tasks[32];
 

--- a/src/core/dev/net_device_val.cpp
+++ b/src/core/dev/net_device_val.cpp
@@ -932,6 +932,7 @@ bool net_device_val::update_active_slaves()
     return 0;
 }
 
+// TODO: azure related, see comment below
 void net_device_val::update_netvsc_slaves(int if_index, int if_flags)
 {
     slave_data_t *s = nullptr;
@@ -955,8 +956,15 @@ void net_device_val::update_netvsc_slaves(int if_index, int if_flags)
 
             up_ib_ctx->set_ctx_time_converter_status(
                 g_p_net_device_table_mgr->get_ctx_time_conversion_mode());
-            g_buffer_pool_rx_rwqe->register_memory(s->p_ib_ctx);
-            g_buffer_pool_tx->register_memory(s->p_ib_ctx);
+
+            // TODO commented out because other than this specific flow - we shouldn't use
+            // specific ib_ctx. So remove ctx argument from register_memory api. This specific flow
+            // will be removed later
+
+            // g_buffer_pool_rx_rwqe->register_memory(s->p_ib_ctx);
+            // g_buffer_pool_tx->register_memory(s->p_ib_ctx);
+            g_buffer_pool_rx_rwqe->register_memory();
+            g_buffer_pool_tx->register_memory();
             found = true;
         }
     } else {

--- a/src/core/dev/ring_simple.cpp
+++ b/src/core/dev/ring_simple.cpp
@@ -87,6 +87,7 @@ inline void ring_simple::send_status_handler(int ret, xlio_ibv_send_wr *p_send_w
 ring_simple::ring_simple(int if_index, ring *parent, ring_type_t type, bool use_locks)
     : ring_slave(if_index, parent, type, use_locks)
     , m_lock_ring_tx_buf_wait("ring:lock_tx_buf_wait")
+    , m_p_doca_mmap(g_buffer_pool_tx->get_doca_mmap())
     , m_gro_mgr(safe_mce_sys().gro_streams_max, MAX_GRO_BUFS)
 {
     net_device_val *p_ndev = g_p_net_device_table_mgr->get_net_device_val(m_parent->get_if_index());

--- a/src/core/dev/ring_simple.h
+++ b/src/core/dev/ring_simple.h
@@ -349,6 +349,7 @@ private:
     uint32_t m_missing_buf_ref_count = 0U;
     uint32_t m_tx_lkey = 0U; // this is the registered memory lkey for a given specific device for
                              // the buffer pool use
+    doca_mmap *m_p_doca_mmap;
     gro_mgr m_gro_mgr;
     bool m_up_tx = false;
     bool m_up_rx = false;

--- a/src/core/proto/mapping.cpp
+++ b/src/core/proto/mapping.cpp
@@ -132,7 +132,7 @@ int mapping_t::map(int fd)
         goto failed_close_fd;
     }
 
-    result = m_registrator.register_memory(m_addr, m_size, m_ib_ctx);
+    result = m_registrator.register_memory(m_addr, m_size);
     if (!result) {
         map_logerr("Failed to register mmapped memory");
         goto failed_unmap;

--- a/src/core/proto/mapping.h
+++ b/src/core/proto/mapping.h
@@ -83,6 +83,7 @@ public:
 
     /* mem_desc interface */
     uint32_t get_lkey(mem_buf_desc_t *desc, ib_ctx_handler *ib_ctx, const void *addr, size_t len);
+    doca_mmap *get_doca_mmap() const { return m_registrator.get_doca_mmap(); };
     void get(void);
     void put(void);
 


### PR DESCRIPTION
Based on PR154.

Adding doca_mmap support:
1. Accessed by get_doca_mmap().
2. Add doca_mmap support for sendfile.
3. Still using lkey by ibv mem_reg to allow traffic during integration.

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

