### PR TITLE
issue: 3884801 Check for resident hugepages to avoid SIGBUS

### DIFF
--- a/README
+++ b/README
@@ -79,6 +79,7 @@ Example:
  XLIO DETAILS: SigIntr Ctrl-C Handle          Enabled                    [XLIO_HANDLE_SIGINTR]
  XLIO DETAILS: SegFault Backtrace             Disabled                   [XLIO_HANDLE_SIGSEGV]
  XLIO DETAILS: Print a report                 Disabled                   [XLIO_PRINT_REPORT]
+ XLIO DETAILS: Quick start                    Disabled                   [XLIO_QUICK_START]
  XLIO DETAILS: Ring allocation logic TX       0 (Ring per interface)     [XLIO_RING_ALLOCATION_LOGIC_TX]
  XLIO DETAILS: Ring allocation logic RX       0 (Ring per interface)     [XLIO_RING_ALLOCATION_LOGIC_RX]
  XLIO INFO   : Ring migration ratio TX        -1                         [XLIO_RING_MIGRATION_RATIO_TX]
@@ -306,6 +307,13 @@ Default value is 1 (Enabled)
 XLIO_HANDLE_SIGSEGV
 When Enabled, print backtrace if segmentation fault happens.
 Value range is 0 to 1
+Default value is 0 (Disabled)
+
+XLIO_QUICK_START
+Avoid expensive extra checks to reduce the initialization time. This may result
+in failures in case of a system misconfiguration.
+For example, if the parameter is enabled and hugepages are requested beyond the
+cgroup limit, XLIO crashes due to an access to an unmapped page.
 Default value is 0 (Disabled)
 
 XLIO_ZC_BUFS

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -501,6 +501,8 @@ void print_xlio_global_settings()
                       safe_mce_sys().handle_segfault ? "Enabled " : "Disabled");
     VLOG_PARAM_STRING("Print a report", safe_mce_sys().print_report, MCE_DEFAULT_PRINT_REPORT,
                       SYS_VAR_PRINT_REPORT, safe_mce_sys().print_report ? "Enabled " : "Disabled");
+    VLOG_PARAM_STRING("Quick start", safe_mce_sys().quick_start, MCE_DEFAULT_QUICK_START,
+                      SYS_VAR_QUICK_START, safe_mce_sys().quick_start ? "Enabled " : "Disabled");
 
     VLOG_PARAM_NUMSTR("Ring allocation logic TX", safe_mce_sys().ring_allocation_logic_tx,
                       MCE_DEFAULT_RING_ALLOCATION_LOGIC_TX, SYS_VAR_RING_ALLOCATION_LOGIC_TX,

--- a/src/core/util/hugepage_mgr.cpp
+++ b/src/core/util/hugepage_mgr.cpp
@@ -141,7 +141,7 @@ void *hugepage_mgr::alloc_hugepages_helper(size_t &size, size_t hugepage)
     if (ptr == MAP_FAILED) {
         ptr = nullptr;
         __log_info_dbg("mmap failed (errno=%d)", errno);
-    } else {
+    } else if (!safe_mce_sys().quick_start) {
         /* Check whether all the pages are resident. Allocation beyond the cgroup limit can be
          * successful and lead to a SIGBUS on an access. For example, the limit can be configured
          * for a container.

--- a/src/core/util/hugepage_mgr.h
+++ b/src/core/util/hugepage_mgr.h
@@ -88,6 +88,7 @@ private:
 
     bool is_hugepage_optimal(size_t hugepage, size_t size);
     bool is_hugepage_acceptable(size_t hugepage, size_t size);
+    bool check_resident_pages(void *ptr, size_t size, size_t page_size);
     void *alloc_hugepages_helper(size_t &size, size_t hugepage);
 
     // Returns unused bytes in the tail hugepage because of alignment.

--- a/src/core/util/sys_vars.cpp
+++ b/src/core/util/sys_vars.cpp
@@ -761,6 +761,7 @@ void mce_sys_var::get_env_params()
     service_enable = MCE_DEFAULT_SERVICE_ENABLE;
 
     print_report = MCE_DEFAULT_PRINT_REPORT;
+    quick_start = MCE_DEFAULT_QUICK_START;
     log_level = VLOG_DEFAULT;
     log_details = MCE_DEFAULT_LOG_DETAILS;
     log_colors = MCE_DEFAULT_LOG_COLORS;
@@ -1082,6 +1083,10 @@ void mce_sys_var::get_env_params()
 
     if ((env_ptr = getenv(SYS_VAR_PRINT_REPORT))) {
         print_report = atoi(env_ptr) ? true : false;
+    }
+
+    if ((env_ptr = getenv(SYS_VAR_QUICK_START))) {
+        quick_start = atoi(env_ptr) ? true : false;
     }
 
     if ((env_ptr = getenv(SYS_VAR_LOG_FILENAME))) {

--- a/src/core/util/sys_vars.h
+++ b/src/core/util/sys_vars.h
@@ -340,6 +340,7 @@ public:
     uint32_t mce_spec;
 
     bool print_report;
+    bool quick_start;
     vlog_levels_t log_level;
     uint32_t log_details;
     char log_filename[PATH_MAX];
@@ -558,6 +559,7 @@ extern mce_sys_var &safe_mce_sys();
 #define SYS_VAR_HANDLE_SIGINTR      "XLIO_HANDLE_SIGINTR"
 #define SYS_VAR_HANDLE_SIGSEGV      "XLIO_HANDLE_SIGSEGV"
 #define SYS_VAR_STATS_FD_NUM        "XLIO_STATS_FD_NUM"
+#define SYS_VAR_QUICK_START         "XLIO_QUICK_START"
 
 #define SYS_VAR_RING_ALLOCATION_LOGIC_TX "XLIO_RING_ALLOCATION_LOGIC_TX"
 #define SYS_VAR_RING_ALLOCATION_LOGIC_RX "XLIO_RING_ALLOCATION_LOGIC_RX"
@@ -710,7 +712,8 @@ extern mce_sys_var &safe_mce_sys();
 #define MCE_DEFAULT_APP_ID                   ("XLIO_DEFAULT_APPLICATION_ID")
 #define MCE_DEFAULT_HANDLE_SIGINTR           (true)
 #define MCE_DEFAULT_HANDLE_SIGFAULT          (false)
-#define MCE_DEFAULT_STATS_FD_NUM             0
+#define MCE_DEFAULT_STATS_FD_NUM             (0)
+#define MCE_DEFAULT_QUICK_START              (false)
 #define MCE_DEFAULT_RING_ALLOCATION_LOGIC_TX (RING_LOGIC_PER_THREAD)
 #define MCE_DEFAULT_RING_ALLOCATION_LOGIC_RX (RING_LOGIC_PER_THREAD)
 #define MCE_DEFAULT_RING_MIGRATION_RATIO_TX  (-1)


### PR DESCRIPTION
## Description

In a containerized environment mmap() beyond the hugepages limit can be successful, but a further memory access triggers SIGBUS and terminates the process. Check that all the allocated hugepages are resident with mincore() to avoid the SIGBUS issue.

Cost of the feature depends on the allocation size and hugepage size:
 - 32GB with 2MB pages takes 4400 us
 - 32GB with 1GB pages takes 11 us
 - 32MB with 2MB pages takes 5-6 us

We expect a big memory preallocation at the start (2GB by default) and
rare 32MB allocations during warmup period. Therefore, this feature can
add several additional 5us latency spikes during warmup period.

##### What
Check for resident hugepages after allocation.

##### Why ?
Avoid SIGBUS in containerized environments.

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

