### PR TITLE
issue: HPCINFRA-2413 [CI] cppcheck step fixup

### DIFF
--- a/.ci/matrix_job.yaml
+++ b/.ci/matrix_job.yaml
@@ -291,7 +291,7 @@ steps:
       - "{name: 'static', category: 'tool'}"
     run: |
       [ "x${do_cppcheck}" == "xtrue" ] && action=yes || action=no
-      env WORKSPACE=$PWD TARGET=${flags} COMPILE_DOCA=false COMPILE_DPCP=false jenkins_test_cppcheck=${action} ./contrib/test_jenkins.sh
+      env WORKSPACE=$PWD TARGET=${flags} jenkins_test_cppcheck=${action} ./contrib/test_jenkins.sh
     parallel: false
     onfail: |
       ./.ci/artifacts.sh

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -106,24 +106,34 @@ i=0
 if [ "$TARGET" == "all" -o "$TARGET" == "default" ]; then
     export jenkins_target="default"
     export prefix=${jenkins_test_custom_prefix}/${jenkins_target}
-    if "$COMPILE_DPCP"; 
-        then do_check_dpcp opt_value
-    fi
-    if [ ! -z "${opt_value}" ]; then
-        target_list[$i]="default: --enable-nginx --with-dpcp=${opt_value}"
-        if "$COMPILE_DOCA"; then
-            if do_compile_doca doca_path; then
-                target_list[$i]="${target_list} --with-doca=${doca_path}"
-            fi
+    if "$COMPILE_DPCP"; then
+        do_check_dpcp opt_value
+        if [ ! -z "${opt_value}" ]; then
+            target_list[$i]="default: --enable-nginx --with-dpcp=${opt_value}"
+        else
+            echo "Requested dpcp support can not be executed"
+    		do_err "target: $TARGET"
+    		exit 1
         fi
-        i=$((i+1))
-	elif ! "$COMPILE_DPCP"; then
-		echo "dpcp support was not requested"
     else
-        echo "Requested dpcp support can not be executed"
-        do_err "target: $TARGET"
-        exit 1
+        echo "dpcp support was not requested"
+		# We need to define a minimum list of targets to iterate over later
+		target_list[$i]="default: --enable-nginx"
     fi
+    if "$COMPILE_DOCA"; then
+        if do_compile_doca doca_path; then
+            target_list[$i]="${target_list} --with-doca=${doca_path}"
+        else 
+            echo "Requested DOCA support can not be executed"
+            do_err "target: $TARGET"
+            exit 1
+        fi
+    else
+        echo "DOCA support was not requested"
+    fi
+	if [ ! -z "${opt_value}" ]; then
+	    i=$((i+1))
+	fi
 fi
 
 echo


### PR DESCRIPTION
## Description
A fixup for cppcheck step in CI, which doesn't work as expected

##### What
_Subject: 
A fix for CI, which doesn't call cppcheck, when DPCP/DOCA compilation is not requested

##### Why ?
_Justification for the PR. 
cppcheck step doesn't do any job when DOCA / DPCP support is not requested

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

