### PR TITLE
issue: 4124248 Don't update CQ consumer index

### DIFF
--- a/src/core/dev/cq_mgr_rx.cpp
+++ b/src/core/dev/cq_mgr_rx.cpp
@@ -105,9 +105,6 @@ cq_mgr_rx::cq_mgr_rx(ring_simple *p_ring, ib_ctx_handler *p_ib_ctx_handler, int 
 
 void cq_mgr_rx::configure(int cq_size)
 {
-    xlio_ibv_cq_init_attr attr;
-    memset(&attr, 0, sizeof(attr));
-
     struct ibv_context *context = m_p_ib_ctx_handler->get_ibv_context();
     int comp_vector = 0;
 #if defined(DEFINED_NGINX) || defined(DEFINED_ENVOY)
@@ -119,8 +116,8 @@ void cq_mgr_rx::configure(int cq_size)
         comp_vector = g_p_app->get_worker_id() % context->num_comp_vectors;
     }
 #endif
-    m_p_ibv_cq = xlio_ibv_create_cq(context, cq_size - 1, (void *)this, m_comp_event_channel,
-                                    comp_vector, &attr);
+    m_p_ibv_cq = ibv_create_cq(context, cq_size - 1, (void *)this, m_comp_event_channel,
+                               comp_vector);
     BULLSEYE_EXCLUDE_BLOCK_START
     if (!m_p_ibv_cq) {
         cq_logerr("Failed to create CQ, this: %p, ctx: %p size: %d compch: %p", this, context,

--- a/src/core/dev/cq_mgr_rx_regrq.cpp
+++ b/src/core/dev/cq_mgr_rx_regrq.cpp
@@ -106,13 +106,10 @@ mem_buf_desc_t *cq_mgr_rx_regrq::poll(enum buff_status_e &status)
     }
     xlio_mlx5_cqe *cqe = check_cqe();
     if (likely(cqe)) {
-        /* Update the consumer index */
         ++m_mlx5_cq.cq_ci;
-        rmb();
         cqe_to_mem_buff_desc(cqe, m_rx_hot_buffer, status);
 
         ++m_hqrx_ptr->m_rq_data.tail;
-        *m_mlx5_cq.dbrec = htonl(m_mlx5_cq.cq_ci & 0xffffff);
 
         buff = m_rx_hot_buffer;
         m_rx_hot_buffer = nullptr;

--- a/src/core/dev/cq_mgr_rx_strq.cpp
+++ b/src/core/dev/cq_mgr_rx_strq.cpp
@@ -187,10 +187,7 @@ mem_buf_desc_t *cq_mgr_rx_strq::poll(enum buff_status_e &status, mem_buf_desc_t 
 
     xlio_mlx5_cqe *cqe = check_cqe();
     if (likely(cqe)) {
-        /* Update the consumer index */
         ++m_mlx5_cq.cq_ci;
-        rmb();
-        *m_mlx5_cq.dbrec = htonl(m_mlx5_cq.cq_ci & 0xffffff);
 
         bool is_filler = false;
         bool is_wqe_complete = strq_cqe_to_mem_buff_desc(cqe, status, is_filler);

--- a/src/core/dev/cq_mgr_tx.cpp
+++ b/src/core/dev/cq_mgr_tx.cpp
@@ -80,9 +80,6 @@ cq_mgr_tx::~cq_mgr_tx()
 
 void cq_mgr_tx::configure(int cq_size)
 {
-    xlio_ibv_cq_init_attr attr;
-    memset(&attr, 0, sizeof(attr));
-
     struct ibv_context *context = m_p_ib_ctx_handler->get_ibv_context();
     int comp_vector = 0;
 #if defined(DEFINED_NGINX) || defined(DEFINED_ENVOY)
@@ -94,8 +91,8 @@ void cq_mgr_tx::configure(int cq_size)
         comp_vector = g_p_app->get_worker_id() % context->num_comp_vectors;
     }
 #endif
-    m_p_ibv_cq = xlio_ibv_create_cq(context, cq_size - 1, (void *)this, m_comp_event_channel,
-                                    comp_vector, &attr);
+    m_p_ibv_cq = ibv_create_cq(context, cq_size - 1, (void *)this, m_comp_event_channel,
+                               comp_vector);
     BULLSEYE_EXCLUDE_BLOCK_START
     if (!m_p_ibv_cq) {
         throw_xlio_exception("ibv_create_cq failed");

--- a/src/core/dev/cq_mgr_tx.cpp
+++ b/src/core/dev/cq_mgr_tx.cpp
@@ -91,8 +91,20 @@ void cq_mgr_tx::configure(int cq_size)
         comp_vector = g_p_app->get_worker_id() % context->num_comp_vectors;
     }
 #endif
-    m_p_ibv_cq = ibv_create_cq(context, cq_size - 1, (void *)this, m_comp_event_channel,
-                               comp_vector);
+
+    struct ibv_cq_init_attr_ex attr = {};
+    struct mlx5dv_cq_init_attr dvattr = {};
+
+    attr.cqe = cq_size - 1; // This parameter is incremented by 1 in libibverbs
+    attr.cq_context = (void *)this;
+    attr.channel = m_comp_event_channel;
+    attr.comp_vector = comp_vector;
+    attr.wc_flags = IBV_WC_STANDARD_FLAGS;
+    attr.comp_mask = IBV_CQ_INIT_ATTR_MASK_FLAGS;
+    attr.flags = IBV_CREATE_CQ_ATTR_IGNORE_OVERRUN;
+
+    struct ibv_cq_ex *cq_ex = mlx5dv_create_cq(context, &attr, &dvattr);
+    m_p_ibv_cq = ibv_cq_ex_to_cq(cq_ex);
     BULLSEYE_EXCLUDE_BLOCK_START
     if (!m_p_ibv_cq) {
         throw_xlio_exception("ibv_create_cq failed");

--- a/src/core/dev/cq_mgr_tx.h
+++ b/src/core/dev/cq_mgr_tx.h
@@ -143,10 +143,6 @@ inline struct xlio_mlx5_cqe *cq_mgr_tx::get_cqe_tx(uint32_t &num_polled_cqes)
                                        ((m_mlx5_cq.cq_ci & (m_mlx5_cq.cqe_count - 1))
                                         << m_mlx5_cq.cqe_size_log));
     }
-    if (cqe_ret) {
-        rmb();
-        *m_mlx5_cq.dbrec = htonl(m_mlx5_cq.cq_ci);
-    }
     return cqe_ret;
 }
 

--- a/src/core/dev/net_device_val.cpp
+++ b/src/core/dev/net_device_val.cpp
@@ -1542,9 +1542,6 @@ bool net_device_val::verify_qp_creation(const char *ifname, enum ibv_qp_type qp_
     xlio_ibv_qp_init_attr qp_init_attr;
     memset(&qp_init_attr, 0, sizeof(qp_init_attr));
 
-    xlio_ibv_cq_init_attr attr;
-    memset(&attr, 0, sizeof(attr));
-
     qp_init_attr.cap.max_send_wr = 2048;
     qp_init_attr.cap.max_recv_wr = MCE_DEFAULT_RX_NUM_WRE;
     qp_init_attr.cap.max_inline_data = MCE_DEFAULT_TX_MAX_INLINE;
@@ -1593,8 +1590,7 @@ bool net_device_val::verify_qp_creation(const char *ifname, enum ibv_qp_type qp_
     }
     VALGRIND_MAKE_MEM_DEFINED(channel, sizeof(ibv_comp_channel));
     context = p_ib_ctx->get_ibv_context();
-    cq = xlio_ibv_create_cq(context, safe_mce_sys().tx_num_wr, (void *)this, channel, comp_vector,
-                            &attr);
+    cq = ibv_create_cq(context, safe_mce_sys().tx_num_wr, (void *)this, channel, comp_vector);
     if (!cq) {
         nd_logdbg("cq creation failed for interface %s (errno=%d %s)", ifname, errno,
                   strerror(errno));

--- a/src/core/ib/base/verbs_extra.h
+++ b/src/core/ib/base/verbs_extra.h
@@ -165,10 +165,6 @@ typedef struct ibv_wc xlio_ibv_wc;
 #define xlio_wc_rx_hw_csum_ok(wc)          (1)
 #endif
 
-typedef int xlio_ibv_cq_init_attr;
-#define xlio_ibv_create_cq(context, cqe, cq_context, channel, comp_vector, attr)                   \
-    ibv_create_cq(context, cqe, cq_context, channel, comp_vector)
-
 // rx hw timestamp
 #ifdef DEFINED_IBV_CQ_TIMESTAMP
 #define XLIO_IBV_DEVICE_ATTR_HCA_CORE_CLOCK 0


### PR DESCRIPTION
## Description
We always create CQs that cannot overflow. Therefore, we can use flag IBV_CREATE_CQ_ATTR_IGNORE_OVERRUN and avoid updating dbrec. HW will ignore the consumer index and this will save a memory barrier per successful polling.

##### What
Don't update CQ consumer index. Create CQs with IBV_CREATE_CQ_ATTR_IGNORE_OVERRUN flag.

##### Why ?
Performance optimization.

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

