### PR TITLE
issue: 4040479 Remove XLIO_TX/RX_BUFS parameters

### DIFF
--- a/README
+++ b/README
@@ -668,12 +668,6 @@ XLIO_STRQ_STRIDE_SIZE_BYTES
 The size, in bytes, of each stride in a receive WQE. Must be power of two and in range [64 - 8192]
 Default: 512
 
-XLIO_STRQ_STRIDES_NUM_BUFS
-The initial number of stride objects in the strides pool. Each received packet is represented by a stride object.
-Each stride object points to a portion of a buffer allocated for a receive WQE.
-When the pool runs out of stride objects it expands by another portion of this value.
-Default: 262144
-
 XLIO_STRQ_STRIDES_COMPENSATION_LEVEL
 Number of spare stride objects a CQ holds to allow faster allocation of a stride object when a packet arrives.
 Default: 16384

--- a/README
+++ b/README
@@ -88,7 +88,6 @@ Example:
  XLIO DETAILS: TCP max syn rate               0 (no limit)               [XLIO_TCP_MAX_SYN_RATE]
  XLIO DETAILS: Zerocopy Mem Bufs              200000                     [XLIO_ZC_BUFS]
  XLIO DETAILS: Zerocopy Cache Threshold       10 GB                      [XLIO_ZC_CACHE_THRESHOLD]
- XLIO DETAILS: Tx Mem Bufs                    200000                     [XLIO_TX_BUFS]
  XLIO DETAILS: Tx Mem Buf size                0                          [XLIO_TX_BUF_SIZE]
  XLIO DETAILS: ZC TX size                     32 KB                      [XLIO_ZC_TX_SIZE]
  XLIO DETAILS: Tx QP WRE                      32768                      [XLIO_TX_WRE]
@@ -100,7 +99,6 @@ Example:
  XLIO DETAILS: Tx Bufs Batch TCP              16                         [XLIO_TX_BUFS_BATCH_TCP]
  XLIO DETAILS: Tx Segs Batch TCP              64                         [XLIO_TX_SEGS_BATCH_TCP]
  XLIO DETAILS: TCP Send Buffer size           1 MB                       [XLIO_TCP_SEND_BUFFER_SIZE]
- XLIO DETAILS: Rx Mem Bufs                    200000                     [XLIO_RX_BUFS]
  XLIO DETAILS: Rx Mem Buf size                0                          [XLIO_RX_BUF_SIZE]
  XLIO DETAILS: Rx QP WRE                      16000                      [XLIO_RX_WRE]
  XLIO DETAILS: Rx QP WRE Batching             1024                       [XLIO_RX_WRE_BATCHING]
@@ -322,10 +320,6 @@ XLIO_ZC_CACHE_THRESHOLD
 Memory limit for the mapping cache which is use by sendfile().
 Default value is 10GB
 
-XLIO_TX_BUFS
-Number of global Tx data buffer elements allocation.
-Default value is 200000
-
 XLIO_TX_BUF_SIZE
 Size of Tx data buffer elements allocation.
 Can not be less then MTU (Maximum Transfer Unit) and greater than 0xFF00.
@@ -429,8 +423,6 @@ Limit the number of rings that can be allocated per interface.
 For example, in ring allocation per socket logic, if the number of sockets using
 the same interface is larger than the limit, then several sockets will be sharing the
 same ring.
-[Note:XLIO_RX_BUFS might need to be adjusted in order to have enough buffers for all
-rings in the system. Each ring consume XLIO_RX_WRE buffers.]
 Use a value of 0 for unlimited number of rings.
 Default value is 0 (no limit)
 
@@ -442,11 +434,6 @@ for each TX ring.
 The total size of the On Device Memory is limited to 256k for a single port HCA and to
 128k for dual port HCA.
 Default value is 0
