### PR TITLE
issue: 3958757 Change error message to warning when reading FS files

### DIFF
--- a/src/core/util/utils.cpp
+++ b/src/core/util/utils.cpp
@@ -547,27 +547,28 @@ int priv_read_file(const char *path, char *buf, size_t size,
     int fd = SYSCALL(open, path, O_RDONLY);
     BULLSEYE_EXCLUDE_BLOCK_START
     if (fd < 0) {
-        VLOG_PRINTF(log_level, "ERROR while opening file %s (errno %d %m)", path, errno);
+        VLOG_PRINTF(log_level, "Couldn't open file %s (errno %d %m)", path, errno);
         return -1;
     }
     BULLSEYE_EXCLUDE_BLOCK_END
     len = SYSCALL(read, fd, buf, size);
     BULLSEYE_EXCLUDE_BLOCK_START
     if (len < 0) {
-        VLOG_PRINTF(log_level, "ERROR while reading from file %s (errno %d %m)", path, errno);
+        VLOG_PRINTF(log_level, "Couldn't read file %s (errno %d %m)", path, errno);
     }
     BULLSEYE_EXCLUDE_BLOCK_END
     SYSCALL(close, fd);
     return len;
 }
 
-int read_file_to_int(const char *path, int default_value, vlog_levels_t log_level)
+int read_file_to_int(const char *path, int default_value, vlog_levels_t log_level /*VLOG_WARNING*/)
 {
     int value = -1;
     std::ifstream file_stream(path);
     if (!file_stream || !(file_stream >> value)) {
-        VLOG_PRINTF(log_level, "ERROR while getting int from from file %s, we'll use default %d",
-                    path, default_value);
+        VLOG_PRINTF(log_level,
+                    "Couldn't read an integer from file %s (errno %d %m), we'll use default %d",
+                    path, errno, default_value);
         return default_value;
     }
     return value;

--- a/src/core/util/utils.h
+++ b/src/core/util/utils.h
@@ -192,10 +192,10 @@ inline int priv_safe_try_read_file(const char *path, char *buf, size_t size)
 
 /**
  * Read content of file detailed in 'path' (usually a sysfs file)
- * upon failure print error
+ * upon failure print warning
  * @return int value (atoi) of the file content, or 'default_value' upon failure
  */
-int read_file_to_int(const char *path, int default_value, vlog_levels_t log_level = VLOG_ERROR);
+int read_file_to_int(const char *path, int default_value, vlog_levels_t log_level = VLOG_WARNING);
 
 /**
  * Get port number from interface name


### PR DESCRIPTION
## Description
At startup, XLIO tries to read files in the /proc/sys/net/core/ directory, which can be inaccessible when running in a container (it doesn’t matter whether in privileged mode or not).  In this case, XLIO produces ERROR messages which can be considered as WARNINGs.
##### What
This commit changes the default log severity in the read_file_to_int() function from VLOG_ERROR to VLOG_WARNING. This is done to account for different container configurations where certain files may not be accessible, while ensuring a default value is used for every parameter. This change enhances XLIO's adaptability in various container environments.
##### Why ?
This breaks CI and blocks the integration with DOCA.


## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [x] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

