### PR TITLE
issue: 4161679 Tracking latest DOCA

### DIFF
--- a/.ci/dockerfiles/Dockerfile.ubuntu22.04
+++ b/.ci/dockerfiles/Dockerfile.ubuntu22.04
@@ -28,8 +28,8 @@ RUN ARCH=$(uname -m) && \
     g++ make vim python3-pip curl \
     git libglib2.0-dev \
 && echo >> /etc/apt/sources.list.d/doca.list \
-&& echo deb [signed-by=/etc/apt/trusted.gpg.d/GPG-KEY-Mellanox.pub] https://doca-repo-prod.nvidia.com/internal/repo/doca/2.9.0/ubuntu22.04/$DOCA_ARCH/dev ./ >> /etc/apt/sources.list.d/doca.list \
-&& curl https://doca-repo-prod.nvidia.com/internal/repo/doca/2.9.0/ubuntu22.04/$DOCA_ARCH/dev//GPG-KEY-Mellanox.pub | gpg --dearmor > /etc/apt/trusted.gpg.d/GPG-KEY-Mellanox.pub \
+&& echo deb [signed-by=/etc/apt/trusted.gpg.d/GPG-KEY-Mellanox.pub] https://doca-repo-prod.nvidia.com/internal/repo/doca/2.9.1/ubuntu22.04/$DOCA_ARCH/dev ./ >> /etc/apt/sources.list.d/doca.list \
+&& curl https://doca-repo-prod.nvidia.com/internal/repo/doca/2.9.1/ubuntu22.04/$DOCA_ARCH/dev//GPG-KEY-Mellanox.pub | gpg --dearmor > /etc/apt/trusted.gpg.d/GPG-KEY-Mellanox.pub \
 && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN apt-get -qq update \

--- a/contrib/jenkins_tests/globals.sh
+++ b/contrib/jenkins_tests/globals.sh
@@ -296,7 +296,7 @@ do_compile_doca()
     echo ""
     echo "===== DOCA checkout & compilation starts ====="
     echo ""
-    doca_version="2.9.0029-1"
+    doca_version="2.10.0023-1"
     doca_sdk="$WORKSPACE/$prefix/doca-sdk"
     doca_repo="ssh://git-nbu.nvidia.com:12023/doca/doca"
     doca_build="$WORKSPACE/$prefix/doca"
@@ -331,9 +331,9 @@ do_compile_doca()
         pushd "$doca_sdk" || exit 1
     fi
 
-    # Patch from Iftah Levi, solving the "Suspend/Resume PE functionallity" in DOCA
-    wget https://github.com/user-attachments/files/16740209/0001-Disable-suspend-during-epoll.patch
-    git apply 0001-Disable-suspend-during-epoll.patch
+    # Patch solving the "Suspend/Resume PE functionallity" in DOCA
+    wget https://github.com/user-attachments/files/17729030/0001-Disable-suspend-during-epoll-2.10.0023-1.patch
+    git apply 0001-Disable-suspend-during-epoll-2.10.0023-1.patch
 
     if [[ -f /.dockerenv ]]; then
         SUDO=""

--- a/src/core/dev/hw_queue_rx.cpp
+++ b/src/core/dev/hw_queue_rx.cpp
@@ -203,7 +203,7 @@ bool hw_queue_rx::prepare_doca_rxq()
     // CPUs to improve CPS in case of multiple processes.
 
     // TODO: [DOCA] Replace with real information from DOCA.
-    int comp_channel_num = 1U;
+    /*int comp_channel_num = 1U;
 
     // TODO: [DOCA] Currently not functional.
     if (safe_mce_sys().app.distribute_cq_interrupts && g_p_app->get_worker_id() >= 0 &&
@@ -217,7 +217,7 @@ bool hw_queue_rx::prepare_doca_rxq()
                            "doca_pe_set_notification_affinity pe/ctx/rxq: %p,%p,%p", pe,
                            m_doca_ctx_rxq, m_doca_rxq.get());
         }
-    }
+    }*/
 #endif
 
     err = doca_pe_get_notification_handle(pe, &m_notification_handle);

