### PR TITLE
issue: 3981627 Print early logs to stderr

### DIFF
--- a/src/vlogger/vlogger.cpp
+++ b/src/vlogger/vlogger.cpp
@@ -286,7 +286,9 @@ void vlog_stop(void)
 
     // Close output stream
     if (g_vlogger_file && g_vlogger_file != stderr) {
-        fclose(g_vlogger_file);
+        FILE *closing_file = g_vlogger_file;
+        g_vlogger_file = nullptr;
+        fclose(closing_file);
     }
 
     // fix for using LD_PRELOAD with LBM. Unset the pointer given by the parent process, so a child
@@ -356,7 +358,7 @@ void vlog_output(vlog_levels_t log_level, const char *fmt, ...)
         fprintf(g_vlogger_file, "%s", buf);
         fflush(g_vlogger_file);
     } else {
-        printf("%s", buf);
+        fprintf(stderr, "%s", buf);
     }
 }
 


### PR DESCRIPTION
## Description
Early logs can be printed before vlogger subsystem initialization. If they are printed to stdout, this can interfere with tools that parse output, such as grep, awk, etc.

Gtest calls a subshell command to find a default gw and early logs breaks this functionality. Example of such scenario is a container with prohibited read access to sysfs files which XLIO reads.

##### What
Print early logs to stderr

##### Why ?
Fix gtests when early logs are printed and avoid interference with parsing tools.

## Change type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

