### PR TITLE
issue: 4039462 XLIO crashes on thread_local stats

### DIFF
--- a/src/core/sock/sock-redirect.cpp
+++ b/src/core/sock/sock-redirect.cpp
@@ -432,7 +432,9 @@ static ssize_t sendfile_helper(sockinfo *p_socket_object, int in_fd, __off64_t *
             mapping->put();
             rc = fstat(in_fd, &st_buf);
             if ((rc == 0) && (st_buf.st_size >= (off_t)(cur_offset + count))) {
-                s->get_sock_stats()->counters.n_tx_sendfile_overflows++;
+                if (s->get_sock_stats()) {
+                    s->get_sock_stats()->counters.n_tx_sendfile_overflows++;
+                }
                 goto fallback;
             } else {
                 errno = EOVERFLOW;
@@ -455,7 +457,9 @@ static ssize_t sendfile_helper(sockinfo *p_socket_object, int in_fd, __off64_t *
     fallback:
         /* Fallback to readv() implementation */
         if (totSent == 0) {
-            s->get_sock_stats()->counters.n_tx_sendfile_fallbacks++;
+            if (s->get_sock_stats()) {
+                s->get_sock_stats()->counters.n_tx_sendfile_fallbacks++;
+            }
             tx_arg.clear();
             tx_arg.opcode = TX_FILE;
             tx_arg.attr.iov = piov;
@@ -526,7 +530,9 @@ static ssize_t sendfile_helper(sockinfo *p_socket_object, int in_fd, __off64_t *
             char buf[sysconf(_SC_PAGE_SIZE)];
             ssize_t toRead, numRead, numSent = 0;
 
-            s->get_sock_stats()->counters.n_tx_sendfile_fallbacks++;
+            if (s->get_sock_stats()) {
+                s->get_sock_stats()->counters.n_tx_sendfile_fallbacks++;
+            }
 
             while (count > 0) {
                 toRead = min(sizeof(buf), count);

--- a/src/core/sock/sock_stats.cpp
+++ b/src/core/sock/sock_stats.cpp
@@ -33,7 +33,6 @@
 
 #include "sock_stats.h"
 
-thread_local socket_stats_t sock_stats::t_dummy_stats;
 sock_stats *sock_stats::s_instance = nullptr;
 
 void sock_stats::init_instance(size_t max_stats)

--- a/src/core/sock/sock_stats.h
+++ b/src/core/sock/sock_stats.h
@@ -49,8 +49,6 @@ public:
     socket_stats_t *get_stats_obj();
     void return_stats_obj(socket_stats_t *stats);
 
-    static thread_local socket_stats_t t_dummy_stats;
-
 private:
     sock_stats() {}
     void init_sock_stats(size_t max_stats);

--- a/src/core/sock/sockinfo.cpp
+++ b/src/core/sock/sockinfo.cpp
@@ -97,11 +97,11 @@ const char *sockinfo::setsockopt_so_opt_to_str(int opt)
 }
 
 sockinfo::sockinfo(int fd, int domain, bool use_ring_locks)
-    : m_fd_context((void *)((uintptr_t)fd))
+    : m_skip_cq_poll_in_rx(safe_mce_sys().skip_poll_in_rx == SKIP_POLL_IN_RX_ENABLE)
+    , m_fd_context((void *)((uintptr_t)fd))
     , m_family(domain)
     , m_fd(fd)
     , m_rx_num_buffs_reuse(safe_mce_sys().rx_bufs_batch)
-    , m_skip_cq_poll_in_rx(safe_mce_sys().skip_poll_in_rx == SKIP_POLL_IN_RX_ENABLE)
     , m_is_ipv6only(safe_mce_sys().sysctl_reader.get_ipv6_bindv6only())
     , m_lock_rcv(MULTILOCK_RECURSIVE, MODULE_NAME "::m_lock_rcv")
     , m_lock_snd(MODULE_NAME "::m_lock_snd")
@@ -161,7 +161,7 @@ sockinfo::~sockinfo()
         }
     }
 
-    if (m_has_stats) {
+    if (m_p_socket_stats) {
         xlio_stats_instance_remove_socket_block(m_p_socket_stats);
         sock_stats::instance().return_stats_obj(m_p_socket_stats);
     }
@@ -182,14 +182,12 @@ sockinfo::~sockinfo()
 
 void sockinfo::socket_stats_init()
 {
-    if (!m_has_stats) { // This check is for listen sockets.
+    if (!m_p_socket_stats) { // This check is for listen sockets.
         m_p_socket_stats = sock_stats::instance().get_stats_obj();
         if (!m_p_socket_stats) {
-            m_p_socket_stats = &sock_stats::t_dummy_stats;
             return;
         }
 
-        m_has_stats = true;
         // Save stats as local copy and allow state publisher to copy from this location
         xlio_stats_instance_create_socket_block(m_p_socket_stats);
     }
@@ -243,7 +241,7 @@ void sockinfo::set_blocking(bool is_blocked)
 {
     si_logdbg("set socket to %s mode", is_blocked ? "blocked" : "non-blocking");
     m_b_blocking = is_blocked;
-    m_p_socket_stats->b_blocking = m_b_blocking;
+    IF_STATS(m_p_socket_stats->b_blocking = m_b_blocking);
 }
 
 int sockinfo::fcntl_helper(int __cmd, unsigned long int __arg, bool &bexit)
@@ -341,9 +339,11 @@ int sockinfo::set_ring_attr(xlio_ring_alloc_logic_attr *attr)
         }
         ring_alloc_logic_updater du(get_fd(), m_lock_snd, m_ring_alloc_log_tx, m_p_socket_stats);
         update_header_field(&du);
-        m_p_socket_stats->ring_alloc_logic_tx = m_ring_alloc_log_tx.get_ring_alloc_logic();
-        m_p_socket_stats->ring_user_id_tx =
-            ring_allocation_logic_tx(get_fd(), m_ring_alloc_log_tx).calc_res_key_by_logic();
+        if (m_p_socket_stats) {
+            m_p_socket_stats->ring_alloc_logic_tx = m_ring_alloc_log_tx.get_ring_alloc_logic();
+            m_p_socket_stats->ring_user_id_tx =
+                ring_allocation_logic_tx(get_fd(), m_ring_alloc_log_tx).calc_res_key_by_logic();
+        }
     }
     if ((attr->comp_mask & XLIO_RING_ALLOC_MASK_RING_INGRESS) && attr->ingress) {
         ring_alloc_logic_attr old_key(*m_ring_alloc_logic_rx.get_key());
@@ -358,8 +358,10 @@ int sockinfo::set_ring_attr(xlio_ring_alloc_logic_attr *attr)
             do_rings_migration_rx(old_key);
         }
 
-        m_p_socket_stats->ring_alloc_logic_rx = m_ring_alloc_log_rx.get_ring_alloc_logic();
-        m_p_socket_stats->ring_user_id_rx = m_ring_alloc_logic_rx.calc_res_key_by_logic();
+        if (m_p_socket_stats) {
+            m_p_socket_stats->ring_alloc_logic_rx = m_ring_alloc_log_rx.get_ring_alloc_logic();
+            m_p_socket_stats->ring_user_id_rx = m_ring_alloc_logic_rx.calc_res_key_by_logic();
+        }
     }
 
     return SOCKOPT_INTERNAL_XLIO_SUPPORT;
@@ -382,8 +384,10 @@ void sockinfo::set_ring_logic_rx(ring_alloc_logic_attr ral)
     if (m_rx_ring_map.empty()) {
         m_ring_alloc_log_rx = ral;
         m_ring_alloc_logic_rx = ring_allocation_logic_rx(get_fd(), m_ring_alloc_log_rx);
-        m_p_socket_stats->ring_alloc_logic_rx = m_ring_alloc_log_rx.get_ring_alloc_logic();
-        m_p_socket_stats->ring_user_id_rx = m_ring_alloc_logic_rx.calc_res_key_by_logic();
+        if (m_p_socket_stats) {
+            m_p_socket_stats->ring_alloc_logic_rx = m_ring_alloc_log_rx.get_ring_alloc_logic();
+            m_p_socket_stats->ring_user_id_rx = m_ring_alloc_logic_rx.calc_res_key_by_logic();
+        }
     }
 }
 
@@ -391,9 +395,11 @@ void sockinfo::set_ring_logic_tx(ring_alloc_logic_attr ral)
 {
     if (!m_p_connected_dst_entry) {
         m_ring_alloc_log_tx = ral;
-        m_p_socket_stats->ring_alloc_logic_tx = m_ring_alloc_log_tx.get_ring_alloc_logic();
-        m_p_socket_stats->ring_user_id_tx =
-            ring_allocation_logic_tx(get_fd(), m_ring_alloc_log_tx).calc_res_key_by_logic();
+        if (m_p_socket_stats) {
+            m_p_socket_stats->ring_alloc_logic_tx = m_ring_alloc_log_tx.get_ring_alloc_logic();
+            m_p_socket_stats->ring_user_id_tx =
+                ring_allocation_logic_tx(get_fd(), m_ring_alloc_log_tx).calc_res_key_by_logic();
+        }
     }
 }
 
@@ -853,7 +859,7 @@ int sockinfo::get_sock_by_L3_L4(in_protocol_t protocol, const ip_address &ip, in
 
 void sockinfo::save_stats_rx_offload(int nbytes)
 {
-    if (unlikely(has_stats()) && nbytes < 0) {
+    if (unlikely(m_p_socket_stats) && nbytes < 0) {
         if (errno == EAGAIN) {
             m_p_socket_stats->counters.n_rx_eagain++;
         } else {
@@ -864,25 +870,29 @@ void sockinfo::save_stats_rx_offload(int nbytes)
 
 void sockinfo::save_stats_rx_os(int bytes)
 {
-    if (bytes >= 0) {
-        m_p_socket_stats->counters.n_rx_os_bytes += bytes;
-        m_p_socket_stats->counters.n_rx_os_packets++;
-    } else if (errno == EAGAIN) {
-        m_p_socket_stats->counters.n_rx_os_eagain++;
-    } else {
-        m_p_socket_stats->counters.n_rx_os_errors++;
+    if (m_p_socket_stats) {
+        if (bytes >= 0) {
+            m_p_socket_stats->counters.n_rx_os_bytes += bytes;
+            m_p_socket_stats->counters.n_rx_os_packets++;
+        } else if (errno == EAGAIN) {
+            m_p_socket_stats->counters.n_rx_os_eagain++;
+        } else {
+            m_p_socket_stats->counters.n_rx_os_errors++;
+        }
     }
 }
 
 void sockinfo::save_stats_tx_os(int bytes)
 {
-    if (bytes >= 0) {
-        m_p_socket_stats->counters.n_tx_os_bytes += bytes;
-        m_p_socket_stats->counters.n_tx_os_packets++;
-    } else if (errno == EAGAIN) {
-        m_p_socket_stats->counters.n_rx_os_eagain++;
-    } else {
-        m_p_socket_stats->counters.n_tx_os_errors++;
+    if (m_p_socket_stats) {
+        if (bytes >= 0) {
+            m_p_socket_stats->counters.n_tx_os_bytes += bytes;
+            m_p_socket_stats->counters.n_tx_os_packets++;
+        } else if (errno == EAGAIN) {
+            m_p_socket_stats->counters.n_rx_os_eagain++;
+        } else {
+            m_p_socket_stats->counters.n_tx_os_errors++;
+        }
     }
 }
 
@@ -1279,7 +1289,7 @@ void sockinfo::do_rings_migration_rx(resource_allocation_key &old_key)
     }
 
     unlock_rx_q();
-    m_p_socket_stats->counters.n_rx_migrations++;
+    IF_STATS(m_p_socket_stats->counters.n_rx_migrations++);
 }
 
 void sockinfo::consider_rings_migration_rx()
@@ -1407,7 +1417,7 @@ void sockinfo::statistics_print(vlog_levels_t log_level /* = VLOG_DEBUG */)
                     m_p_connected_dst_entry->is_offloaded() ? "true" : "false");
     }
 
-    if (!has_stats()) {
+    if (!m_p_socket_stats) {
         return;
     }
 
@@ -1755,10 +1765,11 @@ void sockinfo::pop_descs_rx_ready(descq_t *cache, ring *p_ring)
             continue;
         }
         m_n_rx_pkt_ready_list_count--;
-        m_p_socket_stats->n_rx_ready_pkt_count--;
-
         m_rx_ready_byte_count -= temp->rx.sz_payload;
-        m_p_socket_stats->n_rx_ready_byte_count -= temp->rx.sz_payload;
+        if (m_p_socket_stats) {
+            m_p_socket_stats->n_rx_ready_pkt_count--;
+            m_p_socket_stats->n_rx_ready_byte_count -= temp->rx.sz_payload;
+        }
         cache->push_back(temp);
     }
 }
@@ -1773,10 +1784,11 @@ void sockinfo::push_descs_rx_ready(descq_t *cache)
         temp = cache->front();
         cache->pop_front();
         m_n_rx_pkt_ready_list_count++;
-        m_p_socket_stats->n_rx_ready_pkt_count++;
-
         m_rx_ready_byte_count += temp->rx.sz_payload;
-        m_p_socket_stats->n_rx_ready_byte_count += temp->rx.sz_payload;
+        if (m_p_socket_stats) {
+            m_p_socket_stats->n_rx_ready_pkt_count++;
+            m_p_socket_stats->n_rx_ready_byte_count += temp->rx.sz_payload;
+        }
         push_back_m_rx_pkt_ready_list(temp);
     }
 }

--- a/src/core/sock/sockinfo_tcp.h
+++ b/src/core/sock/sockinfo_tcp.h
@@ -198,7 +198,7 @@ public:
     void setPassthrough(bool _isPassthrough)
     {
         m_sock_offload = _isPassthrough ? TCP_SOCK_PASSTHROUGH : TCP_SOCK_LWIP;
-        m_p_socket_stats->b_is_offloaded = !_isPassthrough;
+        IF_STATS(m_p_socket_stats->b_is_offloaded = !_isPassthrough);
     }
     void setPassthrough() override { setPassthrough(true); }
     bool isPassthrough() override { return m_sock_offload == TCP_SOCK_PASSTHROUGH; }

--- a/src/core/sock/sockinfo_udp.h
+++ b/src/core/sock/sockinfo_udp.h
@@ -87,7 +87,10 @@ public:
     sockinfo_udp(int fd, int domain);
     ~sockinfo_udp() override;
 
-    void setPassthrough() override { m_p_socket_stats->b_is_offloaded = m_sock_offload = false; }
+    void setPassthrough() override
+    {
+        IF_STATS(m_p_socket_stats->b_is_offloaded = m_sock_offload = false);
+    }
     bool isPassthrough() override { return !m_sock_offload; }
 
     int prepare_to_connect(const sockaddr *__to, socklen_t __tolen);

--- a/src/core/sock/sockinfo_ulp.cpp
+++ b/src/core/sock/sockinfo_ulp.cpp
@@ -603,7 +603,9 @@ int sockinfo_tcp_ops_tls::setsockopt(int __level, int __optname, const void *__o
             return -1;
         }
         m_is_tls_tx = true;
-        m_p_sock->get_sock_stats()->tls_tx_offload = true;
+        if (m_p_sock->get_sock_stats()) {
+            m_p_sock->get_sock_stats()->tls_tx_offload = true;
+        }
     } else {
         m_p_cipher_ctx = (void *)g_tls_api->EVP_CIPHER_CTX_new();
         if (unlikely(!m_p_cipher_ctx)) {
@@ -656,12 +658,16 @@ int sockinfo_tcp_ops_tls::setsockopt(int __level, int __optname, const void *__o
         }
 
         tcp_recv(m_p_sock->get_pcb(), sockinfo_tcp_ops_tls::rx_lwip_cb);
-        m_p_sock->get_sock_stats()->tls_rx_offload = true;
+        if (m_p_sock->get_sock_stats()) {
+            m_p_sock->get_sock_stats()->tls_rx_offload = true;
+        }
         m_p_sock->unlock_tcp_con();
     }
 
-    m_p_sock->get_sock_stats()->tls_version = base_info->version;
-    m_p_sock->get_sock_stats()->tls_cipher = base_info->cipher_type;
+    if (m_p_sock->get_sock_stats()) {
+        m_p_sock->get_sock_stats()->tls_version = base_info->version;
+        m_p_sock->get_sock_stats()->tls_cipher = base_info->cipher_type;
+    }
 
     si_ulp_logdbg("TLS%s %s offload is configured, keylen=%u",
                   base_info->version == TLS_1_2_VERSION ? "1.2" : "1.3",
@@ -858,7 +864,7 @@ done:
     /* Statistics */
     if (ret > 0) {
         errno = errno_save;
-        if (unlikely(m_p_sock->has_stats())) {
+        if (unlikely(m_p_sock->get_sock_stats())) {
             m_p_sock->get_sock_stats()->tls_counters.n_tls_tx_records +=
                 m_next_recno_tx - last_recno;
             m_p_sock->get_sock_stats()->tls_counters.n_tls_tx_bytes += ret;
@@ -977,9 +983,11 @@ int sockinfo_tcp_ops_tls::postrouting(struct pbuf *p, struct tcp_seg *seg, xlio_
                 m_expected_seqno = seg->seqno;
 
                 /* Statistics */
-                ++m_p_sock->get_sock_stats()->tls_counters.n_tls_tx_resync;
-                m_p_sock->get_sock_stats()->tls_counters.n_tls_tx_resync_replay +=
-                    (seg->seqno != rec->m_seqno);
+                if (m_p_sock->get_sock_stats()) {
+                    ++m_p_sock->get_sock_stats()->tls_counters.n_tls_tx_resync;
+                    m_p_sock->get_sock_stats()->tls_counters.n_tls_tx_resync_replay +=
+                        (seg->seqno != rec->m_seqno);
+                }
             }
             m_expected_seqno += seg->len;
             attr.tis = m_p_tis;
@@ -1298,7 +1306,9 @@ err_t sockinfo_tcp_ops_tls::recv(struct pbuf *p)
             memset(m_rx_psv_buf->lwip_pbuf.payload, 0, 64);
             m_rx_resync_recno = m_next_recno_rx;
             m_p_tx_ring->tls_get_progress_params_rx(m_p_tir, payload, LKEY_TX_DEFAULT);
-            ++m_p_sock->get_sock_stats()->tls_counters.n_tls_rx_resync;
+            if (m_p_sock->get_sock_stats()) {
+                ++m_p_sock->get_sock_stats()->tls_counters.n_tls_rx_resync;
+            }
         }
     }
 
@@ -1442,7 +1452,7 @@ check_single_record:
         }
 
         /* Statistics */
-        if (unlikely(m_p_sock->has_stats())) {
+        if (unlikely(m_p_sock->get_sock_stats())) {
             m_p_sock->get_sock_stats()->tls_counters.n_tls_rx_records_enc += !!(decrypted_nr == 0);
             m_p_sock->get_sock_stats()->tls_counters.n_tls_rx_records_partial +=
                 !!(decrypted_nr != 0);
@@ -1478,7 +1488,7 @@ check_single_record:
     }
 
     /* Statistics */
-    if (unlikely(m_p_sock->has_stats())) {
+    if (unlikely(m_p_sock->get_sock_stats())) {
         m_p_sock->get_sock_stats()->tls_counters.n_tls_rx_records += 1U;
         m_p_sock->get_sock_stats()->tls_counters.n_tls_rx_bytes += likely(pres) ? pres->tot_len : 0;
         /* Adjust TCP counters with received TLS header/trailer. */

--- a/src/core/util/data_updater.cpp
+++ b/src/core/util/data_updater.cpp
@@ -89,7 +89,9 @@ ring_alloc_logic_updater::ring_alloc_logic_updater(int fd, lock_base &socket_loc
 bool ring_alloc_logic_updater::update_field(dst_entry &dst)
 {
     if (dst.update_ring_alloc_logic(m_fd, m_socket_lock, m_key)) {
-        m_sock_stats->counters.n_tx_migrations++;
+        if (m_sock_stats) {
+            m_sock_stats->counters.n_tx_migrations++;
+        }
     }
 
     return true;


### PR DESCRIPTION
## Description
Fixing XLIO crash with thread_local stats object

##### What
The thread_local objects are deallocated once the thread is finished.
Depending on the configuration sockets can use a pointer to a thread_local stats object.
If that thread is finished but the socket is still alive, XLIO will try to access deallocated stats object and hit seg fault.

##### Why ?
Crash fix

##### How ?
To make things straight forward we always ask if stats object exists. This should also be the most efficient. No more thread_local or global dummy object. 

## Change type
What kind of change does this PR introduce?
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

