### PR TITLE
issue: 3784248 Nginx UDP reuseport for IPv6

### DIFF
--- a/src/core/dev/rfs_uc.cpp
+++ b/src/core/dev/rfs_uc.cpp
@@ -88,7 +88,8 @@ void rfs_uc::prepare_flow_spec()
         if (m_flow_tuple.get_protocol() != PROTO_UDP)
 #else
         if (m_flow_tuple.get_protocol() != PROTO_UDP ||
-            (g_map_udp_bounded_port.count(ntohs(m_flow_tuple.get_dst_port()))))
+            (g_map_udp_resue_port.count(((uint32_t)m_flow_tuple.get_family() << 16) |
+                                        ntohs(m_flow_tuple.get_dst_port()))))
 #endif
         {
             int src_port;

--- a/src/core/sock/sock-app.h
+++ b/src/core/sock/sock-app.h
@@ -43,9 +43,10 @@
 #include <set>
 
 #if defined(DEFINED_NGINX)
-typedef std::unordered_map<uint16_t, bool> map_udp_bounded_port_t;
+// uint32_t stands for sa_family on the 16 MSB bits, and port number on 16 LSB.
+typedef std::unordered_map<uint32_t, bool> map_udp_reuse_port_t;
 
-extern map_udp_bounded_port_t g_map_udp_bounded_port;
+extern map_udp_reuse_port_t g_map_udp_resue_port;
 #endif
 
 #if defined(DEFINED_NGINX) || defined(DEFINED_ENVOY)

--- a/src/core/sock/sockinfo.cpp
+++ b/src/core/sock/sockinfo.cpp
@@ -933,7 +933,8 @@ bool sockinfo::attach_receiver(flow_tuple_with_local_if &flow_key)
 #else
         if (flow_key.get_protocol() != PROTO_UDP ||
             (flow_key.get_protocol() == PROTO_UDP &&
-             g_map_udp_bounded_port.count(ntohs(flow_key.get_dst_port()))))
+             g_map_udp_resue_port.count(((uint32_t)flow_key.get_family() << 16) |
+                                        ntohs(flow_key.get_dst_port()))))
 #endif
         {
             if ((g_p_app->workers_num != g_p_app->workers_pow2) && flow_key.is_3_tuple()) {


### PR DESCRIPTION
Add support for UDP reuse port for listen socket for both IPv4 and IPv6 at the same conf file.

## Change type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

