### PR TITLE
Partial ack TSO after retransmission + Fix TCP segments order in RTO after fast retransmission

### DIFF
--- a/src/core/lwip/tcp.h
+++ b/src/core/lwip/tcp.h
@@ -339,7 +339,7 @@ struct tcp_pcb {
     u32_t snd_sml_snt; /* maintain state for minshall's algorithm */
     u32_t snd_sml_add; /* maintain state for minshall's algorithm */
 
-    u32_t snd_queuelen; /* Available buffer space for sending (in tcp_segs). */
+    u32_t snd_queuelen; /* Available buffer space for sending (in pbufs). */
     u32_t snd_queuelen_max;
 
     /* These are ordered by sequence number: */

--- a/src/core/lwip/tcp_out.c
+++ b/src/core/lwip/tcp_out.c
@@ -1657,6 +1657,24 @@ void tcp_rexmit_rto(struct tcp_pcb *pcb)
         return;
     }
 
+    if (pcb->unsent != NULL && TCP_SEQ_GT(pcb->unacked->seqno, pcb->unsent->seqno)) {
+        // Move fast-retransmitted segments to unacked - RTO after fast retransmission
+        struct tcp_seg *rexmit_start = pcb->unsent;
+        struct tcp_seg *rexmit_end = pcb->unsent;
+        while (rexmit_end->next != NULL &&
+               TCP_SEQ_GT(pcb->unacked->seqno, rexmit_end->next->seqno)) {
+            rexmit_end = rexmit_end->next;
+        }
+
+        pcb->unsent = rexmit_end->next;
+        if (pcb->unsent == NULL) {
+            pcb->last_unsent = NULL;
+        }
+
+        rexmit_end->next = pcb->unacked;
+        pcb->unacked = rexmit_start;
+    }
+
     /* Move all unacked segments to the head of the unsent queue */
     if (pcb->unsent) {
         pcb->last_unacked->next = pcb->unsent;


### PR DESCRIPTION
1. Fix ACK of partial TSO segment:
    In the happy TSO path whenever we get an ack, we go over
    the unacked list and shrink TSO segments accordingly.
    The issue is when we get the ack after retransmission where
    the segment/s move from the unacked list to unsent.
    In this case, we don't shrink segments in the unsent list.
        a. Shrink is done for all segments now, not only TSO
        b. Avoid the corner case when partially ACKed and not shrunk segments block TCP progress.

2. Fix unsent queue after fast retransmission+RTO:
    In fast retransmission, we move a single segment from the unacked list to the unsent list.
    But if we have RTO right after, we move all the unacked list to the unsent list, but we don't
    take into consideration the we might have a retransmitted segment already in the unsent list.
    
    Example:
    unacked: 1->2->3
    unsent: 4->5->6
    
    After fast retransmission reorder in LWIP:
    unacked: 2->3
    unsent: 1->4->5->6
    
    After RTO:
    unacked: ----
    unsent: 2->3->1->4->5->6

## Change type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

