### PR TITLE
issue: 3964910 Align ring size to cache line

### DIFF
--- a/src/core/dev/ring_slave.h
+++ b/src/core/dev/ring_slave.h
@@ -337,6 +337,7 @@ protected:
 
 private:
     ring_type_t m_type; /* ring type */
+    uint8_t padding[8]; // make class size up to a whole cache line
 };
 
 #endif /* RING_SLAVE_H_ */


### PR DESCRIPTION
Fixes latency degradation caused by the reduced size of xlio_list.
It created a gap in the ring class which is not cache line aligned.
Added padding bytes to align it to a full cache line.

## Change type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

