### PR TITLE
issue: 4023262 Handle down interface states during table update

### DIFF
--- a/src/core/dev/net_device_table_mgr.cpp
+++ b/src/core/dev/net_device_table_mgr.cpp
@@ -190,6 +190,9 @@ void net_device_table_mgr::update_tbl()
     static int _seq = 0;
     net_device_val *p_net_device_val;
 
+    /* Track ips assigned to multiple-interfaces */
+    std::set<std::string> duplicate_ips;
+
     /* Set up the netlink socket */
     fd = SYSCALL(socket, AF_NETLINK, SOCK_RAW, NETLINK_ROUTE);
     if (fd < 0) {
@@ -264,19 +267,31 @@ void net_device_table_mgr::update_tbl()
                 if ((int)get_max_mtu() < p_net_device_val->get_mtu()) {
                     set_max_mtu(p_net_device_val->get_mtu());
                 }
+                auto handle_ip_insertion = [&p_net_device_val, &duplicate_ips](
+                                               const std::unique_ptr<ip_data> &ip,
+                                               net_device_map_addr &net_device_map,
+                                               sa_family_t family) {
+                    auto it = net_device_map.find(ip->local_addr);
+                    if (it != net_device_map.end()) {
+                        duplicate_ips.insert(ip->local_addr.to_str(family));
+                    }
+                    if (it == net_device_map.end() ||
+                        p_net_device_val->get_state() != net_device_val::DOWN) {
+                        net_device_map[ip->local_addr] = p_net_device_val;
+                    }
+                };
 
                 const ip_data_vector_t &ipvec_v4 = p_net_device_val->get_ip_array(AF_INET);
                 std::for_each(ipvec_v4.begin(), ipvec_v4.end(),
-                              [this, p_net_device_val](const std::unique_ptr<ip_data> &ip) {
-                                  m_net_device_map_addr_v4[ip->local_addr] = p_net_device_val;
+                              [this, &handle_ip_insertion](const std::unique_ptr<ip_data> &ip) {
+                                  handle_ip_insertion(ip, m_net_device_map_addr_v4, AF_INET);
                               });
 
                 const ip_data_vector_t &ipvec_v6 = p_net_device_val->get_ip_array(AF_INET6);
                 std::for_each(ipvec_v6.begin(), ipvec_v6.end(),
-                              [this, p_net_device_val](const std::unique_ptr<ip_data> &ip) {
-                                  m_net_device_map_addr_v6[ip->local_addr] = p_net_device_val;
+                              [this, &handle_ip_insertion](const std::unique_ptr<ip_data> &ip) {
+                                  handle_ip_insertion(ip, m_net_device_map_addr_v6, AF_INET6);
                               });
-
                 m_net_device_map_index[p_net_device_val->get_if_idx()] = p_net_device_val;
             }
 
@@ -293,9 +308,15 @@ void net_device_table_mgr::update_tbl()
 ret:
 
     m_lock.unlock();
+
     ndtm_logdbg("Check completed. Found %ld offload capable network interfaces",
                 m_net_device_map_index.size());
-
+    for (const auto &ip : duplicate_ips) {
+        vlog_printf(VLOG_WARNING,
+                    "Duplicate IP address %s detected on multiple interfaces. XLIO will work with "
+                    "a single interface.\n",
+                    ip.c_str());
+    }
     SYSCALL(close, fd);
 }
 

--- a/src/core/util/ip_address.h
+++ b/src/core/util/ip_address.h
@@ -315,7 +315,8 @@ public:
     }
 
     ip_addr(ip_addr &&addr)
-        : ip_address(addr)
+        : ip_address(std::forward<ip_address>(addr))
+        // coverity[copy_constructor_call:FALSE] /*Turn off check use_after_move*/
         , m_family(addr.m_family)
     {
     }

--- a/src/core/util/ip_address.h
+++ b/src/core/util/ip_address.h
@@ -316,7 +316,7 @@ public:
 
     ip_addr(ip_addr &&addr)
         : ip_address(std::forward<ip_address>(addr))
-        // coverity[copy_constructor_call:FALSE] /*Turn off check use_after_move*/
+        // coverity[use_after_move:FALSE] /*Turn off check use_after_move*/
         , m_family(addr.m_family)
     {
     }


### PR DESCRIPTION
In this commit, we address a scenario where more than one network interface is assigned the same IP address. The current implementation supports creating RX rules for only one interface per IP address, which can lead to issues if multiple interfaces share the same IP.

Key Changes:

Added a mechanism to detect when the same IP address is assigned to multiple interfaces.
If this conflict occurs, a warning message is printed to notify the user that this configuration is not supported.
When faced with this conflict, the implementation now prioritizes the interface that is in the "Up" state, assigning the RX rules to it.
This change helps prevent potential conflicts and ensures that the most relevant (active) interface is used when an IP address conflict occurs.


## Change type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

