### PR TITLE
HPCINFRA-2456 update EPEL7 source 

### DIFF
--- a/.ci/dockerfiles/Dockerfile.rhel8.6
+++ b/.ci/dockerfiles/Dockerfile.rhel8.6
@@ -4,8 +4,9 @@ ARG _GID=101
 ARG _LOGIN=swx-jenkins
 ARG _HOME=/var/home/$_LOGIN
 
-RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
- && yum install -y cppcheck \
+RUN yum install -y yum-utils \
+ && yum-config-manager --add-repo https://archives.fedoraproject.org/pub/archive/epel/7/x86_64/ \
+ && yum --nogpgcheck install -y cppcheck \
  && yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm \
  && yum install -y csbuild clang-tools-extra sudo curl autoconf automake make libtool \
     libnl3-devel libnl3 rdma-core-devel rdma-core bc \


### PR DESCRIPTION
## Description
We need to update the EPEL repository for our RHEL8-based CI branches

##### What
Change the location of pkg repository for RHEL8-based builds

##### Why ?
The Fedora Project, who maintains and distributes EPEL repository for RHEL/Centos has recently moved it to different location


## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

