### PR TITLE
issue: 3981627 [GTEST] Fix default gateway detection

### DIFF
--- a/tests/gtest/common/sys.cc
+++ b/tests/gtest/common/sys.cc
@@ -204,7 +204,7 @@ bool sys_gateway(struct sockaddr *addr, sa_family_t family)
             line[len - 1] = 0;
         }
         sys_str2addr(line, &temp_addr.addr, false);
-        found = (addr->sa_family == family);
+        found = (temp_addr.addr.sa_family == family);
         if (found) {
             sys_str2addr(line, addr, false);
             log_trace("%s found gateway ip: %s\n", line, sys_addr2str(addr));


### PR DESCRIPTION
## Description
sys_str2addr() converts a string address representation to the sockaddr
structure. However, an invalid address sets either AF_INET or AF_INET6
address family and returns corrupted IP portion of the sockaddr object.

Return AF_UNSPEC address family in case of an invalid IP address. So,
default gateway detection can handle address parsing.

Invalid port portion is still silently ignored. In the future, the
function should return the conversion status and this needs to be
handled explicitly by the function users.

sys_gateway() converts string address to a temporary sockaddr object
on stack before changing the result object. However, a different
uninitialized object is checked for the conversion status.

Check the correct object.

##### What
Fix default gateway detection.

##### Why ?
Fix incorrect gateway detection in corner cases.

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

