### PR TITLE
issue: 3976544 Don't close epfd for event_handler_manager_local

### DIFF
--- a/src/core/event/event_handler_manager.cpp
+++ b/src/core/event/event_handler_manager.cpp
@@ -258,7 +258,8 @@ event_handler_manager::event_handler_manager(bool internal_thread_mode)
 {
     evh_logfunc("");
 
-    m_cq_epfd = m_epfd = 0;
+    m_cq_epfd = 0;
+    m_epfd = -1;
     m_event_handler_tid = 0;
 
     if (!internal_thread_mode) {
@@ -415,7 +416,9 @@ void event_handler_manager::stop_thread()
     m_event_handler_tid = 0;
 
     // Close main epfd and signaling socket
-    SYSCALL(close, m_epfd);
+    if (m_epfd >= 0) {
+        SYSCALL(close, m_epfd);
+    }
     m_epfd = -1;
 }
 


### PR DESCRIPTION
## Description
Base class event_handler_manager closes m_epfd unconditionally in the destructor. But in case of local copy, the constructor exits early and leaves m_epfd initialized as 0.

This leads to closing 0 file descriptor during the local copy destruction what causes runtime issues for objects related to the fd 0.

##### What
Don't close epfd in event_handler_manager_local destructor.

##### Why ?
Fix closing of a wrong file description what causes runtime issues.

## Change type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

