### PR TITLE
issue: 4043152 Removing redundant net_dev_entry registration socket

### DIFF
--- a/src/core/proto/dst_entry_udp_mc.cpp
+++ b/src/core/proto/dst_entry_udp_mc.cpp
@@ -61,6 +61,8 @@ dst_entry_udp_mc::~dst_entry_udp_mc()
         // Registered in: dst_entry_udp_mc::resolve_net_dev
         // With: g_p_net_device_table_mgr->register_observer(ip_addr(m_mc_tx_src_ip.get_in_addr()),
         //                                                   this, &net_dev_entry).
+        dst_udp_mc_logdbg("Unregistering net_dev MC observer if_index: %d",
+                          m_p_net_dev_val->get_if_idx());
         if (!g_p_net_device_table_mgr->unregister_observer(m_p_net_dev_val->get_if_idx(), this)) {
             dst_udp_mc_logwarn("Failed to unregister observer (dst_entry_udp_mc) for if_index %d",
                                m_p_net_dev_val->get_if_idx());
@@ -93,6 +95,8 @@ bool dst_entry_udp_mc::resolve_net_dev()
                 if (g_p_net_device_table_mgr->register_observer(mc_net_dev->get_if_idx(), this,
                                                                 &net_dev_entry)) {
                     m_p_net_dev_entry = dynamic_cast<net_device_entry *>(net_dev_entry);
+                    dst_udp_mc_logdbg("Registered net_dev MC observer if_index: %d",
+                                      mc_net_dev->get_if_idx());
                 } else {
                     dst_udp_mc_logwarn(
                         "Failed to register observer (dst_entry_udp_mc) for if_index %d",

--- a/src/core/proto/route_entry.cpp
+++ b/src/core/proto/route_entry.cpp
@@ -92,15 +92,15 @@ void route_entry::register_to_net_device()
 {
     cache_entry_subject<int, net_device_val *> *net_dev_entry = nullptr;
     if (g_p_net_device_table_mgr->register_observer(m_val->get_if_index(), this, &net_dev_entry)) {
-        rt_entry_logdbg("route_entry [%p] is registered to an offloaded device", this);
+        rt_entry_logdbg("route_entry [%p] is registered to if_index: %d", this,
+                        m_val->get_if_index());
         m_p_net_dev_entry = (net_device_entry *)net_dev_entry;
         m_p_net_dev_entry->get_val(m_p_net_dev_val);
         m_b_offloaded_net_dev = true;
     } else {
         // We try to register also non-offloaded devices -> this log should be dbg.
-        rt_entry_logdbg("route_entry [%p] tried to register to non-offloaded device ---> "
-                        "registration failed, if_index: %d",
-                        this, m_val->get_if_index());
+        rt_entry_logdbg("route_entry [%p] failed to register to if_index: %d", this,
+                        m_val->get_if_index());
         m_b_offloaded_net_dev = false;
     }
 }
@@ -113,7 +113,7 @@ void route_entry::unregister_to_net_device()
     }
 
     if (m_p_net_dev_val) {
-        rt_entry_logdbg("unregister from net device idx %d", m_p_net_dev_val->get_if_idx());
+        rt_entry_logdbg("Unregistering from if_index: %d", m_p_net_dev_val->get_if_idx());
         if (!g_p_net_device_table_mgr->unregister_observer(m_p_net_dev_val->get_if_idx(), this)) {
             rt_entry_logwarn("Failed to unregister net_device_entry (route_entry) if_index %d",
                              m_p_net_dev_val->get_if_idx());

--- a/src/core/sock/sockinfo.cpp
+++ b/src/core/sock/sockinfo.cpp
@@ -1028,28 +1028,10 @@ net_device_resources_t *sockinfo::create_nd_resources(const ip_addr &ip_local)
         // Need to register as observer to net_device
         net_device_resources_t nd_resources;
         nd_resources.refcnt = 0;
-        nd_resources.p_nde = nullptr;
-        nd_resources.p_ndv = nullptr;
-        nd_resources.p_ring = nullptr;
 
-        BULLSEYE_EXCLUDE_BLOCK_START
-        cache_entry_subject<int, net_device_val *> *net_dev_entry = nullptr;
-        net_device_val *net_dev = g_p_net_device_table_mgr->get_net_device_val(ip_local);
-        if (!net_dev ||
-            !g_p_net_device_table_mgr->register_observer(net_dev->get_if_idx(), &m_rx_nd_observer,
-                                                         &net_dev_entry)) {
-            si_logwarn("Failed to register observer for local ip %s, if_index %d",
-                       ip_local.to_str().c_str(), (net_dev ? net_dev->get_if_idx() : -1));
-            goto err;
-        }
-        nd_resources.p_nde = (net_device_entry *)net_dev_entry;
-        if (!nd_resources.p_nde) {
-            si_logerr("Got NULL net_devide_entry for local ip %s", ip_local.to_str().c_str());
-            goto err;
-        }
-        if (!nd_resources.p_nde->get_val(nd_resources.p_ndv)) {
-            si_logerr("Got net_device_val=NULL (interface is not offloaded) for local ip %s",
-                      ip_local.to_str().c_str());
+        nd_resources.p_ndv = g_p_net_device_table_mgr->get_net_device_val(ip_local);
+        if (!nd_resources.p_ndv) {
+            si_logwarn("Failed to obtain device for local ip %s", ip_local.to_str().c_str());
             goto err;
         }
 
@@ -1086,7 +1068,6 @@ net_device_resources_t *sockinfo::create_nd_resources(const ip_addr &ip_local)
             si_logerr("Failed to find rx_nd_iter");
             goto err;
         }
-        BULLSEYE_EXCLUDE_BLOCK_END
     }
 
     // Now we have the net_device object (created or found)
@@ -1125,7 +1106,6 @@ bool sockinfo::destroy_nd_resources(const ip_addr &ip_local)
     if (p_nd_resources->refcnt == 0) {
 
         // Release ring reference
-        BULLSEYE_EXCLUDE_BLOCK_START
         unlock_rx_q();
         resource_allocation_key *key;
         if (m_ring_alloc_logic_rx.get_alloc_logic_type() != RING_LOGIC_PER_IP) {
@@ -1140,15 +1120,6 @@ bool sockinfo::destroy_nd_resources(const ip_addr &ip_local)
             return false;
         }
         lock_rx_q();
-
-        // Release observer reference
-        if (!g_p_net_device_table_mgr->unregister_observer(p_nd_resources->p_ndv->get_if_idx(),
-                                                           &m_rx_nd_observer)) {
-            si_logwarn("Failed to unregister observer (nd_resource) for if_index %d",
-                       p_nd_resources->p_ndv->get_if_idx());
-            return false;
-        }
-        BULLSEYE_EXCLUDE_BLOCK_END
 
         m_rx_nd_map.erase(rx_nd_iter);
     }

--- a/src/core/sock/sockinfo.h
+++ b/src/core/sock/sockinfo.h
@@ -177,7 +177,6 @@ struct epoll_fd_rec {
 };
 
 struct net_device_resources_t {
-    net_device_entry *p_nde;
     net_device_val *p_ndv;
     ring *p_ring;
     int refcnt;
@@ -554,7 +553,6 @@ protected:
     sock_addr m_bound;
     sock_addr m_connected;
     ip_addr m_so_bindtodevice_ip;
-    cache_observer m_rx_nd_observer;
     rx_net_device_map_t m_rx_nd_map;
     rx_flow_map_t m_rx_flow_map;
     rx_ring_map_t m_rx_ring_map; // CQ map


### PR DESCRIPTION
## Description
Fixing device unregistration errors in socket cleanup

##### What
See Commit message 

##### Why ?
Fixing socket cleanup

## Change type
What kind of change does this PR introduce?
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [X] Code follows the style de facto guidelines of this project
- [X] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

