### PR TITLE
Issue: [Bugfix] blackduck reports wrong version

### DIFF
--- a/.ci/matrix_job.yaml
+++ b/.ci/matrix_job.yaml
@@ -357,7 +357,7 @@ steps:
     run: NGCIBlackDuckScan
     args:
       projectName: "libxlio"
-      projectVersion: "0.1.0"
+      projectVersion: "${sha1}"
       projectSrcPath: "src"
       attachArtifact: true
       reportName: "BlackDuck report"


### PR DESCRIPTION
## Description
Blackduck module report output shows the wrong version

##### What
Change blackduck input to match branch selected instead of static `0.1.0`

##### Why ?
Bugfix for blackduck report

## Change type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

