### PR TITLE
[Blackduck] Bugfix - ngci connecting to the wrong url

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -2,7 +2,7 @@
 
 // load pipeline functions
 // Requires pipeline-github-lib plugin to load library from github
-@Library('github.com/Mellanox/ci-demo@stable')
+@Library('github.com/Mellanox/ci-demo@stable_media')
 def matrix = new com.mellanox.cicd.Matrix()
 
 matrix.main()

--- a/.ci/matrix_job.yaml
+++ b/.ci/matrix_job.yaml
@@ -8,7 +8,7 @@ registry_auth: 65eb3652-9da0-4f39-8a4c-f61972fb65a1
 registry_path: /swx-infra/media
 
 kubernetes:
-  privileged: false
+  privileged: true
   cloud: swx-k8s-spray
   nodeSelector: 'beta.kubernetes.io/os=linux'
   namespace: xlio-ci
@@ -362,6 +362,8 @@ steps:
       attachArtifact: true
       reportName: "BlackDuck report"
       scanMode: "source"
+      skipDockerDaemonCheck: true
+      credentialsId: "b68aedbd-e39f-4ee2-acce-e25a5b91fe18"
     env:
       SPRING_APPLICATION_JSON: '{"blackduck.url":"https://blackduck.mellanox.com/","blackduck.api.token":"ODMwOWYwMzEtODA2ZC00MzBjLWI1ZDEtNmFiMjBkYzQzMzkwOjNmNjExN2M1LWE2ZmEtNDZlYS1hZjRiLTZlNDgwNjAwOTVjNw=="}'
 


### PR DESCRIPTION
## Description
BlackDuck scan fails due to ngci connecting to the old gerrit url, fix is made to both this repo and the ci-demo repo (Changes made in this PR: https://github.com/Mellanox/ci-demo/pull/90)

##### What
Add credentialsId to login into the new gerrit url
skipDockerDaemonCheck configuration provided by the gerrit team.

##### Why ?
Issue: HPCINFRA-2289

## Change type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

