### PR TITLE
issue: 4144197 Using doca_mmap thread safety mode

### DIFF
--- a/src/core/dev/allocator.cpp
+++ b/src/core/dev/allocator.cpp
@@ -299,6 +299,12 @@ bool xlio_registrator::register_memory(void *data, size_t size)
         return false;
     }
 
+    rc = doca_mmap_enable_thread_safety(m_p_doca_mmap);
+    if (DOCA_IS_ERROR(rc)) {
+        PRINT_DOCA_ERR(__log_info_err, rc, "doca_mmap_enable_thread_safety");
+        return false;
+    }
+
     rc = doca_mmap_start(m_p_doca_mmap);
     if (DOCA_IS_ERROR(rc)) {
         PRINT_DOCA_ERR(__log_info_err, rc, "doca_mmap_start");


### PR DESCRIPTION
DOCA thread safety mode in doca_mmap, kind of, does the opposite of what it may sound. This mode disables internal non-atomic counter which tracks bufs allocated from the mmap. Thus, the application becomes responsible for tracking doca_mmap usages.

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [X] Code follows the style de facto guidelines of this project
- [X] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

