### PR TITLE
HPCINFRA-2575 copyright check on doca_xlio_vNext branch

### DIFF
--- a/.ci/matrix_job.yaml
+++ b/.ci/matrix_job.yaml
@@ -17,6 +17,7 @@ kubernetes:
 
 credentials:
   - {credentialsId: '925b0900-e273-4042-bc7c-facaefae0727', usernameVariable: 'XLIO_COV_USER', passwordVariable: 'XLIO_COV_PASSWORD'}
+  - {credentialsId: 'fb735938-fa1c-4b61-b568-a7c153b4fe74', usernameVariable: 'MELLANOX_GH_USER', passwordVariable: 'MELLANOX_GH_TOKEN'}
 
 volumes:
   - {mountPath: /hpc/local/bin, hostPath: /hpc/local/bin}
@@ -155,7 +156,8 @@ steps:
 
   - name: Copyrights
     enable: ${do_copyrights}
-    run: env WORKSPACE=$PWD COMPILE_DOCA=false COMPILE_DPCP=false ./contrib/jenkins_tests/copyrights.sh
+    credentialsId: 'fb735938-fa1c-4b61-b568-a7c153b4fe74'
+    run: env WORKSPACE=$PWD COMPILE_DOCA=false COMPILE_DPCP=false GITHUB_TOKEN=$MELLANOX_GH_TOKEN ./contrib/jenkins_tests/copyrights.sh
     containerSelector:
       - "{name: 'header-check', category: 'tool', variant: 1}"
     agentSelector:

--- a/config/m4/compiler.m4
+++ b/config/m4/compiler.m4
@@ -1,5 +1,6 @@
 #
-# Copyright © 2001-2024 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # This software is available to you under a choice of one of two
 # licenses.  You may choose to be licensed under the terms of the GNU

--- a/config/m4/doca.m4
+++ b/config/m4/doca.m4
@@ -1,5 +1,6 @@
 #
-# Copyright © 2001-2024 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # This software is available to you under a choice of one of two
 # licenses.  You may choose to be licensed under the terms of the GNU

--- a/config/m4/dpcp.m4
+++ b/config/m4/dpcp.m4
@@ -1,5 +1,6 @@
 #
-# Copyright © 2001-2024 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # This software is available to you under a choice of one of two
 # licenses.  You may choose to be licensed under the terms of the GNU

--- a/config/m4/func.m4
+++ b/config/m4/func.m4
@@ -1,5 +1,6 @@
 #
-# Copyright © 2001-2024 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # This software is available to you under a choice of one of two
 # licenses.  You may choose to be licensed under the terms of the GNU

--- a/config/m4/linking_optimization.m4
+++ b/config/m4/linking_optimization.m4
@@ -1,5 +1,6 @@
 #
-# Copyright © 2001-2024 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # This software is available to you under a choice of one of two
 # licenses.  You may choose to be licensed under the terms of the GNU

--- a/config/m4/nl.m4
+++ b/config/m4/nl.m4
@@ -1,5 +1,6 @@
 #
-# Copyright © 2001-2024 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # This software is available to you under a choice of one of two
 # licenses.  You may choose to be licensed under the terms of the GNU

--- a/config/m4/opt.m4
+++ b/config/m4/opt.m4
@@ -1,5 +1,6 @@
 #
-# Copyright © 2001-2024 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # This software is available to you under a choice of one of two
 # licenses.  You may choose to be licensed under the terms of the GNU

--- a/config/m4/prof.m4
+++ b/config/m4/prof.m4
@@ -1,5 +1,6 @@
 #
-# Copyright © 2001-2024 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # This software is available to you under a choice of one of two
 # licenses.  You may choose to be licensed under the terms of the GNU

--- a/config/m4/utls.m4
+++ b/config/m4/utls.m4
@@ -1,5 +1,6 @@
 #
-# Copyright © 2001-2024 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # This software is available to you under a choice of one of two
 # licenses.  You may choose to be licensed under the terms of the GNU

