### PR TITLE
issue: 3914075 CQ Moderation with small payloads

### DIFF
--- a/src/core/dev/ring_simple.h
+++ b/src/core/dev/ring_simple.h
@@ -51,6 +51,7 @@ struct cq_moderation_info {
     uint64_t packets;
     uint64_t prev_packets;
     uint32_t missed_rounds;
+    uint32_t interrupt_rate_per_sec;
 };
 
 /**


### PR DESCRIPTION
Adapting interrupt rate per second to packet rate when using adaptive CQ moderation.

## Description
With Nginx scenarios when downloading small files (0B payloads) alongside XLIO_CQ_MODERATION_ENABLE=1 - a throughput degradation was observed.
This, in contrast to running the same scenarios with XLIO_CQ_MODERATION_ENABLE=0.

The degradation was 25% for 2400 connections, and 40% for 1200 connections.

Upon inspecting the performance, it seemed the adaptive Completion Event Moderation's `cq_timeout` and `cq_count` were extremely sensitive to momentarily spikes in CQEs - leading to overall degradation in the performance for the above use case.

##### What
Adapting interrupt rate to packet rate - be it short bursts or temporary silence, or other pattern changes - when using adaptive CQ moderation. This, in turn, changes the `cq_timeout` and `cq_count` values chosen for moderation.

##### Why ?
This PR solves bug 3914075.

##### How ?
I printed the arguments to `ring_simple::modify_cq_moderation`, witnessing them momentarily spiking.
upon ignoring the spikes by putting constant values, the performance improved.

We've witnessed the arguments are controlled by `XLIO_CQ_AIM_INTERRUPTS_RATE_PER_SEC` - which is 1000 by default.
I've conducted an extensive matrix of benchmarks - checking:
```
(1200 connections, 2400 connections) X (0B file, 100KB file) X (0 interrupt rate, 500 interrupt rate, 1000 interrupt rate, ..., 15000 interrupt rate)
```

The results were mixed, but it was clear every set of (connections, file_length) had a range of good interrupt rate values - and a set of really bad values.

The outcome was finding it dynamically, to adjust the interrupt rate based on the packet rate.
This gave best results across all use cases, i.e. - a second matrix of tests was conducted to test the proposed PR:
```
(1200 connections, 2400 connections) X (0B file, 100KB file) X (no_cq_moderation, cq_moderation_w/o_pr, cq_moderation_after_pr)
```

## Change type
What kind of change does this PR introduce?
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other