-
-XLIO_RX_BUFS
-Number Rx data buffer elements allocation for the processes. These data buffers
-may be used by all QPs on all HCAs
-Default value is 200000
 
 XLIO_RX_BUF_SIZE
 Size of Rx data buffer elements allocation.

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -566,8 +566,6 @@ void print_xlio_global_settings()
     VLOG_PARAM_STRING("Zerocopy Cache Threshold", safe_mce_sys().zc_cache_threshold,
                       MCE_DEFAULT_ZC_CACHE_THRESHOLD, SYS_VAR_ZC_CACHE_THRESHOLD,
                       option_size::to_str(safe_mce_sys().zc_cache_threshold));
-    VLOG_PARAM_NUMBER("Tx Mem Bufs", safe_mce_sys().tx_num_bufs, MCE_DEFAULT_TX_NUM_BUFS,
-                      SYS_VAR_TX_NUM_BUFS);
     VLOG_PARAM_STRING("Tx Mem Buf size", safe_mce_sys().tx_buf_size, MCE_DEFAULT_TX_BUF_SIZE,
                       SYS_VAR_TX_BUF_SIZE, option_size::to_str(safe_mce_sys().tx_buf_size));
     VLOG_PARAM_NUMBER("Tx QP WRE", safe_mce_sys().tx_num_wr, MCE_DEFAULT_TX_NUM_WRE,
@@ -593,10 +591,6 @@ void print_xlio_global_settings()
     VLOG_PARAM_STRING("TCP Send Buffer size", safe_mce_sys().tcp_send_buffer_size,
                       MCE_DEFAULT_TCP_SEND_BUFFER_SIZE, SYS_VAR_TCP_SEND_BUFFER_SIZE,
                       option_size::to_str(safe_mce_sys().tcp_send_buffer_size));
-    VLOG_PARAM_NUMBER(
-        "Rx Mem Bufs", safe_mce_sys().rx_num_bufs,
-        (safe_mce_sys().enable_striding_rq ? MCE_DEFAULT_STRQ_NUM_BUFS : MCE_DEFAULT_RX_NUM_BUFS),
-        SYS_VAR_RX_NUM_BUFS);
     VLOG_PARAM_NUMBER(
         "Rx QP WRE", safe_mce_sys().rx_num_wr,
         (safe_mce_sys().enable_striding_rq ? MCE_DEFAULT_STRQ_NUM_WRE : MCE_DEFAULT_RX_NUM_WRE),

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -661,8 +661,6 @@ void print_xlio_global_settings()
                       MCE_DEFAULT_STRQ_NUM_STRIDES, SYS_VAR_STRQ_NUM_STRIDES);
     VLOG_PARAM_NUMBER("STRQ Stride Size (Bytes)", safe_mce_sys().strq_stride_size_bytes,
                       MCE_DEFAULT_STRQ_STRIDE_SIZE_BYTES, SYS_VAR_STRQ_STRIDE_SIZE_BYTES);
-    VLOG_PARAM_NUMBER("STRQ Initial Strides Per Ring", safe_mce_sys().strq_strides_num_bufs,
-                      MCE_DEFAULT_STRQ_STRIDES_NUM_BUFS, SYS_VAR_STRQ_STRIDES_NUM_BUFS);
     VLOG_PARAM_NUMBER(
         "STRQ Strides Compensation Level", safe_mce_sys().strq_strides_compensation_level,
         MCE_DEFAULT_STRQ_STRIDES_COMPENSATION_LEVEL, SYS_VAR_STRQ_STRIDES_COMPENSATION_LEVEL);

--- a/src/core/util/sys_vars.cpp
+++ b/src/core/util/sys_vars.cpp
@@ -812,7 +812,6 @@ void mce_sys_var::get_env_params()
     enable_strq_env = MCE_DEFAULT_STRQ;
     strq_stride_num_per_rwqe = MCE_DEFAULT_STRQ_NUM_STRIDES;
     strq_stride_size_bytes = MCE_DEFAULT_STRQ_STRIDE_SIZE_BYTES;
-    strq_strides_num_bufs = MCE_DEFAULT_STRQ_STRIDES_NUM_BUFS;
     strq_strides_compensation_level = MCE_DEFAULT_STRQ_STRIDES_COMPENSATION_LEVEL;
 
     gro_streams_max = MCE_DEFAULT_GRO_STREAMS_MAX;
@@ -987,7 +986,6 @@ void mce_sys_var::get_env_params()
         strcpy(internal_thread_affinity_str, "0"); // MCE_DEFAULT_INTERNAL_THREAD_AFFINITY_STR;
 
         if (enable_striding_rq) {
-            strq_strides_num_bufs = 131072; // MCE_DEFAULT_STRQ_NUM_BUFS(262144)
             strq_stride_num_per_rwqe = 65536; // MCE_DEFAULT_STRQ_NUM_STRIDES(16384)
             strq_stride_size_bytes = 64; // MCE_DEFAULT_STRQ_STRIDE_SIZE_BYTES(512)
         } else {
@@ -1020,7 +1018,6 @@ void mce_sys_var::get_env_params()
         ring_dev_mem_tx = 16384; // MCE_DEFAULT_RING_DEV_MEM_TX (0)
 
         if (enable_striding_rq) {
-            strq_strides_num_bufs = 131072; // MCE_DEFAULT_STRQ_NUM_BUFS(262144)
             strq_stride_num_per_rwqe = 32768; // MCE_DEFAULT_STRQ_NUM_STRIDES(16384)
             strq_stride_size_bytes = 64; // MCE_DEFAULT_STRQ_STRIDE_SIZE_BYTES(512)
         } else {
@@ -1155,7 +1152,6 @@ void mce_sys_var::get_env_params()
 
             // Derived from Latency profile but changed.
             strq_stride_num_per_rwqe = 8192;
-            strq_strides_num_bufs = 131072;
             strq_stride_size_bytes = 64;
         }
 
@@ -1259,10 +1255,6 @@ void mce_sys_var::get_env_params()
 
     read_strq_strides_num();
     read_strq_stride_size_bytes();
-
-    if ((env_ptr = getenv(SYS_VAR_STRQ_STRIDES_NUM_BUFS))) {
-        strq_strides_num_bufs = (uint32_t)atoi(env_ptr);
-    }
 
     if ((env_ptr = getenv(SYS_VAR_STRQ_STRIDES_COMPENSATION_LEVEL))) {
         strq_strides_compensation_level = (uint32_t)atoi(env_ptr);

--- a/src/core/util/sys_vars.cpp
+++ b/src/core/util/sys_vars.cpp
@@ -780,7 +780,6 @@ void mce_sys_var::get_env_params()
     tcp_max_syn_rate = MCE_DEFAULT_TCP_MAX_SYN_RATE;
 
     zc_cache_threshold = MCE_DEFAULT_ZC_CACHE_THRESHOLD;
-    tx_num_bufs = MCE_DEFAULT_TX_NUM_BUFS;
     tx_buf_size = MCE_DEFAULT_TX_BUF_SIZE;
     tcp_nodelay_treshold = MCE_DEFAULT_TCP_NODELAY_TRESHOLD;
     tx_num_wr = MCE_DEFAULT_TX_NUM_WRE;
@@ -794,7 +793,6 @@ void mce_sys_var::get_env_params()
     tx_segs_batch_tcp = MCE_DEFAULT_TX_SEGS_BATCH_TCP;
     tx_segs_ring_batch_tcp = MCE_DEFAULT_TX_SEGS_RING_BATCH_TCP;
     tx_segs_pool_batch_tcp = MCE_DEFAULT_TX_SEGS_POOL_BATCH_TCP;
-    rx_num_bufs = MCE_DEFAULT_RX_NUM_BUFS;
     rx_buf_size = MCE_DEFAULT_RX_BUF_SIZE;
     rx_bufs_batch = MCE_DEFAULT_RX_BUFS_BATCH;
     rx_num_wr = MCE_DEFAULT_RX_NUM_WRE;
@@ -927,7 +925,6 @@ void mce_sys_var::get_env_params()
     enable_striding_rq = (enable_strq_env == option_3::ON || enable_strq_env == option_3::AUTO);
 
     if (enable_striding_rq) {
-        rx_num_bufs = MCE_DEFAULT_STRQ_NUM_BUFS;
         rx_num_wr = MCE_DEFAULT_STRQ_NUM_WRE;
         rx_num_wr_to_post_recv = MCE_DEFAULT_STRQ_NUM_WRE_TO_POST_RECV;
         qp_compensation_level = MCE_DEFAULT_STRQ_COMPENSATION_LEVEL;
@@ -1275,12 +1272,6 @@ void mce_sys_var::get_env_params()
         zc_cache_threshold = option_size::from_str(env_ptr);
     }
 
-    bool tx_num_bufs_set = false;
-    if ((env_ptr = getenv(SYS_VAR_TX_NUM_BUFS))) {
-        tx_num_bufs = (uint32_t)atoi(env_ptr);
-        tx_num_bufs_set = true;
-    }
-
     if ((env_ptr = getenv(SYS_VAR_TX_BUF_SIZE))) {
         tx_buf_size = (uint32_t)option_size::from_str(env_ptr);
     }
@@ -1376,12 +1367,6 @@ void mce_sys_var::get_env_params()
 
     if ((env_ptr = getenv(SYS_VAR_TCP_MAX_SYN_RATE))) {
         tcp_max_syn_rate = std::min(TCP_MAX_SYN_RATE_TOP_LIMIT, std::max(0, atoi(env_ptr)));
-    }
-
-    bool rx_num_bufs_set = false;
-    if ((env_ptr = getenv(SYS_VAR_RX_NUM_BUFS))) {
-        rx_num_bufs = (uint32_t)atoi(env_ptr);
-        rx_num_bufs_set = true;
     }
 
     if ((env_ptr = getenv(SYS_VAR_RX_BUF_SIZE))) {
@@ -1811,45 +1796,6 @@ void mce_sys_var::get_env_params()
     }
     if ((env_ptr = getenv(SYS_VAR_MEMORY_LIMIT))) {
         memory_limit = option_size::from_str(env_ptr) ?: MCE_DEFAULT_MEMORY_LIMIT;
-    } else {
-        /*
-         * This section is for backward compatibility with deprecated parameters
-         * XLIO_TX_BUFS and XLIO_RX_BUFS. These parameters will be removed with the future
-         * versions and only XLIO_MEMORY_LIMIT will affect memory allocation.
-         */
-        if (tx_num_bufs_set || rx_num_bufs_set || tx_buf_size != MCE_DEFAULT_TX_BUF_SIZE) {
-#if defined(DEFINED_NGINX)
-            // Adjust default buffers configuration for specific profiles
-            if (mce_spec == MCE_SPEC_NGINX) {
-                tx_num_bufs = tx_num_bufs_set ? tx_num_bufs : 1000000;
-                rx_num_bufs = (rx_num_bufs_set || !enable_striding_rq) ? rx_num_bufs : 512;
-                if (strq_stride_num_per_rwqe * strq_stride_size_bytes < 2048 * 1024) {
-                    // Increase this value back to original if user reduces the buffer size.
-                    rx_num_wr = 256;
-                }
-            } else if (mce_spec == MCE_SPEC_NGINX_DPU) {
-                tx_num_bufs = tx_num_bufs_set ? tx_num_bufs : 90000;
-                if (enable_striding_rq) {
-                    rx_num_bufs = rx_num_bufs_set ? rx_num_bufs : 384;
-                } else {
-                    rx_num_bufs = rx_num_bufs_set ? rx_num_bufs : 96000;
-                }
-            }
-#endif /* DEFINED_NGINX */
-            // We don't have net_device manager yet, so we don't know MTU. Assume ~1500.
-            size_t memory_limit_est = std::max<size_t>(tx_buf_size + 100, 2048U) * tx_num_bufs;
-            if (enable_striding_rq) {
-                memory_limit_est += strq_stride_num_per_rwqe * strq_stride_size_bytes * rx_num_bufs;
-            } else {
-                memory_limit_est += std::max<size_t>(rx_buf_size + 100, 2048U) * rx_num_bufs;
-            }
-#if defined(DEFINED_NGINX)
-            if (app.type == APP_NGINX) {
-                memory_limit_est *= std::max<size_t>(app.workers_num, 1U);
-            }
-#endif /* DEFINED_NGINX */
-            memory_limit = std::max(memory_limit, memory_limit_est);
-        }
     }
     if ((env_ptr = getenv(SYS_VAR_MEMORY_LIMIT_USER))) {
         memory_limit_user = option_size::from_str(env_ptr);
@@ -1986,15 +1932,6 @@ void mce_sys_var::get_env_params()
             temp = 0;
         }
         multilock = (multilock_t)temp;
-    }
-
-    std::vector<const char *> deprecated_params = {SYS_VAR_TX_NUM_BUFS, SYS_VAR_RX_NUM_BUFS};
-    for (const char *param : deprecated_params) {
-        env_ptr = getenv(param);
-        if (env_ptr) {
-            vlog_printf(VLOG_WARNING,
-                        "%s is deprecated and will be removed in the future versions\n", param);
-        }
     }
 }
 

--- a/src/core/util/sys_vars.h
+++ b/src/core/util/sys_vars.h
@@ -401,7 +401,6 @@ public:
 
     uint32_t strq_stride_num_per_rwqe;
     uint32_t strq_stride_size_bytes;
-    uint32_t strq_strides_num_bufs;
     uint32_t strq_strides_compensation_level;
 
     uint32_t gro_streams_max;
@@ -589,7 +588,6 @@ extern mce_sys_var &safe_mce_sys();
 #define SYS_VAR_STRQ                            "XLIO_STRQ"
 #define SYS_VAR_STRQ_NUM_STRIDES                "XLIO_STRQ_NUM_STRIDES"
 #define SYS_VAR_STRQ_STRIDE_SIZE_BYTES          "XLIO_STRQ_STRIDE_SIZE_BYTES"
-#define SYS_VAR_STRQ_STRIDES_NUM_BUFS           "XLIO_STRQ_STRIDES_NUM_BUFS"
 #define SYS_VAR_STRQ_STRIDES_COMPENSATION_LEVEL "XLIO_STRQ_STRIDES_COMPENSATION_LEVEL"
 
 #define SYS_VAR_RX_BUF_SIZE                   "XLIO_RX_BUF_SIZE"
@@ -750,7 +748,6 @@ extern mce_sys_var &safe_mce_sys();
 #define MCE_DEFAULT_STRQ_NUM_WRE                    (8)
 #define MCE_DEFAULT_STRQ_NUM_WRE_TO_POST_RECV       (1)
 #define MCE_DEFAULT_STRQ_COMPENSATION_LEVEL         (1)
-#define MCE_DEFAULT_STRQ_STRIDES_NUM_BUFS           (262144)
 #define MCE_DEFAULT_STRQ_STRIDES_COMPENSATION_LEVEL (16384)
 
 #define MCE_DEFAULT_RX_BUF_SIZE                   (0)

--- a/src/core/util/sys_vars.h
+++ b/src/core/util/sys_vars.h
@@ -370,7 +370,6 @@ public:
     int tcp_max_syn_rate;
 
     size_t zc_cache_threshold;
-    uint32_t tx_num_bufs;
     uint32_t tx_buf_size;
     uint32_t tcp_nodelay_treshold;
     uint32_t tx_num_wr;
@@ -383,7 +382,6 @@ public:
     uint32_t tx_bufs_batch_tcp;
     uint32_t tx_segs_batch_tcp;
 
-    uint32_t rx_num_bufs;
     uint32_t rx_buf_size;
     uint32_t rx_bufs_batch;
     uint32_t rx_num_wr;
@@ -577,7 +575,6 @@ extern mce_sys_var &safe_mce_sys();
 #define SYS_VAR_RING_DEV_MEM_TX          "XLIO_RING_DEV_MEM_TX"
 
 #define SYS_VAR_ZC_CACHE_THRESHOLD    "XLIO_ZC_CACHE_THRESHOLD"
-#define SYS_VAR_TX_NUM_BUFS           "XLIO_TX_BUFS"
 #define SYS_VAR_TX_BUF_SIZE           "XLIO_TX_BUF_SIZE"
 #define SYS_VAR_TCP_NODELAY_TRESHOLD  "XLIO_TCP_NODELAY_TRESHOLD"
 #define SYS_VAR_TX_NUM_WRE            "XLIO_TX_WRE"
@@ -595,7 +592,6 @@ extern mce_sys_var &safe_mce_sys();
 #define SYS_VAR_STRQ_STRIDES_NUM_BUFS           "XLIO_STRQ_STRIDES_NUM_BUFS"
 #define SYS_VAR_STRQ_STRIDES_COMPENSATION_LEVEL "XLIO_STRQ_STRIDES_COMPENSATION_LEVEL"
 
-#define SYS_VAR_RX_NUM_BUFS                   "XLIO_RX_BUFS"
 #define SYS_VAR_RX_BUF_SIZE                   "XLIO_RX_BUF_SIZE"
 #define SYS_VAR_RX_NUM_WRE                    "XLIO_RX_WRE"
 #define SYS_VAR_RX_NUM_WRE_TO_POST_RECV       "XLIO_RX_WRE_BATCHING"
@@ -733,7 +729,6 @@ extern mce_sys_var &safe_mce_sys();
 #define MCE_DEFAULT_TCP_MAX_SYN_RATE         (0)
 #define MCE_DEFAULT_TCP_NODELAY_TRESHOLD     (0)
 #define MCE_DEFAULT_ZC_CACHE_THRESHOLD       (10LU * 1024 * 1024 * 1024) // 10GB
-#define MCE_DEFAULT_TX_NUM_BUFS              (200000)
 #define MCE_DEFAULT_TX_BUF_SIZE              (0)
 #define MCE_DEFAULT_TX_NUM_WRE               (32768)
 #define MCE_DEFAULT_TX_NUM_WRE_TO_SIGNAL     (64)
@@ -752,14 +747,12 @@ extern mce_sys_var &safe_mce_sys();
 #define MCE_DEFAULT_STRQ                            (option_3::ON)
 #define MCE_DEFAULT_STRQ_NUM_STRIDES                (16384)
 #define MCE_DEFAULT_STRQ_STRIDE_SIZE_BYTES          (512)
-#define MCE_DEFAULT_STRQ_NUM_BUFS                   (64)
 #define MCE_DEFAULT_STRQ_NUM_WRE                    (8)
 #define MCE_DEFAULT_STRQ_NUM_WRE_TO_POST_RECV       (1)
 #define MCE_DEFAULT_STRQ_COMPENSATION_LEVEL         (1)
 #define MCE_DEFAULT_STRQ_STRIDES_NUM_BUFS           (262144)
 #define MCE_DEFAULT_STRQ_STRIDES_COMPENSATION_LEVEL (16384)
 
-#define MCE_DEFAULT_RX_NUM_BUFS                   (200000)
 #define MCE_DEFAULT_RX_BUF_SIZE                   (0)
 #define MCE_DEFAULT_RX_BUFS_BATCH                 (64)
 #define MCE_DEFAULT_RX_NUM_WRE                    (16000)


### PR DESCRIPTION
## Description
The parameters have been deprecated for some time and replaced with
XLIO_MEMORY_LIMIT logic.

Previous release printed a warning if the parameters were used. It's
time to remove them completely and use the new functionality
unconditionally.

Also, Remove unused XLIO_STRQ_STRIDES_NUM_BUFS.

##### What
Remove XLIO_TX/RX_BUFS and XLIO_STRQ_STRIDES_NUM_BUFS parameters.

##### Why ?
Deprecated and unused parameters.

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

