### PR TITLE
issue: 4071902 Fix notifications after RST

### DIFF
--- a/src/core/lwip/tcp.c
+++ b/src/core/lwip/tcp.c
@@ -321,7 +321,7 @@ void tcp_abandon(struct tcp_pcb *pcb, int reset)
     if (get_tcp_state(pcb) == TIME_WAIT) {
         tcp_pcb_remove(pcb);
     } else {
-        int send_rst = reset && (get_tcp_state(pcb) != CLOSED);
+        int send_rst = reset && (get_tcp_state(pcb) != CLOSED) && (get_tcp_state(pcb) != SYN_RCVD);
         void *errf_arg = pcb->my_container;
         tcp_err_fn errf = pcb->errf;
 

--- a/src/core/lwip/tcp_in.c
+++ b/src/core/lwip/tcp_in.c
@@ -189,9 +189,10 @@ void L3_level_tcp_input(struct pbuf *p, struct tcp_pcb *pcb)
                     /* TF_RESET means that the connection was reset by the other
                        end. We then call the error callback to inform the
                        application that the connection is dead before we
-                       deallocate the PCB. */
-                    tcp_pcb_remove(pcb);
+                       deallocate the PCB.
+                       Error callback will trigger event only if pcb is active. */
                     TCP_EVENT_ERR(pcb->errf, pcb->my_container, ERR_RST);
+                    tcp_pcb_remove(pcb);
                 } else if (in_data.recv_flags & TF_CLOSED) {
                     /* The connection has been closed and we will deallocate the
                        PCB. */


### PR DESCRIPTION
Sockets that were closed after TCP RST didn't gerenate event.
Related to issue 3594311, presented by commit d289cdc8.

## Change type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

