### PR TITLE
issue: 4021863 Add XLIO_TCP_2T_RULES

### DIFF
--- a/README
+++ b/README
@@ -112,6 +112,7 @@ Example:
  XLIO DETAILS: Rx Prefetch Bytes Before Poll  0                          [XLIO_RX_PREFETCH_BYTES_BEFORE_POLL]
  XLIO DETAILS: Rx CQ Drain Rate               Disabled                   [XLIO_RX_CQ_DRAIN_RATE_NSEC]
  XLIO DETAILS: GRO max streams                32                         [XLIO_GRO_STREAMS_MAX]
+ XLIO DETAILS: TCP 2T rules                   Disabled                   [XLIO_TCP_2T_RULES]
  XLIO DETAILS: TCP 3T rules                   Disabled                   [XLIO_TCP_3T_RULES]
  XLIO DETAILS: UDP 3T rules                   Enabled                    [XLIO_UDP_3T_RULES]
  XLIO DETAILS: ETH MC L2 only rules           Disabled                   [XLIO_ETH_MC_L2_ONLY_RULES]
@@ -622,6 +623,14 @@ XLIO_GRO_STREAMS_MAX
 Control the number of TCP streams to perform GRO (generic receive offload) simultaneously.
 Disable GRO with a value of 0.
 Default value is 32
+
+XLIO_TCP_2T_RULES
+Use only 2 tuple rules for TCP connections, instead of using 5 tuple rules.
+This can help to overcome steering limitations for outgoing TCP connections.
+However, this option requires a unique local IP address per XLIO ring. In
+the default ring per thread configuration, this means that each thread must
+bind its sockets to a thread local IP address.
+Default: 0 (Disabled)
 
 XLIO_TCP_3T_RULES
 Use only 3 tuple rules for incoming TCP connections, instead of using 5 tuple

