### PR TITLE
issue: 4144195 MSIX distribution

### DIFF
--- a/src/core/dev/hw_queue_rx.cpp
+++ b/src/core/dev/hw_queue_rx.cpp
@@ -212,6 +212,32 @@ bool hw_queue_rx::prepare_doca_rxq()
         return false;
     }
 
+#if defined(DEFINED_NGINX) || defined(DEFINED_ENVOY)
+    if (safe_mce_sys().app.distribute_cq_interrupts) {
+        uint32_t num_comp_vectors = 0;
+        err = doca_ctx_cap_get_num_completion_vectors(devinfo, &num_comp_vectors);
+        if (DOCA_IS_ERROR(err)) {
+            PRINT_DOCA_ERR(hwqrx_logerr, err, "doca_ctx_cap_get_num_completion_vectors devinfo: %p",
+                           devinfo);
+            return false;
+        }
+
+        // fetching once - as this operation requires locking
+        const int worker_id = g_p_app->get_worker_id();
+        if (likely(worker_id >= 0)) {
+            const uint32_t comp_vector = worker_id % num_comp_vectors;
+            hwqrx_logdbg("Setting PE completion affinity: %" PRIu32 ", pid: %d", comp_vector,
+                         getpid());
+            err = doca_ctx_set_completion_vector(m_doca_ctx_rxq, comp_vector);
+            if (DOCA_IS_ERROR(err)) {
+                PRINT_DOCA_ERR(hwqrx_logerr, err,
+                               "doca_ctx_set_completion_vector ctx/comp_vector: %p,%" PRIu32,
+                               m_doca_ctx_rxq, comp_vector);
+            }
+        }
+    }
+#endif
+
     doca_buf_inventory *inventory = nullptr;
     err = doca_buf_inventory_create(m_rxq_burst_size, &inventory);
     if (DOCA_IS_ERROR(err)) {

--- a/src/core/dev/ib_ctx_handler.h
+++ b/src/core/dev/ib_ctx_handler.h
@@ -101,7 +101,6 @@ public:
     size_t get_on_device_memory_size() { return m_on_device_memory; }
     bool is_active(int port_num);
     bool is_mlx4() { return is_mlx4(get_ibname().c_str()); }
-    bool is_notification_affinity_supported() const { return m_notification_affinity_cap; }
     static bool is_mlx4(const char *dev) { return strncmp(dev, "mlx4", 4) == 0; }
     virtual void handle_event_ibverbs_cb(void *ev_data, void *ctx);
 
@@ -130,7 +129,6 @@ private:
     pacing_caps_t m_pacing_caps;
     size_t m_on_device_memory;
     bool m_removed;
-    bool m_notification_affinity_cap = false;
     lock_spin m_lock_umr;
     time_converter *m_p_ctx_time_converter;
     mr_map_lkey_t m_mr_map_lkey;


### PR DESCRIPTION
Using DOCA API to distribute interrupts to different completion vectors.

## Description
Setting different completion vectors to different contexts spreads the CPU load more evenly.
We use DOCA API to associate different workers with different completion vectors to improve performance.

##### What
Using DOCA API to distribute interrupts to different completion vectors.

##### Why ?
Fixing issue 4144195 and improving performance.

##### How?
1. Inspecting changes in `/proc/interrupts` to verify the distribution - verified successfully.
2. Inspecting RPS and TP - no improvement and no degradation.
3. Inspecting CPS - 
       - cps improvement for 0B download test - 13%.
       - recurring degradation for 100KB download - between 3% to 5% across different runs.
4. Inspecting CPU - no degradation.


## Change type
What kind of change does this PR introduce?
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

