### PR TITLE
HPCINFRA-2661: copyright fix on doca_xlio_vNext

### DIFF
--- a/.ci/matrix_job.yaml
+++ b/.ci/matrix_job.yaml
@@ -65,7 +65,7 @@ runs_on_dockers:
      category: 'tool'
     }
   - {name: 'blackduck', url: 'harbor.mellanox.com/toolbox/blackduck_post_scan', category: 'tool', arch: 'x86_64'}
-  - {name: 'header-check', url: 'harbor.mellanox.com/toolbox/header_check:0.0.14', category: 'tool', arch: 'x86_64', tag: '0.0.14'}
+  - {name: 'header-check', url: 'harbor.mellanox.com/toolbox/header_check:0.0.51', category: 'tool', arch: 'x86_64', tag: '0.0.51'}
 # static tests
   - {
      file: '.ci/dockerfiles/Dockerfile.ubuntu22.04',

--- a/contrib/jenkins_tests/copyright-check-map.yaml
+++ b/contrib/jenkins_tests/copyright-check-map.yaml
@@ -35,7 +35,7 @@ general:
         - ".*src/core/config_parser.*"
         - ".*src/core/config_scanner\\.c"
 
-bsd:
+dual_gpl_2_bsd_3:
     include:
         - ".*"
     exclude:

--- a/src/core/util/cached_obj_pool.h
+++ b/src/core/util/cached_obj_pool.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/util/config_parser.y
+++ b/src/core/util/config_parser.y
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/util/config_scanner.l
+++ b/src/core/util/config_scanner.l
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/util/data_updater.cpp
+++ b/src/core/util/data_updater.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/util/data_updater.h
+++ b/src/core/util/data_updater.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/util/hugepage_mgr.cpp
+++ b/src/core/util/hugepage_mgr.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/util/hugepage_mgr.h
+++ b/src/core/util/hugepage_mgr.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/util/if.h
+++ b/src/core/util/if.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/util/instrumentation.cpp
+++ b/src/core/util/instrumentation.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/util/instrumentation.h
+++ b/src/core/util/instrumentation.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/util/ip_address.h
+++ b/src/core/util/ip_address.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/util/libxlio.h
+++ b/src/core/util/libxlio.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/util/match.cpp
+++ b/src/core/util/match.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/util/sg_array.h
+++ b/src/core/util/sg_array.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/util/sock_addr.h
+++ b/src/core/util/sock_addr.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/util/sys_vars.cpp
+++ b/src/core/util/sys_vars.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/util/sys_vars.h
+++ b/src/core/util/sys_vars.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/util/sysctl_reader.h
+++ b/src/core/util/sysctl_reader.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/util/to_str.h
+++ b/src/core/util/to_str.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/util/utils.cpp
+++ b/src/core/util/utils.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/util/utils.h
+++ b/src/core/util/utils.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/util/valgrind.h
+++ b/src/core/util/valgrind.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/util/vtypes.h
+++ b/src/core/util/vtypes.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/util/wakeup.cpp
+++ b/src/core/util/wakeup.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/util/wakeup.h
+++ b/src/core/util/wakeup.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/util/wakeup_pipe.cpp
+++ b/src/core/util/wakeup_pipe.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/util/wakeup_pipe.h
+++ b/src/core/util/wakeup_pipe.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/util/xlio_list.h
+++ b/src/core/util/xlio_list.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/core/util/xlio_stats.h
+++ b/src/core/util/xlio_stats.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/state_machine/main.cpp
+++ b/src/state_machine/main.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/state_machine/sm.cpp
+++ b/src/state_machine/sm.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/state_machine/sm.h
+++ b/src/state_machine/sm.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/state_machine/sm_fifo.cpp
+++ b/src/state_machine/sm_fifo.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/state_machine/sm_fifo.h
+++ b/src/state_machine/sm_fifo.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/stats/stats_data_reader.h
+++ b/src/stats/stats_data_reader.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/stats/stats_printer.cpp
+++ b/src/stats/stats_printer.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/stats/stats_publisher.cpp
+++ b/src/stats/stats_publisher.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/stats/stats_reader.cpp
+++ b/src/stats/stats_reader.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/utils/asm-arm64.h
+++ b/src/utils/asm-arm64.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/utils/asm-ppc64.h
+++ b/src/utils/asm-ppc64.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/utils/asm-x86.h
+++ b/src/utils/asm-x86.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/utils/asm.h
+++ b/src/utils/asm.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/utils/atomic.h
+++ b/src/utils/atomic.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/utils/bullseye.h
+++ b/src/utils/bullseye.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/utils/clock.h
+++ b/src/utils/clock.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/utils/compiler.h
+++ b/src/utils/compiler.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/utils/lock_wrapper.h
+++ b/src/utils/lock_wrapper.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/utils/rdtsc.h
+++ b/src/utils/rdtsc.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/utils/types.h
+++ b/src/utils/types.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/vlogger/main.cpp
+++ b/src/vlogger/main.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/vlogger/vlogger.cpp
+++ b/src/vlogger/vlogger.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/src/vlogger/vlogger.h
+++ b/src/vlogger/vlogger.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/extra_api/server_tcp.c
+++ b/tests/extra_api/server_tcp.c
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2019-2024 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+ * Copyright (c) 2019-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/extra_api/socket_isolation.c
+++ b/tests/extra_api/socket_isolation.c
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2019-2024 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+ * Copyright (c) 2019-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/extra_api/xlio_socket_api.c
+++ b/tests/extra_api/xlio_socket_api.c
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2019-2024 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+ * Copyright (c) 2019-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/functionality/getsockname_test.c
+++ b/tests/functionality/getsockname_test.c
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2013-2024 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+ * Copyright (c) 2013-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/functionality/iomux/1epoll_1socket_twice.c
+++ b/tests/functionality/iomux/1epoll_1socket_twice.c
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2016-2024 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+ * Copyright (c) 2016-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/functionality/iomux/2epoll_1socket.c
+++ b/tests/functionality/iomux/2epoll_1socket.c
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2016-2024 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+ * Copyright (c) 2016-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/gtest/common/base.cc
+++ b/tests/gtest/common/base.cc
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/gtest/common/base.h
+++ b/tests/gtest/common/base.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/gtest/common/cmn.h
+++ b/tests/gtest/common/cmn.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/gtest/common/def.h
+++ b/tests/gtest/common/def.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/gtest/common/log.h
+++ b/tests/gtest/common/log.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/gtest/common/sys.cc
+++ b/tests/gtest/common/sys.cc
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/gtest/common/sys.h
+++ b/tests/gtest/common/sys.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/gtest/core/xlio_base.cc
+++ b/tests/gtest/core/xlio_base.cc
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/gtest/core/xlio_base.h
+++ b/tests/gtest/core/xlio_base.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/gtest/core/xlio_ioctl.cc
+++ b/tests/gtest/core/xlio_ioctl.cc
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/gtest/core/xlio_send_zc.cc
+++ b/tests/gtest/core/xlio_send_zc.cc
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/gtest/core/xlio_sockopt.cc
+++ b/tests/gtest/core/xlio_sockopt.cc
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/gtest/main.cc
+++ b/tests/gtest/main.cc
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/gtest/mix/ip_address.cc
+++ b/tests/gtest/mix/ip_address.cc
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/gtest/mix/mix_base.cc
+++ b/tests/gtest/mix/mix_base.cc
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/gtest/mix/mix_base.h
+++ b/tests/gtest/mix/mix_base.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/gtest/mix/mix_list.cc
+++ b/tests/gtest/mix/mix_list.cc
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/gtest/mix/sg_array.cc
+++ b/tests/gtest/mix/sg_array.cc
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/gtest/mix/sock_addr.cc
+++ b/tests/gtest/mix/sock_addr.cc
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/gtest/nvme/nvme.cc
+++ b/tests/gtest/nvme/nvme.cc
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/gtest/sock/sock_base.cc
+++ b/tests/gtest/sock/sock_base.cc
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/gtest/sock/sock_base.h
+++ b/tests/gtest/sock/sock_base.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/gtest/sock/sock_socket.cc
+++ b/tests/gtest/sock/sock_socket.cc
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/gtest/tcp/tcp_accept.cc
+++ b/tests/gtest/tcp/tcp_accept.cc
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/gtest/tcp/tcp_base.h
+++ b/tests/gtest/tcp/tcp_base.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/gtest/tcp/tcp_bind.cc
+++ b/tests/gtest/tcp/tcp_bind.cc
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/gtest/tcp/tcp_connect.cc
+++ b/tests/gtest/tcp/tcp_connect.cc
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/gtest/tcp/tcp_connect_nb.cc
+++ b/tests/gtest/tcp/tcp_connect_nb.cc
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/gtest/tcp/tcp_event.cc
+++ b/tests/gtest/tcp/tcp_event.cc
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/gtest/tcp/tcp_rfs.cc
+++ b/tests/gtest/tcp/tcp_rfs.cc
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/gtest/tcp/tcp_send.cc
+++ b/tests/gtest/tcp/tcp_send.cc
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/gtest/tcp/tcp_send_zc.cc
+++ b/tests/gtest/tcp/tcp_send_zc.cc
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/gtest/tcp/tcp_sendfile.cc
+++ b/tests/gtest/tcp/tcp_sendfile.cc
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/gtest/tcp/tcp_sendto.cc
+++ b/tests/gtest/tcp/tcp_sendto.cc
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/gtest/tcp/tcp_socket.cc
+++ b/tests/gtest/tcp/tcp_socket.cc
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/gtest/tcp/tcp_sockopt.cc
+++ b/tests/gtest/tcp/tcp_sockopt.cc
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/gtest/tcp/tcp_tls.cc
+++ b/tests/gtest/tcp/tcp_tls.cc
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/gtest/udp/udp_base.h
+++ b/tests/gtest/udp/udp_base.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/gtest/udp/udp_bind.cc
+++ b/tests/gtest/udp/udp_bind.cc
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/gtest/udp/udp_connect.cc
+++ b/tests/gtest/udp/udp_connect.cc
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/gtest/udp/udp_recv.cc
+++ b/tests/gtest/udp/udp_recv.cc
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/gtest/udp/udp_rfs.cc
+++ b/tests/gtest/udp/udp_rfs.cc
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/gtest/udp/udp_send.cc
+++ b/tests/gtest/udp/udp_send.cc
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/gtest/udp/udp_sendto.cc
+++ b/tests/gtest/udp/udp_sendto.cc
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/gtest/udp/udp_socket.cc
+++ b/tests/gtest/udp/udp_socket.cc
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/gtest/xliod/xliod_base.cc
+++ b/tests/gtest/xliod/xliod_base.cc
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/gtest/xliod/xliod_base.h
+++ b/tests/gtest/xliod/xliod_base.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/gtest/xliod/xliod_bitmap.cc
+++ b/tests/gtest/xliod/xliod_bitmap.cc
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/gtest/xliod/xliod_flow.cc
+++ b/tests/gtest/xliod/xliod_flow.cc
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/gtest/xliod/xliod_hash.cc
+++ b/tests/gtest/xliod/xliod_hash.cc
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/gtest/xliod/xliod_init.cc
+++ b/tests/gtest/xliod/xliod_init.cc
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/gtest/xliod/xliod_state.cc
+++ b/tests/gtest/xliod/xliod_state.cc
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/latency_test/tcp_lat.cpp
+++ b/tests/latency_test/tcp_lat.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/latency_test/udp_lat.c
+++ b/tests/latency_test/udp_lat.c
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/low_pps_tcp_send_test/exchange.cpp
+++ b/tests/low_pps_tcp_send_test/exchange.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/low_pps_tcp_send_test/trader.cpp
+++ b/tests/low_pps_tcp_send_test/trader.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/mc_loop_test/mc_loop_test.c
+++ b/tests/mc_loop_test/mc_loop_test.c
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/multithread_test/exchange.cpp
+++ b/tests/multithread_test/exchange.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2013-2024 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+ * Copyright (c) 2013-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/multithread_test/trader.cpp
+++ b/tests/multithread_test/trader.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2013-2024 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+ * Copyright (c) 2013-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/nginx/constant_reply_module/ngx_http_constant_reply_module.cpp
+++ b/tests/nginx/constant_reply_module/ngx_http_constant_reply_module.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/pps_test/pps_test.c
+++ b/tests/pps_test/pps_test.c
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/reuse_ud_test.c
+++ b/tests/reuse_ud_test.c
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2013-2024 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+ * Copyright (c) 2013-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/select_t1.c
+++ b/tests/select_t1.c
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2013-2024 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+ * Copyright (c) 2013-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/server_test/client.cc
+++ b/tests/server_test/client.cc
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/server_test/client.h
+++ b/tests/server_test/client.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/server_test/main.cc
+++ b/tests/server_test/main.cc
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/server_test/options.cc
+++ b/tests/server_test/options.cc
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/server_test/options.h
+++ b/tests/server_test/options.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/server_test/server.cc
+++ b/tests/server_test/server.cc
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/server_test/server.h
+++ b/tests/server_test/server.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/server_test/vtime.cc
+++ b/tests/server_test/vtime.cc
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/server_test/vtime.h
+++ b/tests/server_test/vtime.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/tcp_window_size_exerciser/Makefile
+++ b/tests/tcp_window_size_exerciser/Makefile
@@ -1,5 +1,6 @@
 #
-# Copyright © 2024 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # This software is available to you under a choice of one of two
 # licenses.  You may choose to be licensed under the terms of the GNU

--- a/tests/tcp_window_size_exerciser/tcp_wnd_test.h
+++ b/tests/tcp_window_size_exerciser/tcp_wnd_test.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/tcp_window_size_exerciser/tcp_wnd_test_client.c
+++ b/tests/tcp_window_size_exerciser/tcp_wnd_test_client.c
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/tcp_window_size_exerciser/tcp_wnd_test_server.c
+++ b/tests/tcp_window_size_exerciser/tcp_wnd_test_server.c
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/throughput_test/bandwidth_test.c
+++ b/tests/throughput_test/bandwidth_test.c
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tests/timetest/timetest.cpp
+++ b/tests/timetest/timetest.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tools/daemon/bitmap.h
+++ b/tools/daemon/bitmap.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tools/daemon/daemon.c
+++ b/tools/daemon/daemon.c
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tools/daemon/daemon.h
+++ b/tools/daemon/daemon.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tools/daemon/flow.c
+++ b/tools/daemon/flow.c
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tools/daemon/hash.c
+++ b/tools/daemon/hash.c
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tools/daemon/hash.h
+++ b/tools/daemon/hash.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tools/daemon/loop.c
+++ b/tools/daemon/loop.c
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tools/daemon/message.c
+++ b/tools/daemon/message.c
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tools/daemon/nl.c
+++ b/tools/daemon/nl.c
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tools/daemon/nl.h
+++ b/tools/daemon/nl.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tools/daemon/notify.c
+++ b/tools/daemon/notify.c
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tools/daemon/store.c
+++ b/tools/daemon/store.c
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tools/daemon/tc.c
+++ b/tools/daemon/tc.c
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/tools/daemon/tc.h
+++ b/tools/daemon/tc.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2001-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two


### PR DESCRIPTION
## Description
Fix the Copyright information format template

##### What
Fix the Copyright information format template to be used with header checker

##### Why ?
The format that is in use does not match the required license type ("bsd" ->? "dual_gpt_2_bsd3")

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