--- a/config/m4/verbs.m4
+++ b/config/m4/verbs.m4
@@ -1,5 +1,6 @@
 #
-# Copyright © 2001-2024 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # This software is available to you under a choice of one of two
 # licenses.  You may choose to be licensed under the terms of the GNU

--- a/contrib/jenkins_tests/copyright-check-map.yaml
+++ b/contrib/jenkins_tests/copyright-check-map.yaml
@@ -35,7 +35,7 @@ general:
         - ".*src/core/config_parser.*"
         - ".*src/core/config_scanner\\.c"
 
-nbu-open-source:
+bsd:
     include:
         - ".*"
     exclude:

--- a/contrib/jenkins_tests/copyrights.sh
+++ b/contrib/jenkins_tests/copyrights.sh
@@ -12,7 +12,12 @@ if [ ! -d "$WORKSPACE" ]; then
     exit 1
 fi
 
-cpp_files='        "extensions": [".c", ".cc", ".cpp", "c++", ".h", ".hpp", ".cs", ".l", ".y"],'
+if [[ -z $GITHUB_TOKEN ]]; then
+    echo "ERROR: GITHUB_TOKEN variable is empty"
+    exit 1
+fi
+
+cpp_files='        "extensions": [".c", ".cc", ".cpp", "c++", ".h", ".hpp", ".cs", ".inl", ".l", ".y"],'
 sed -i "s/.*\"extensions\": \[\"\.c\".*/$cpp_files/g" /opt/nvidia/ProjectConfig/header-types.json
 
 cat /opt/nvidia/ProjectConfig/header-types.json

--- a/contrib/scripts/xlio.init.in
+++ b/contrib/scripts/xlio.init.in
@@ -1,6 +1,7 @@
 #!/bin/bash
 #
-# Copyright © 2001-2024 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # This software is available to you under a choice of one of two
 # licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/core/dev/allocator.cpp
