### PR TITLE
[CI] Remove latest file from release script

### DIFF
--- a/.ci/do_release.sh
+++ b/.ci/do_release.sh
@@ -73,7 +73,6 @@ if [ "${do_release}" = true ] ; then
 
     cd "${release_folder}"
     sudo -E -u swx-jenkins ln -s "$DST_DIR/${pkg_name}" "${pkg_name}"
-    sudo -E -u swx-jenkins echo "${pkg_name}" | sudo -E -u swx-jenkins tee "${DST_DIR}"/../latest.txt
     echo "Release found at $DST_DIR"
 else
      echo "do_release is set to false, skipping package release."


### PR DESCRIPTION
## Description
The new release pipeline links the latest release to a file called latest.txt, the dev team requested this feature to be removed

##### What
Remove echo line from do_release script into latest.txt

##### Why ?
Requested by the dev team

## Change type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)