### PR TITLE
issue: 4039879 Reset m_rx_pkt_ready_offset after clearing RX buffer

### DIFF
--- a/src/core/sock/sockinfo.h
+++ b/src/core/sock/sockinfo.h
@@ -402,7 +402,7 @@ protected:
                                                int &rx_pkt_ready_list_idx) = 0;
     virtual timestamps_t *get_socket_timestamps() = 0;
     virtual void update_socket_timestamps(timestamps_t *ts) = 0;
-    virtual void post_deqeue(bool release_buff) = 0;
+    virtual void post_dequeue(bool release_buff) = 0;
     virtual int os_epoll_wait(epoll_event *ep_events, int maxevents);
     virtual int zero_copy_rx(iovec *p_iov, mem_buf_desc_t *pdesc, int *p_flags) = 0;
     virtual void handle_ip_pktinfo(struct cmsg_state *cm_state) = 0;
@@ -679,7 +679,7 @@ int sockinfo::dequeue_packet(iovec *p_iov, ssize_t sz_iov, sockaddr *__from, soc
     mem_buf_desc_t *pdesc;
     int total_rx = 0;
     uint32_t nbytes, pos;
-    bool relase_buff = true;
+    bool release_buff = true;
 
     bool is_peek = in_flags & MSG_PEEK;
     int rx_pkt_ready_list_idx = 1;
@@ -702,7 +702,7 @@ int sockinfo::dequeue_packet(iovec *p_iov, ssize_t sz_iov, sockaddr *__from, soc
     }
 
     if (in_flags & MSG_XLIO_ZCOPY) {
-        relase_buff = false;
+        release_buff = false;
         total_rx = zero_copy_rx(p_iov, pdesc, p_out_flags);
         if (unlikely(total_rx < 0)) {
             return -1;
@@ -756,7 +756,7 @@ int sockinfo::dequeue_packet(iovec *p_iov, ssize_t sz_iov, sockaddr *__from, soc
     } else {
         IF_STATS(m_p_socket_stats->n_rx_ready_byte_count -= total_rx);
         m_rx_ready_byte_count -= total_rx;
-        post_deqeue(relase_buff);
+        post_dequeue(release_buff);
         save_stats_rx_offload(total_rx);
     }
 

--- a/src/core/sock/sockinfo_tcp.cpp
+++ b/src/core/sock/sockinfo_tcp.cpp
@@ -5284,7 +5284,7 @@ timestamps_t *sockinfo_tcp::get_socket_timestamps()
     return &m_rx_timestamps;
 }
 
-void sockinfo_tcp::post_deqeue(bool release_buff)
+void sockinfo_tcp::post_dequeue(bool release_buff)
 {
     NOT_IN_USE(release_buff);
 }

--- a/src/core/sock/sockinfo_tcp.h
+++ b/src/core/sock/sockinfo_tcp.h
@@ -569,7 +569,7 @@ private:
         }
     }
 
-    void post_deqeue(bool release_buff) override;
+    void post_dequeue(bool release_buff) override;
     int zero_copy_rx(iovec *p_iov, mem_buf_desc_t *pdesc, int *p_flags) override;
 
     // Returns the connected pcb, with 5 tuple which matches the input arguments,

--- a/src/core/sock/sockinfo_udp.cpp
+++ b/src/core/sock/sockinfo_udp.cpp
@@ -3178,7 +3178,7 @@ timestamps_t *sockinfo_udp::get_socket_timestamps()
     return &m_rx_pkt_ready_list.front()->rx.timestamps;
 }
 
-void sockinfo_udp::post_deqeue(bool release_buff)
+void sockinfo_udp::post_dequeue(bool release_buff)
 {
     mem_buf_desc_t *to_resue = m_rx_pkt_ready_list.get_and_pop_front();
     IF_STATS(m_p_socket_stats->n_rx_ready_pkt_count--);

--- a/src/core/sock/sockinfo_udp.h
+++ b/src/core/sock/sockinfo_udp.h
@@ -277,7 +277,7 @@ private:
     inline void update_ready(mem_buf_desc_t *p_rx_wc_buf_desc, void *pv_fd_ready_array,
                              xlio_recv_callback_retval_t cb_ret);
 
-    void post_deqeue(bool release_buff) override;
+    void post_dequeue(bool release_buff) override;
     int zero_copy_rx(iovec *p_iov, mem_buf_desc_t *pdesc, int *p_flags) override;
     size_t handle_msg_trunc(size_t total_rx, size_t payload_size, int in_flags,
                             int *p_out_flags) override;

--- a/src/core/sock/sockinfo_ulp.cpp
+++ b/src/core/sock/sockinfo_ulp.cpp
@@ -691,7 +691,7 @@ err_t sockinfo_tcp_ops_tls::tls_rx_consume_ready_packets()
         descq_t descs_rx_ready;
 
         m_p_sock->sock_pop_descs_rx_ready(&descs_rx_ready);
-        for (size_t i = 0; i < descs_rx_ready.size(); i++) {
+        while (descs_rx_ready.size()) {
             mem_buf_desc_t *temp;
             temp = descs_rx_ready.front();
             descs_rx_ready.pop_front();


### PR DESCRIPTION
After clearing the RX buffer, we need to reset all related state, including m_rx_pkt_ready_offset, to ensure consistency of the state.

## Change type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