+++ b/src/core/dev/allocator.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/dev/allocator.h
+++ b/src/core/dev/allocator.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/dev/buffer_pool.cpp
+++ b/src/core/dev/buffer_pool.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/dev/buffer_pool.h
+++ b/src/core/dev/buffer_pool.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/dev/cq_mgr_rx.cpp
+++ b/src/core/dev/cq_mgr_rx.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/dev/cq_mgr_rx.h
+++ b/src/core/dev/cq_mgr_rx.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/dev/cq_mgr_rx_inl.h
+++ b/src/core/dev/cq_mgr_rx_inl.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/dev/cq_mgr_rx_regrq.cpp
+++ b/src/core/dev/cq_mgr_rx_regrq.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/dev/cq_mgr_rx_regrq.h
+++ b/src/core/dev/cq_mgr_rx_regrq.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/dev/cq_mgr_rx_strq.cpp
+++ b/src/core/dev/cq_mgr_rx_strq.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/dev/cq_mgr_rx_strq.h
+++ b/src/core/dev/cq_mgr_rx_strq.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/dev/cq_mgr_tx.cpp
+++ b/src/core/dev/cq_mgr_tx.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/dev/cq_mgr_tx.h
+++ b/src/core/dev/cq_mgr_tx.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/dev/dm_mgr.cpp
+++ b/src/core/dev/dm_mgr.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/dev/dm_mgr.h
+++ b/src/core/dev/dm_mgr.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/dev/gro_mgr.cpp
+++ b/src/core/dev/gro_mgr.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/dev/gro_mgr.h
+++ b/src/core/dev/gro_mgr.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/dev/hw_queue_rx.cpp
+++ b/src/core/dev/hw_queue_rx.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/dev/hw_queue_rx.h
+++ b/src/core/dev/hw_queue_rx.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/dev/hw_queue_tx.cpp
+++ b/src/core/dev/hw_queue_tx.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/dev/hw_queue_tx.h
+++ b/src/core/dev/hw_queue_tx.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/dev/ib_ctx_handler.cpp
+++ b/src/core/dev/ib_ctx_handler.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/dev/ib_ctx_handler.h
+++ b/src/core/dev/ib_ctx_handler.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/dev/ib_ctx_handler_collection.cpp
+++ b/src/core/dev/ib_ctx_handler_collection.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/dev/ib_ctx_handler_collection.h
+++ b/src/core/dev/ib_ctx_handler_collection.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/dev/net_device_entry.cpp
+++ b/src/core/dev/net_device_entry.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/dev/net_device_entry.h
+++ b/src/core/dev/net_device_entry.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/dev/net_device_table_mgr.cpp
+++ b/src/core/dev/net_device_table_mgr.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/dev/net_device_table_mgr.h
+++ b/src/core/dev/net_device_table_mgr.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/dev/net_device_val.cpp
+++ b/src/core/dev/net_device_val.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/dev/net_device_val.h
+++ b/src/core/dev/net_device_val.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/dev/rfs.cpp
+++ b/src/core/dev/rfs.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/dev/rfs.h
+++ b/src/core/dev/rfs.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/dev/rfs_mc.cpp
+++ b/src/core/dev/rfs_mc.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/dev/rfs_mc.h
+++ b/src/core/dev/rfs_mc.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/dev/rfs_rule.cpp
+++ b/src/core/dev/rfs_rule.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/dev/rfs_rule.h
+++ b/src/core/dev/rfs_rule.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/dev/rfs_uc.cpp
+++ b/src/core/dev/rfs_uc.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/dev/rfs_uc.h
+++ b/src/core/dev/rfs_uc.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/dev/rfs_uc_tcp_gro.cpp
+++ b/src/core/dev/rfs_uc_tcp_gro.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/dev/rfs_uc_tcp_gro.h
+++ b/src/core/dev/rfs_uc_tcp_gro.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/dev/ring.cpp
+++ b/src/core/dev/ring.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/dev/ring.h
+++ b/src/core/dev/ring.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/dev/ring_allocation_logic.cpp
+++ b/src/core/dev/ring_allocation_logic.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/dev/ring_allocation_logic.h
+++ b/src/core/dev/ring_allocation_logic.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/dev/ring_bond.cpp
+++ b/src/core/dev/ring_bond.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/dev/ring_bond.h
+++ b/src/core/dev/ring_bond.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/dev/ring_simple.cpp
+++ b/src/core/dev/ring_simple.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/dev/ring_simple.h
+++ b/src/core/dev/ring_simple.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/dev/ring_slave.cpp
+++ b/src/core/dev/ring_slave.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/dev/ring_slave.h
+++ b/src/core/dev/ring_slave.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/dev/ring_tap.cpp
+++ b/src/core/dev/ring_tap.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/dev/ring_tap.h
+++ b/src/core/dev/ring_tap.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/dev/src_addr_selector.cpp
+++ b/src/core/dev/src_addr_selector.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/dev/src_addr_selector.h
+++ b/src/core/dev/src_addr_selector.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/dev/time_converter.cpp
+++ b/src/core/dev/time_converter.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/dev/time_converter.h
+++ b/src/core/dev/time_converter.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/dev/time_converter_ib_ctx.cpp
+++ b/src/core/dev/time_converter_ib_ctx.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/dev/time_converter_ib_ctx.h
+++ b/src/core/dev/time_converter_ib_ctx.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/dev/time_converter_ptp.cpp
+++ b/src/core/dev/time_converter_ptp.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/dev/time_converter_ptp.h
+++ b/src/core/dev/time_converter_ptp.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/dev/time_converter_rtc.cpp
+++ b/src/core/dev/time_converter_rtc.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/dev/time_converter_rtc.h
+++ b/src/core/dev/time_converter_rtc.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/dev/wqe_send_handler.cpp
+++ b/src/core/dev/wqe_send_handler.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/dev/wqe_send_handler.h
+++ b/src/core/dev/wqe_send_handler.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/dev/xlio_ti.h
+++ b/src/core/dev/xlio_ti.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/event/command.h
+++ b/src/core/event/command.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/event/delta_timer.cpp
+++ b/src/core/event/delta_timer.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/event/delta_timer.h
+++ b/src/core/event/delta_timer.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/event/event.h
+++ b/src/core/event/event.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/event/event_handler_ibverbs.h
+++ b/src/core/event/event_handler_ibverbs.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/event/event_handler_manager.cpp
+++ b/src/core/event/event_handler_manager.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/event/event_handler_manager.h
+++ b/src/core/event/event_handler_manager.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/event/event_handler_manager_local.cpp
+++ b/src/core/event/event_handler_manager_local.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/event/event_handler_manager_local.h
+++ b/src/core/event/event_handler_manager_local.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/event/event_handler_rdma_cm.h
+++ b/src/core/event/event_handler_rdma_cm.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/event/netlink_event.cpp
+++ b/src/core/event/netlink_event.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/event/netlink_event.h
+++ b/src/core/event/netlink_event.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/event/poll_group.cpp
+++ b/src/core/event/poll_group.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/event/poll_group.h
+++ b/src/core/event/poll_group.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/event/timer_handler.h
+++ b/src/core/event/timer_handler.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/event/vlogger_timer_handler.cpp
+++ b/src/core/event/vlogger_timer_handler.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/event/vlogger_timer_handler.h
+++ b/src/core/event/vlogger_timer_handler.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/ib/base/verbs_extra.cpp
+++ b/src/core/ib/base/verbs_extra.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/ib/base/verbs_extra.h
+++ b/src/core/ib/base/verbs_extra.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/ib/mlx5/ib_mlx5.cpp
+++ b/src/core/ib/mlx5/ib_mlx5.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/ib/mlx5/ib_mlx5.h
+++ b/src/core/ib/mlx5/ib_mlx5.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/ib/mlx5/ib_mlx5_dv.cpp
+++ b/src/core/ib/mlx5/ib_mlx5_dv.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/infra/DemoCollMgr.cpp
+++ b/src/core/infra/DemoCollMgr.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/infra/DemoCollMgr.h
+++ b/src/core/infra/DemoCollMgr.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/infra/DemoObserver.cpp
+++ b/src/core/infra/DemoObserver.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/infra/DemoObserver.h
+++ b/src/core/infra/DemoObserver.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/infra/DemoSubject.cpp
+++ b/src/core/infra/DemoSubject.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/infra/DemoSubject.h
+++ b/src/core/infra/DemoSubject.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/infra/cache_subject_observer.h
+++ b/src/core/infra/cache_subject_observer.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/infra/main.cpp
+++ b/src/core/infra/main.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/infra/sender.cpp
+++ b/src/core/infra/sender.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2013-2024 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+ * Copyright (c) 2013-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/core/infra/sender.h
+++ b/src/core/infra/sender.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/infra/subject_observer.cpp
+++ b/src/core/infra/subject_observer.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/infra/subject_observer.h
+++ b/src/core/infra/subject_observer.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/iomux/epfd_info.cpp
+++ b/src/core/iomux/epfd_info.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/iomux/epfd_info.h
+++ b/src/core/iomux/epfd_info.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/iomux/epoll_wait_call.cpp
+++ b/src/core/iomux/epoll_wait_call.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/iomux/epoll_wait_call.h
+++ b/src/core/iomux/epoll_wait_call.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/iomux/io_mux_call.cpp
+++ b/src/core/iomux/io_mux_call.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/iomux/io_mux_call.h
+++ b/src/core/iomux/io_mux_call.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/iomux/poll_call.cpp
+++ b/src/core/iomux/poll_call.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/iomux/poll_call.h
+++ b/src/core/iomux/poll_call.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/iomux/select_call.cpp
+++ b/src/core/iomux/select_call.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/iomux/select_call.h
+++ b/src/core/iomux/select_call.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/libxlio.c
+++ b/src/core/libxlio.c
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/main.h
+++ b/src/core/main.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/netlink/link_info.cpp
+++ b/src/core/netlink/link_info.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/netlink/link_info.h
+++ b/src/core/netlink/link_info.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/netlink/neigh_info.cpp
+++ b/src/core/netlink/neigh_info.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/netlink/neigh_info.h
+++ b/src/core/netlink/neigh_info.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/netlink/netlink_wrapper.cpp
+++ b/src/core/netlink/netlink_wrapper.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/netlink/netlink_wrapper.h
+++ b/src/core/netlink/netlink_wrapper.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/netlink/route_info.cpp
+++ b/src/core/netlink/route_info.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/netlink/route_info.h
+++ b/src/core/netlink/route_info.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/netlink/test_main.cpp
+++ b/src/core/netlink/test_main.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/proto/L2_address.cpp
+++ b/src/core/proto/L2_address.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/proto/L2_address.h
+++ b/src/core/proto/L2_address.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/proto/arp.cpp
+++ b/src/core/proto/arp.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/proto/arp.h
+++ b/src/core/proto/arp.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/proto/dst_entry.cpp
+++ b/src/core/proto/dst_entry.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/proto/dst_entry.h
+++ b/src/core/proto/dst_entry.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/proto/dst_entry_tcp.cpp
+++ b/src/core/proto/dst_entry_tcp.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/proto/dst_entry_tcp.h
+++ b/src/core/proto/dst_entry_tcp.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/proto/dst_entry_udp.cpp
+++ b/src/core/proto/dst_entry_udp.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/proto/dst_entry_udp.h
+++ b/src/core/proto/dst_entry_udp.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/proto/dst_entry_udp_mc.cpp
+++ b/src/core/proto/dst_entry_udp_mc.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/proto/dst_entry_udp_mc.h
+++ b/src/core/proto/dst_entry_udp_mc.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/proto/flow_tuple.cpp
+++ b/src/core/proto/flow_tuple.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/proto/flow_tuple.h
+++ b/src/core/proto/flow_tuple.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/proto/header.cpp
+++ b/src/core/proto/header.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/proto/header.h
+++ b/src/core/proto/header.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/proto/ip_frag.cpp
+++ b/src/core/proto/ip_frag.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/proto/ip_frag.h
+++ b/src/core/proto/ip_frag.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/proto/mapping.cpp
+++ b/src/core/proto/mapping.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/proto/mapping.h
+++ b/src/core/proto/mapping.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/proto/mem_buf_desc.h
+++ b/src/core/proto/mem_buf_desc.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/proto/mem_desc.cpp
+++ b/src/core/proto/mem_desc.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/proto/mem_desc.h
+++ b/src/core/proto/mem_desc.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/proto/neighbour.cpp
+++ b/src/core/proto/neighbour.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/proto/neighbour.h
+++ b/src/core/proto/neighbour.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/proto/neighbour_table_mgr.cpp
+++ b/src/core/proto/neighbour_table_mgr.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/proto/neighbour_table_mgr.h
+++ b/src/core/proto/neighbour_table_mgr.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/proto/netlink_socket_mgr.cpp
+++ b/src/core/proto/netlink_socket_mgr.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/proto/netlink_socket_mgr.h
+++ b/src/core/proto/netlink_socket_mgr.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/proto/nvme_parse_input_args.h
+++ b/src/core/proto/nvme_parse_input_args.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/proto/route_entry.cpp
+++ b/src/core/proto/route_entry.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/proto/route_entry.h
+++ b/src/core/proto/route_entry.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/proto/route_rule_table_key.h
+++ b/src/core/proto/route_rule_table_key.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/proto/route_table_mgr.cpp
+++ b/src/core/proto/route_table_mgr.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/proto/route_table_mgr.h
+++ b/src/core/proto/route_table_mgr.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/proto/route_val.cpp
+++ b/src/core/proto/route_val.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/proto/route_val.h
+++ b/src/core/proto/route_val.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/proto/rule_entry.cpp
+++ b/src/core/proto/rule_entry.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/proto/rule_entry.h
+++ b/src/core/proto/rule_entry.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/proto/rule_table_mgr.cpp
+++ b/src/core/proto/rule_table_mgr.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/proto/rule_table_mgr.h
+++ b/src/core/proto/rule_table_mgr.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/proto/rule_val.cpp
+++ b/src/core/proto/rule_val.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/proto/rule_val.h
+++ b/src/core/proto/rule_val.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/proto/tls.h
+++ b/src/core/proto/tls.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/proto/xlio_lwip.cpp
+++ b/src/core/proto/xlio_lwip.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/proto/xlio_lwip.h
+++ b/src/core/proto/xlio_lwip.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/sock/bind_no_port.cpp
+++ b/src/core/sock/bind_no_port.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/sock/bind_no_port.h
+++ b/src/core/sock/bind_no_port.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/sock/cleanable_obj.h
+++ b/src/core/sock/cleanable_obj.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/sock/fd_collection.cpp
+++ b/src/core/sock/fd_collection.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/sock/fd_collection.h
+++ b/src/core/sock/fd_collection.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/sock/sock-app.cpp
+++ b/src/core/sock/sock-app.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/sock/sock-app.h
+++ b/src/core/sock/sock-app.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/sock/sock-extra.cpp
+++ b/src/core/sock/sock-extra.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/sock/sock-extra.h
+++ b/src/core/sock/sock-extra.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/sock/sock-redirect-internal.h
+++ b/src/core/sock/sock-redirect-internal.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/sock/sock-redirect.cpp
+++ b/src/core/sock/sock-redirect.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/sock/sock-redirect.h
+++ b/src/core/sock/sock-redirect.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/sock/sock_stats.cpp
+++ b/src/core/sock/sock_stats.cpp
@@ -1,5 +1,6 @@
 
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/sock/sock_stats.h
+++ b/src/core/sock/sock_stats.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/sock/sockinfo.cpp
+++ b/src/core/sock/sockinfo.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/sock/sockinfo.h
+++ b/src/core/sock/sockinfo.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/sock/sockinfo_nvme.cpp
+++ b/src/core/sock/sockinfo_nvme.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/sock/sockinfo_nvme.h
+++ b/src/core/sock/sockinfo_nvme.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/sock/sockinfo_tcp.cpp
+++ b/src/core/sock/sockinfo_tcp.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/sock/sockinfo_tcp.h
+++ b/src/core/sock/sockinfo_tcp.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/sock/sockinfo_udp.cpp
+++ b/src/core/sock/sockinfo_udp.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/sock/sockinfo_udp.h
+++ b/src/core/sock/sockinfo_udp.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/sock/sockinfo_ulp.cpp
+++ b/src/core/sock/sockinfo_ulp.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/sock/sockinfo_ulp.h
+++ b/src/core/sock/sockinfo_ulp.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/util/agent.cpp
+++ b/src/core/util/agent.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/util/agent.h
+++ b/src/core/util/agent.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/util/agent_def.h
+++ b/src/core/util/agent_def.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/util/chunk_list.h
+++ b/src/core/util/chunk_list.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/xlio.h
+++ b/src/core/xlio.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/xlio_extra.h
+++ b/src/core/xlio_extra.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/xlio_types.h
+++ b/src/core/xlio_types.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two


### PR DESCRIPTION
## Description
NVidia has changed its license & copyright header standard. We've been requested to update the project with these changes.

##### What
Upgrade codebase with new license & copyrigh headers

##### Why ?
We must make headers compliant with the new standard

##### How ?
Using the latest NGCI 5.0.3-82 Header Check Tool

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [x] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

