### PR TITLE
issue: 3807308 Add Ring TSO statistics

### DIFF
--- a/src/core/dev/hw_queue_tx.h
+++ b/src/core/dev/hw_queue_tx.h
@@ -261,7 +261,7 @@ private:
     inline void store_current_wqe_prop(mem_buf_desc_t *wr_id, unsigned credits, xlio_ti *ti);
     inline int fill_wqe(xlio_ibv_send_wr *p_send_wqe);
     inline int fill_wqe_send(xlio_ibv_send_wr *pswr);
-    inline int fill_wqe_lso(xlio_ibv_send_wr *pswr);
+    inline int fill_wqe_lso(xlio_ibv_send_wr *pswr, int data_len);
     inline int fill_inl_segment(sg_array &sga, uint8_t *cur_seg, uint8_t *data_addr,
                                 int max_inline_len, int inline_len);
     inline void ring_doorbell(int num_wqebb, bool skip_comp = false);

--- a/src/core/dev/ring_simple.h
+++ b/src/core/dev/ring_simple.h
@@ -131,6 +131,12 @@ public:
     struct ibv_comp_channel *get_tx_comp_event_channel() { return m_p_tx_comp_event_channel; }
     void modify_cq_moderation(uint32_t period, uint32_t count);
 
+    void update_tso_stats(uint64_t bytes)
+    {
+        ++m_p_ring_stat->simple.n_tx_tso_pkt_count;
+        m_p_ring_stat->simple.n_tx_tso_byte_count += bytes;
+    }
+
 #ifdef DEFINED_UTLS
     bool tls_tx_supported(void) override { return m_tls.tls_tx; }
     bool tls_rx_supported(void) override { return m_tls.tls_rx; }

--- a/src/core/util/xlio_stats.h
+++ b/src/core/util/xlio_stats.h
@@ -373,6 +373,8 @@ typedef struct {
     ring_type_t n_type;
     union {
         struct {
+            uint64_t n_tx_tso_pkt_count;
+            uint64_t n_tx_tso_byte_count;
             uint64_t n_rx_interrupt_requests;
             uint64_t n_rx_interrupt_received;
             uint32_t n_rx_cq_moderation_count;

--- a/src/stats/stats_reader.cpp
+++ b/src/stats/stats_reader.cpp
@@ -379,6 +379,14 @@ void update_delta_ring_stat(ring_stats_t *p_curr_ring_stats, ring_stats_t *p_pre
             p_prev_ring_stats->tap.n_vf_plugouts =
                 (p_curr_ring_stats->tap.n_vf_plugouts - p_prev_ring_stats->tap.n_vf_plugouts);
         } else {
+            p_prev_ring_stats->simple.n_tx_tso_pkt_count =
+                (p_curr_ring_stats->simple.n_tx_tso_pkt_count -
+                 p_prev_ring_stats->simple.n_tx_tso_pkt_count) /
+                delay;
+            p_prev_ring_stats->simple.n_tx_tso_byte_count =
+                (p_curr_ring_stats->simple.n_tx_tso_byte_count -
+                 p_prev_ring_stats->simple.n_tx_tso_byte_count) /
+                delay;
             p_prev_ring_stats->simple.n_rx_interrupt_received =
                 (p_curr_ring_stats->simple.n_rx_interrupt_received -
                  p_prev_ring_stats->simple.n_rx_interrupt_received) /
@@ -534,6 +542,12 @@ void print_ring_stats(ring_instance_block_t *p_ring_inst_arr)
                 printf(FORMAT_STATS_32bit, "Tap fd:", p_ring_stats->tap.n_tap_fd);
                 printf(FORMAT_RING_TAP_NAME, "Tap Device:", p_ring_stats->tap.s_tap_name);
             } else {
+                if (p_ring_stats->simple.n_tx_tso_pkt_count ||
+                    p_ring_stats->simple.n_tx_tso_byte_count) {
+                    printf(FORMAT_RING_PACKETS, "TSO Offload:",
+                           p_ring_stats->simple.n_tx_tso_byte_count / BYTES_TRAFFIC_UNIT,
+                           p_ring_stats->simple.n_tx_tso_pkt_count, post_fix);
+                }
                 if (p_ring_stats->simple.n_rx_interrupt_requests ||
                     p_ring_stats->simple.n_rx_interrupt_received) {
                     printf(FORMAT_RING_INTERRUPT,
@@ -1794,6 +1808,8 @@ void zero_ring_stats(ring_stats_t *p_ring_stats)
     if (p_ring_stats->n_type == RING_TAP) {
         p_ring_stats->tap.n_vf_plugouts = 0;
     } else {
+        p_ring_stats->simple.n_tx_tso_pkt_count = 0;
+        p_ring_stats->simple.n_tx_tso_byte_count = 0;
         p_ring_stats->simple.n_rx_interrupt_received = 0;
         p_ring_stats->simple.n_rx_interrupt_requests = 0;
         p_ring_stats->simple.n_tx_dropped_wqes = 0;


### PR DESCRIPTION
## Description
TSO statistics are very important for tracking TX performance. 

##### What
Two variables are added, TSO packets number and TSO bytes number. With these two and with conjunction of total TX packets and bytes, the needed information can be derrived.

##### Why ?
Statistics and performance visibility

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [X] Code follows the style de facto guidelines of this project
- [X] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