--- a/src/core/dev/ring_slave.cpp
+++ b/src/core/dev/ring_slave.cpp
@@ -302,7 +302,10 @@ bool steering_handler<KEY4T, KEY2T, HDR>::attach_flow(flow_tuple &flow_spec_5t, 
         sock_addr rule_key(flow_spec_5t.get_family(), &flow_spec_5t.get_dst_ip(),
                            flow_spec_5t.get_dst_port());
         rfs_rule_filter *dst_port_filter = nullptr;
-        if (safe_mce_sys().tcp_3t_rules) {
+        if (safe_mce_sys().tcp_3t_rules || safe_mce_sys().tcp_2t_rules) {
+            if (safe_mce_sys().tcp_2t_rules) {
+                rule_key.set_in_port(0);
+            }
             auto dst_port_iter = m_ring.m_tcp_dst_port_attach_map.find(rule_key);
             if (dst_port_iter == m_ring.m_tcp_dst_port_attach_map.end()) {
                 m_ring.m_tcp_dst_port_attach_map[rule_key].counter = 1;
@@ -313,7 +316,8 @@ bool steering_handler<KEY4T, KEY2T, HDR>::attach_flow(flow_tuple &flow_spec_5t, 
         }
 
         if (flow_tag_id &&
-            (flow_spec_5t.is_3_tuple() || (!force_5t && safe_mce_sys().tcp_3t_rules))) {
+            (flow_spec_5t.is_3_tuple() || (!force_5t && safe_mce_sys().tcp_3t_rules) ||
+             safe_mce_sys().tcp_2t_rules)) {
             ring_logdbg("flow tag id = %d is disabled for socket fd = %d to be processed on RFS!",
                         flow_tag_id, si->get_fd());
             flow_tag_id = FLOW_TAG_MASK;
@@ -323,7 +327,12 @@ bool steering_handler<KEY4T, KEY2T, HDR>::attach_flow(flow_tuple &flow_spec_5t, 
         if (itr == end(m_flow_tcp_map)) {
             // It means that no rfs object exists so I need to create a new one and insert it to
             // the flow map
-            if (!force_5t && safe_mce_sys().tcp_3t_rules) {
+            if (safe_mce_sys().tcp_2t_rules) {
+                flow_tuple tcp_2t_only(flow_spec_5t.get_dst_ip(), 0, ip_address::any_addr(), 0,
+                                       flow_spec_5t.get_protocol(), flow_spec_5t.get_family());
+                dst_port_filter =
+                    new rfs_rule_filter(m_ring.m_tcp_dst_port_attach_map, rule_key, tcp_2t_only);
+            } else if (!force_5t && safe_mce_sys().tcp_3t_rules) {
                 flow_tuple tcp_3t_only(flow_spec_5t.get_dst_ip(), flow_spec_5t.get_dst_port(),
                                        ip_address::any_addr(), 0, flow_spec_5t.get_protocol(),
                                        flow_spec_5t.get_family());
@@ -484,7 +493,7 @@ bool steering_handler<KEY4T, KEY2T, HDR>::detach_flow(flow_tuple &flow_spec_5t, 
                       flow_spec_5t.get_dst_port(), flow_spec_5t.get_src_port());
         sock_addr rule_key(flow_spec_5t.get_family(), &flow_spec_5t.get_dst_ip(),
                            flow_spec_5t.get_dst_port());
-        if (safe_mce_sys().tcp_3t_rules) {
+        if (safe_mce_sys().tcp_3t_rules || safe_mce_sys().tcp_2t_rules) {
             auto dst_port_iter = m_ring.m_tcp_dst_port_attach_map.find(rule_key);
             BULLSEYE_EXCLUDE_BLOCK_START
             if (dst_port_iter == m_ring.m_tcp_dst_port_attach_map.end()) {

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -628,6 +628,8 @@ void print_xlio_global_settings()
     VLOG_PARAM_NUMBER("Disable flow tag", safe_mce_sys().disable_flow_tag,
                       MCE_DEFAULT_DISABLE_FLOW_TAG, SYS_VAR_DISABLE_FLOW_TAG);
 
+    VLOG_PARAM_STRING("TCP 2T rules", safe_mce_sys().tcp_2t_rules, MCE_DEFAULT_TCP_2T_RULES,
+                      SYS_VAR_TCP_2T_RULES, safe_mce_sys().tcp_2t_rules ? "Enabled " : "Disabled");
     VLOG_PARAM_STRING("TCP 3T rules", safe_mce_sys().tcp_3t_rules, MCE_DEFAULT_TCP_3T_RULES,
                       SYS_VAR_TCP_3T_RULES, safe_mce_sys().tcp_3t_rules ? "Enabled " : "Disabled");
     VLOG_PARAM_STRING("UDP 3T rules", safe_mce_sys().udp_3t_rules, MCE_DEFAULT_UDP_3T_RULES,

--- a/src/core/util/sys_vars.cpp
+++ b/src/core/util/sys_vars.cpp
@@ -814,6 +814,7 @@ void mce_sys_var::get_env_params()
     gro_streams_max = MCE_DEFAULT_GRO_STREAMS_MAX;
     disable_flow_tag = MCE_DEFAULT_DISABLE_FLOW_TAG;
 
+    tcp_2t_rules = MCE_DEFAULT_TCP_2T_RULES;
     tcp_3t_rules = MCE_DEFAULT_TCP_3T_RULES;
     udp_3t_rules = MCE_DEFAULT_UDP_3T_RULES;
     eth_mc_l2_only_rules = MCE_DEFAULT_ETH_MC_L2_ONLY_RULES;
@@ -1363,6 +1364,9 @@ void mce_sys_var::get_env_params()
         gro_streams_max = std::max(atoi(env_ptr), 0);
     }
 
+    if ((env_ptr = getenv(SYS_VAR_TCP_2T_RULES))) {
+        tcp_2t_rules = atoi(env_ptr) ? true : false;
+    }
     if ((env_ptr = getenv(SYS_VAR_TCP_3T_RULES))) {
         tcp_3t_rules = atoi(env_ptr) ? true : false;
     }

--- a/src/core/util/sys_vars.h
+++ b/src/core/util/sys_vars.h
@@ -398,6 +398,7 @@ public:
     bool disable_flow_tag;
 
     bool enable_striding_rq;
+    bool tcp_2t_rules;
     bool tcp_3t_rules;
     bool udp_3t_rules;
     bool eth_mc_l2_only_rules;
@@ -594,6 +595,7 @@ extern mce_sys_var &safe_mce_sys();
 #define SYS_VAR_RX_CQ_DRAIN_RATE_NSEC         "XLIO_RX_CQ_DRAIN_RATE_NSEC"
 #define SYS_VAR_GRO_STREAMS_MAX               "XLIO_GRO_STREAMS_MAX"
 #define SYS_VAR_DISABLE_FLOW_TAG              "XLIO_DISABLE_FLOW_TAG"
+#define SYS_VAR_TCP_2T_RULES                  "XLIO_TCP_2T_RULES"
 #define SYS_VAR_TCP_3T_RULES                  "XLIO_TCP_3T_RULES"
 #define SYS_VAR_UDP_3T_RULES                  "XLIO_UDP_3T_RULES"
 #define SYS_VAR_ETH_MC_L2_ONLY_RULES          "XLIO_ETH_MC_L2_ONLY_RULES"
@@ -753,6 +755,7 @@ extern mce_sys_var &safe_mce_sys();
 #define MCE_DEFAULT_RX_CQ_DRAIN_RATE              (MCE_RX_CQ_DRAIN_RATE_DISABLED)
 #define MCE_DEFAULT_GRO_STREAMS_MAX               (32)
 #define MCE_DEFAULT_DISABLE_FLOW_TAG              (false)
+#define MCE_DEFAULT_TCP_2T_RULES                  (false)
 #define MCE_DEFAULT_TCP_3T_RULES                  (false)
 #define MCE_DEFAULT_UDP_3T_RULES                  (true)
 #define MCE_DEFAULT_ETH_MC_L2_ONLY_RULES          (false)


### PR DESCRIPTION
## Description

This adds support of a TCP steering which matches only destination IP. It can be used with a big number of outgoing connections when they exceed the steering root table limit.

For proper and optimal work, user needs to guarantee a unique IP per ring.

##### What
Overcome 64K steering limitation for outgoing connections with a SW implementation.

##### Why ?
Create over 64K outgoing connections.

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

