### PR TITLE
issue: 3976537 Avoid TX polling in XLIO Socket flush

### DIFF
--- a/src/core/event/poll_group.cpp
+++ b/src/core/event/poll_group.cpp
@@ -183,6 +183,11 @@ void poll_group::close_socket(sockinfo_tcp *si, bool force /*=false*/)
     g_p_fd_collection->clear_socket(si->get_fd());
     m_sockets_list.erase(si);
 
+    auto iter = std::find(m_dirty_sockets.begin(), m_dirty_sockets.end(), si);
+    if (iter != std::end(m_dirty_sockets)) {
+        m_dirty_sockets.erase(iter);
+    }
+
     bool closed = si->prepare_to_close(force);
     if (closed) {
         /*

--- a/src/core/proto/xlio_lwip.h
+++ b/src/core/proto/xlio_lwip.h
@@ -72,6 +72,8 @@ typedef enum xlio_wr_tx_packet_attr {
     XLIO_TX_PACKET_BLOCK = (1 << 8),
     /* Force SW checksum */
     XLIO_TX_SW_L4_CSUM = (1 << 9),
+    /* Skip TX polling */
+    XLIO_TX_SKIP_POLL = (1 << 10),
 } xlio_wr_tx_packet_attr;
 
 static inline bool is_set(xlio_wr_tx_packet_attr state_, xlio_wr_tx_packet_attr tx_mode_)

--- a/src/core/sock/sockinfo_tcp.cpp
+++ b/src/core/sock/sockinfo_tcp.cpp
@@ -1364,7 +1364,9 @@ err_t sockinfo_tcp::ip_output(struct pbuf *p, struct tcp_seg *seg, void *v_p_con
     dst_entry *p_dst = p_si_tcp->m_p_connected_dst_entry;
     int max_count = p_si_tcp->m_pcb.tso.max_send_sge;
     tcp_iovec lwip_iovec[max_count];
-    xlio_send_attr attr = {(xlio_wr_tx_packet_attr)flags, p_si_tcp->m_pcb.mss, 0, nullptr};
+    xlio_send_attr attr = {
+        (xlio_wr_tx_packet_attr)(flags | (!!p_si_tcp->is_xlio_socket() * XLIO_TX_SKIP_POLL)),
+        p_si_tcp->m_pcb.mss, 0, nullptr};
     int count = 0;
     void *cur_end;
 


### PR DESCRIPTION
## Description
TX polling can trigger a zerocopy completion event. If this happens in
context of xlio_poll_group_flush(), a send operation can break
consistency between socket dirty status and their group's dirty list.

To avoid the issue, don't poll TX outside the xlio_poll_group_poll()
context. This will make the zerocopy completion events possible only
from the polling context.

If a dirty socket is closed without a flush, it must be removed from the
group's dirty list. Otherwise, this can lead to a use-after-free issue.

##### What
Avoid TX polling in XLIO Socket flush. Remove leftover closed socket from the dirty list.

##### Why ?
XLIO Socket API Bugfixes.

## Change type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

