### PR TITLE
issue: 3777769 Fix No traffic with VLAN tagged packets

### DIFF
--- a/src/core/proto/header.cpp
+++ b/src/core/proto/header.cpp
@@ -100,6 +100,7 @@ void header::set_mac_to_eth_header(const L2_address &src, const L2_address &dst)
     if (m_is_vlan_enabled) {
         vlan_eth_hdr_template_t *p_vlan_eth_hdr = &get_l2_hdr()->vlan_eth_hdr;
         set_mac_to_eth_header(src, dst, p_vlan_eth_hdr->m_eth_hdr);
+        m_transport_header_len += sizeof(p_vlan_eth_hdr->m_vlan_hdr);
     } else {
         eth_hdr_template_t *p_eth_hdr = &get_l2_hdr()->eth_hdr;
         set_mac_to_eth_header(src, dst, p_eth_hdr->m_eth_hdr);


### PR DESCRIPTION
Need to add the length of VLAN header
to L2 header length in case of VLAN tagged
packets, the issue was only in send to neigh flow
when neigh is not resolved yet


## Change type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