--- a/src/core/dev/hw_queue_tx.cpp
+++ b/src/core/dev/hw_queue_tx.cpp
@@ -363,6 +363,7 @@ bool hw_queue_tx::prepare_doca_txq()
 
 #if defined(DEFINED_NGINX) || defined(DEFINED_ENVOY)
     // TODO: [DOCA] Replace with real information from DOCA.
+    /*
     int comp_channel_num = 1U;
 
     if (safe_mce_sys().app.distribute_cq_interrupts && g_p_app->get_worker_id() >= 0 &&
@@ -377,6 +378,7 @@ bool hw_queue_tx::prepare_doca_txq()
                            m_doca_ctx_txq, m_doca_txq.get());
         }
     }
+    */
 #endif
 
     err = doca_pe_get_notification_handle(pe, &m_notification_handle);

--- a/src/core/dev/ib_ctx_handler.cpp
+++ b/src/core/dev/ib_ctx_handler.cpp
@@ -75,7 +75,6 @@ ib_ctx_handler::ib_ctx_handler(doca_devinfo *devinfo, const char *ibname, ibv_de
     m_ibname = ibname;
 
     open_doca_dev(devinfo);
-    check_doca_dev_caps(devinfo);
 
     m_p_ibv_device = ibvdevice;
 
@@ -192,19 +191,6 @@ void ib_ctx_handler::open_doca_dev(doca_devinfo *devinfo)
     if (DOCA_IS_ERROR(err)) {
         PRINT_DOCA_ERR(ibch_logpanic, err, "doca_dev_open devinfo: %p,%s", devinfo,
                        m_ibname.c_str());
-    }
-}
-
-void ib_ctx_handler::check_doca_dev_caps(doca_devinfo *devinfo)
-{
-    uint8_t temprc = 0U;
-    doca_error_t err = doca_pe_is_set_notification_affinity_supported(devinfo, &temprc);
-    if (DOCA_IS_ERROR(err)) {
-        PRINT_DOCA_ERR(ibch_logerr, err,
-                       "doca_pe_is_set_notification_affinity_supported devinfo: %p,%s", devinfo,
-                       m_ibname.c_str());
-    } else {
-        m_notification_affinity_cap = (temprc != 0);
     }
 }
 

--- a/src/core/dev/ib_ctx_handler.h
+++ b/src/core/dev/ib_ctx_handler.h
@@ -101,7 +101,6 @@ public:
     size_t get_on_device_memory_size() { return m_on_device_memory; }
     bool is_active(int port_num);
     bool is_mlx4() { return is_mlx4(get_ibname().c_str()); }
-    bool is_notification_affinity_supported() const { return m_notification_affinity_cap; }
     static bool is_mlx4(const char *dev) { return strncmp(dev, "mlx4", 4) == 0; }
     virtual void handle_event_ibverbs_cb(void *ev_data, void *ctx);
 
@@ -114,7 +113,6 @@ public:
 
 private:
     void open_doca_dev(doca_devinfo *devinfo);
-    void check_doca_dev_caps(doca_devinfo *devinfo);
     void handle_event_device_fatal();
     doca_error_t start_doca_flow_port();
     doca_error_t create_doca_root_pipe();
@@ -131,7 +129,6 @@ private:
     pacing_caps_t m_pacing_caps;
     size_t m_on_device_memory;
     bool m_removed;
-    bool m_notification_affinity_cap = false;
     lock_spin m_lock_umr;
     time_converter *m_p_ctx_time_converter;
     mr_map_lkey_t m_mr_map_lkey;


### PR DESCRIPTION
Using latest DOCA.

## Description
Currently, on `doca_xlio_vNext` branch, we compile and use DOCA from tag `2.9.0029-1`.

This blocks the merge of https://github.com/Mellanox/libxlio/pull/258 that uses newer features.

##### What
Using latest DOCA.

##### Why?
Fixing issue 4161679, unblocking 4144195 and reducing friction.


## Change type
What kind of change does this PR introduce?
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

