### PR TITLE
[CI] BUGFIX - CI job fails to build new dockers

### DIFF
--- a/.ci/matrix_job.yaml
+++ b/.ci/matrix_job.yaml
@@ -4,7 +4,7 @@ job: LIBXLIO
 step_allow_single_selector: false
 
 registry_host: harbor.mellanox.com
-registry_auth: 65eb3652-9da0-4f39-8a4c-f61972fb65a1
+registry_auth: 1daaea28-800e-425f-a91f-3bd3e9136eea
 registry_path: /swx-infra/media
 
 kubernetes:


### PR DESCRIPTION
## Description
LibXLIO CI definition under job_matrix.yaml has the credentials of rivermax which do not have permissions to pull docker images needed to build LibXLIO docker images

##### What
Fix issue with libxlio CI being unable to build new images

##### Why ?
Credentials under matrix_job.yaml set to registry_auth are incorrect

##### How ?
Change harbor credentialsID under matrix_job.yaml to one with permissions over libxlio docker images

## Change type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

