### PR TITLE
issue: 3947680 Add flow_tag support for new XLIO socket API

### DIFF
--- a/src/core/event/poll_group.cpp
+++ b/src/core/event/poll_group.cpp
@@ -174,10 +174,13 @@ void poll_group::add_ring(ring *rng, ring_alloc_logic_attr *attr)
 void poll_group::add_socket(sockinfo_tcp *si)
 {
     m_sockets_list.push_back(si);
+    // For the flow_tag fast path support.
+    g_p_fd_collection->set_socket(si->get_fd(), si);
 }
 
 void poll_group::close_socket(sockinfo_tcp *si, bool force /*=false*/)
 {
+    g_p_fd_collection->clear_socket(si->get_fd());
     m_sockets_list.erase(si);
 
     bool closed = si->prepare_to_close(force);

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -119,6 +119,9 @@ static int free_libxlio_resources()
 
     g_b_exit = true;
 
+    // Destroy polling groups before fd_collection to clear XLIO sockets from the fd_collection
+    poll_group::destroy_all_groups();
+
     // Triggers connection close, relevant for TCP which may need some time to terminate the
     // connection. and for any socket that may wait from another thread
     if (g_p_fd_collection) {
@@ -145,8 +148,6 @@ static int free_libxlio_resources()
     if (g_p_fd_collection_temp) {
         delete g_p_fd_collection_temp;
     }
-
-    poll_group::destroy_all_groups();
 
     if (g_p_lwip) {
         delete g_p_lwip;

--- a/src/core/sock/fd_collection.h
+++ b/src/core/sock/fd_collection.h
@@ -132,6 +132,9 @@ public:
      */
     void del_tapfd(int fd);
 
+    void set_socket(int fd, sockinfo *si) { m_p_sockfd_map[fd] = si; }
+    void clear_socket(int fd) { m_p_sockfd_map[fd] = nullptr; }
+
     /**
      * Call set_immediate_os_sample of the input fd.
      */


### PR DESCRIPTION
## Description
Add XLIO sockets to the fd_collection array, but bypassing all the internal logic. This allows ring_slave to find socket object for the flow tag feature.

##### What
Add flow_tag support for new XLIO socket API

##### Why ?
Performance improvement

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

