### PR TITLE
issue: 4159515 Removing DOCA code from cq_mgr_tx

### DIFF
--- a/src/core/dev/cq_mgr_tx.cpp
+++ b/src/core/dev/cq_mgr_tx.cpp
@@ -137,10 +137,6 @@ bool cq_mgr_tx::request_notification()
 {
     cq_logfuncall(LOG_FUNCTION_CALL);
 
-    if (safe_mce_sys().doca_tx) {
-        return m_hqtx_ptr->request_notification();
-    }
-
     if (m_b_notification_armed == false) {
         cq_logfunc("arming cq_mgr_tx notification channel");
 
@@ -187,10 +183,6 @@ cq_mgr_tx *cq_mgr_tx::get_cq_mgr_from_cq_event(struct ibv_comp_channel *p_cq_cha
 int cq_mgr_tx::poll_and_process_element_tx()
 {
     cq_logfuncall(LOG_FUNCTION_CALL);
-
-    if (safe_mce_sys().doca_tx) {
-        return m_hqtx_ptr->poll_and_process_doca_tx();
-    }
 
     static auto is_error_opcode = [&](uint8_t opcode) {
         return opcode == MLX5_CQE_REQ_ERR || opcode == MLX5_CQE_RESP_ERR;

--- a/src/core/dev/hw_queue_tx.cpp
+++ b/src/core/dev/hw_queue_tx.cpp
@@ -1765,7 +1765,6 @@ void hw_queue_tx::trigger_completion_for_all_sent_packets()
         hwqtx_logdbg("Need to send closing tx wr...");
         mem_buf_desc_t *p_mem_buf_desc = m_p_ring->mem_buf_tx_get(0, true, PBUF_RAM);
         // Align Tx buffer accounting since we will be bypassing the normal send calls
-        m_p_ring->m_missing_buf_ref_count--;
         if (!p_mem_buf_desc) {
             hwqtx_logerr("no buffer in pool");
             return;

--- a/src/core/dev/hw_queue_tx.cpp
+++ b/src/core/dev/hw_queue_tx.cpp
@@ -1763,7 +1763,7 @@ void hw_queue_tx::trigger_completion_for_all_sent_packets()
     if (!is_signal_requested_for_last_wqe()) {
         // Post a dummy WQE and request a signal to complete all the unsignaled WQEs in SQ
         hwqtx_logdbg("Need to send closing tx wr...");
-        mem_buf_desc_t *p_mem_buf_desc = m_p_ring->mem_buf_tx_get(0, true, PBUF_RAM);
+        mem_buf_desc_t *p_mem_buf_desc = m_p_ring->mem_buf_tx_get(0, PBUF_RAM);
         // Align Tx buffer accounting since we will be bypassing the normal send calls
         if (!p_mem_buf_desc) {
             hwqtx_logerr("no buffer in pool");

--- a/src/core/dev/ring.h
+++ b/src/core/dev/ring.h
@@ -81,8 +81,8 @@ public:
     virtual void restart() = 0;
 
     // Get/Release memory buffer descriptor with a linked data memory buffer
-    virtual mem_buf_desc_t *mem_buf_tx_get(ring_user_id_t id, bool b_block, pbuf_type type,
-                                           int n_num_mem_bufs = 1) = 0;
+    virtual mem_buf_desc_t *mem_buf_tx_get(ring_user_id_t id, pbuf_type type,
+                                           uint32_t n_num_mem_bufs = 1) = 0;
     virtual int mem_buf_tx_release(mem_buf_desc_t *p_mem_buf_desc_list, bool trylock = false) = 0;
     virtual void mem_buf_rx_release(mem_buf_desc_t *p_mem_buf_desc)
     {

--- a/src/core/dev/ring.h
+++ b/src/core/dev/ring.h
@@ -83,8 +83,7 @@ public:
     // Get/Release memory buffer descriptor with a linked data memory buffer
     virtual mem_buf_desc_t *mem_buf_tx_get(ring_user_id_t id, bool b_block, pbuf_type type,
                                            int n_num_mem_bufs = 1) = 0;
-    virtual int mem_buf_tx_release(mem_buf_desc_t *p_mem_buf_desc_list, bool b_accounting,
-                                   bool trylock = false) = 0;
+    virtual int mem_buf_tx_release(mem_buf_desc_t *p_mem_buf_desc_list, bool trylock = false) = 0;
     virtual void mem_buf_rx_release(mem_buf_desc_t *p_mem_buf_desc)
     {
         buffer_pool::free_rx_lwip_pbuf_custom(&p_mem_buf_desc->lwip_pbuf);

--- a/src/core/dev/ring_bond.cpp
+++ b/src/core/dev/ring_bond.cpp
@@ -269,8 +269,7 @@ mem_buf_desc_t *ring_bond::mem_buf_tx_get(ring_user_id_t id, bool b_block, pbuf_
     return ret;
 }
 
-int ring_bond::mem_buf_tx_release(mem_buf_desc_t *p_mem_buf_desc_list, bool b_accounting,
-                                  bool trylock /*=false*/)
+int ring_bond::mem_buf_tx_release(mem_buf_desc_t *p_mem_buf_desc_list, bool trylock /*=false*/)
 {
     mem_buf_desc_t *buffer_per_ring[MAX_NUM_RING_RESOURCES];
     int ret = 0;
@@ -283,7 +282,7 @@ int ring_bond::mem_buf_tx_release(mem_buf_desc_t *p_mem_buf_desc_list, bool b_ac
 
     for (i = 0; i < m_bond_rings.size(); i++) {
         if (buffer_per_ring[i]) {
-            ret += m_bond_rings[i]->mem_buf_tx_release(buffer_per_ring[i], b_accounting, trylock);
+            ret += m_bond_rings[i]->mem_buf_tx_release(buffer_per_ring[i], trylock);
         }
     }
     return ret;
@@ -328,9 +327,9 @@ void ring_bond::send_ring_buffer(ring_user_id_t id, xlio_ibv_send_wr *p_send_wqe
                      p_mem_buf_desc);
         p_mem_buf_desc->p_next_desc = nullptr;
         if (likely(p_mem_buf_desc->p_desc_owner == m_bond_rings[id])) {
-            m_bond_rings[id]->mem_buf_tx_release(p_mem_buf_desc, true);
+            m_bond_rings[id]->mem_buf_tx_release(p_mem_buf_desc);
         } else {
-            mem_buf_tx_release(p_mem_buf_desc, true);
+            mem_buf_tx_release(p_mem_buf_desc);
         }
     }
 }

--- a/src/core/dev/ring_bond.cpp
+++ b/src/core/dev/ring_bond.cpp
@@ -258,13 +258,13 @@ void ring_bond::flow_del_all_rfs_safe()
     }
 }
 
-mem_buf_desc_t *ring_bond::mem_buf_tx_get(ring_user_id_t id, bool b_block, pbuf_type type,
-                                          int n_num_mem_bufs /* default = 1 */)
+mem_buf_desc_t *ring_bond::mem_buf_tx_get(ring_user_id_t id, pbuf_type type,
+                                          uint32_t n_num_mem_bufs /* default = 1 */)
 {
     mem_buf_desc_t *ret = nullptr;
 
     std::lock_guard<decltype(m_lock_ring_tx)> lock(m_lock_ring_tx);
-    ret = m_xmit_rings[id]->mem_buf_tx_get(id, b_block, type, n_num_mem_bufs);
+    ret = m_xmit_rings[id]->mem_buf_tx_get(id, type, n_num_mem_bufs);
 
     return ret;
 }

--- a/src/core/dev/ring_bond.h
+++ b/src/core/dev/ring_bond.h
@@ -69,8 +69,7 @@ public:
     virtual void restart();
     virtual mem_buf_desc_t *mem_buf_tx_get(ring_user_id_t id, bool b_block, pbuf_type type,
                                            int n_num_mem_bufs = 1);
-    virtual int mem_buf_tx_release(mem_buf_desc_t *p_mem_buf_desc_list, bool b_accounting,
-                                   bool trylock = false);
+    virtual int mem_buf_tx_release(mem_buf_desc_t *p_mem_buf_desc_list, bool trylock = false);
     virtual void inc_tx_retransmissions_stats(ring_user_id_t id);
     virtual void send_ring_buffer(ring_user_id_t id, xlio_ibv_send_wr *p_send_wqe,
                                   xlio_wr_tx_packet_attr attr);

--- a/src/core/dev/ring_bond.h
+++ b/src/core/dev/ring_bond.h
@@ -67,8 +67,8 @@ public:
     virtual bool attach_flow(flow_tuple &flow_spec_5t, sockinfo *sink, bool force_5t = false);
     virtual bool detach_flow(flow_tuple &flow_spec_5t, sockinfo *sink);
     virtual void restart();
-    virtual mem_buf_desc_t *mem_buf_tx_get(ring_user_id_t id, bool b_block, pbuf_type type,
-                                           int n_num_mem_bufs = 1);
+    virtual mem_buf_desc_t *mem_buf_tx_get(ring_user_id_t id, pbuf_type type,
+                                           uint32_t n_num_mem_bufs = 1);
     virtual int mem_buf_tx_release(mem_buf_desc_t *p_mem_buf_desc_list, bool trylock = false);
     virtual void inc_tx_retransmissions_stats(ring_user_id_t id);
     virtual void send_ring_buffer(ring_user_id_t id, xlio_ibv_send_wr *p_send_wqe,

--- a/src/core/dev/ring_simple.cpp
+++ b/src/core/dev/ring_simple.cpp
@@ -692,8 +692,6 @@ bool ring_simple::is_available_qp_wr(bool b_block, unsigned credits)
     bool granted;
     int ret;
 
-    // TODO credits_get() does TX polling. Call current method only for bocking mode?
-
     do {
         // Try to poll once in the hope that we get space in SQ
         ret = m_p_cq_mgr_tx->poll_and_process_element_tx();
@@ -755,11 +753,7 @@ bool ring_simple::is_available_qp_wr(bool b_block, unsigned credits)
                 if (p_cq_mgr_tx) {
 
                     // Allow additional CQ arming now
-                    if (safe_mce_sys().doca_tx) {
-                        m_hqtx->clear_notification();
-                    } else {
-                        p_cq_mgr_tx->reset_notification_armed();
-                    }
+                    p_cq_mgr_tx->reset_notification_armed();
 
                     // Perform a non blocking event read, clear the fd channel
                     ret = p_cq_mgr_tx->poll_and_process_element_tx();

--- a/src/core/dev/ring_simple.h
+++ b/src/core/dev/ring_simple.h
@@ -84,8 +84,8 @@ public:
     void start_active_queue_rx();
     void stop_active_queue_tx();
     void stop_active_queue_rx();
-    mem_buf_desc_t *mem_buf_tx_get(ring_user_id_t id, bool b_block, pbuf_type type,
-                                   int n_num_mem_bufs = 1) override;
+    mem_buf_desc_t *mem_buf_tx_get(ring_user_id_t id, pbuf_type type,
+                                   uint32_t n_num_mem_bufs = 1) override;
     int mem_buf_tx_release(mem_buf_desc_t *p_mem_buf_desc_list, bool trylock = false) override;
     void send_ring_buffer(ring_user_id_t id, xlio_ibv_send_wr *p_send_wqe,
                           xlio_wr_tx_packet_attr attr) override;
@@ -298,7 +298,6 @@ protected:
 
 private:
     inline void send_status_handler(int ret, xlio_ibv_send_wr *p_send_wqe);
-    inline mem_buf_desc_t *get_tx_buffers(pbuf_type type, uint32_t n_num_mem_bufs);
     inline int put_tx_buffer_helper(mem_buf_desc_t *buff);
     inline int put_tx_buffers(mem_buf_desc_t *buff_list);
     inline int put_tx_single_buffer(mem_buf_desc_t *buff);

--- a/src/core/dev/ring_simple.h
+++ b/src/core/dev/ring_simple.h
@@ -86,8 +86,7 @@ public:
     void stop_active_queue_rx();
     mem_buf_desc_t *mem_buf_tx_get(ring_user_id_t id, bool b_block, pbuf_type type,
                                    int n_num_mem_bufs = 1) override;
-    int mem_buf_tx_release(mem_buf_desc_t *p_mem_buf_desc_list, bool b_accounting,
-                           bool trylock = false) override;
+    int mem_buf_tx_release(mem_buf_desc_t *p_mem_buf_desc_list, bool trylock = false) override;
     void send_ring_buffer(ring_user_id_t id, xlio_ibv_send_wr *p_send_wqe,
                           xlio_wr_tx_packet_attr attr) override;
     int send_lwip_buffer(ring_user_id_t id, xlio_ibv_send_wr *p_send_wqe,
@@ -332,7 +331,6 @@ private:
     uint32_t m_tx_num_bufs = 0U;
     uint32_t m_zc_num_bufs = 0U;
     uint32_t m_tx_num_wr = 0U;
-    uint32_t m_missing_buf_ref_count = 0U;
     uint32_t m_tx_lkey = 0U; // this is the registered memory lkey for a given specific device for
                              // the buffer pool use
     doca_mmap *m_p_doca_mmap;

--- a/src/core/proto/dst_entry.cpp
+++ b/src/core/proto/dst_entry.cpp
@@ -103,11 +103,11 @@ dst_entry::~dst_entry()
         }
 
         if (m_p_tx_mem_buf_desc_list) {
-            m_p_ring->mem_buf_tx_release(m_p_tx_mem_buf_desc_list, true);
+            m_p_ring->mem_buf_tx_release(m_p_tx_mem_buf_desc_list);
             m_p_tx_mem_buf_desc_list = nullptr;
         }
         if (m_p_zc_mem_buf_desc_list) {
-            m_p_ring->mem_buf_tx_release(m_p_zc_mem_buf_desc_list, true);
+            m_p_ring->mem_buf_tx_release(m_p_zc_mem_buf_desc_list);
             m_p_zc_mem_buf_desc_list = nullptr;
         }
 
@@ -373,11 +373,11 @@ bool dst_entry::release_ring()
     if (m_p_net_dev_val) {
         if (m_p_ring) {
             if (m_p_tx_mem_buf_desc_list) {
-                m_p_ring->mem_buf_tx_release(m_p_tx_mem_buf_desc_list, true);
+                m_p_ring->mem_buf_tx_release(m_p_tx_mem_buf_desc_list);
                 m_p_tx_mem_buf_desc_list = nullptr;
             }
             if (m_p_zc_mem_buf_desc_list) {
-                m_p_ring->mem_buf_tx_release(m_p_zc_mem_buf_desc_list, true);
+                m_p_ring->mem_buf_tx_release(m_p_zc_mem_buf_desc_list);
                 m_p_zc_mem_buf_desc_list = nullptr;
             }
             dst_logdbg("releasing a ring");
@@ -555,11 +555,11 @@ bool dst_entry::prepare_to_send(struct xlio_rate_limit_t &rate_limit, bool skip_
                                                  htons(ETH_P_IP), m_pkt_src_ip, m_dst_ip,
                                                  m_src_port, m_dst_port);
                     if (m_p_tx_mem_buf_desc_list) {
-                        m_p_ring->mem_buf_tx_release(m_p_tx_mem_buf_desc_list, true);
+                        m_p_ring->mem_buf_tx_release(m_p_tx_mem_buf_desc_list);
                         m_p_tx_mem_buf_desc_list = nullptr;
                     }
                     if (m_p_zc_mem_buf_desc_list) {
-                        m_p_ring->mem_buf_tx_release(m_p_zc_mem_buf_desc_list, true);
+                        m_p_ring->mem_buf_tx_release(m_p_zc_mem_buf_desc_list);
                         m_p_zc_mem_buf_desc_list = nullptr;
                     }
                     resolved = true;
@@ -672,10 +672,10 @@ void dst_entry::do_ring_migration_tx(lock_base &socket_lock, resource_allocation
     socket_lock.unlock();
 
     if (tmp_list) {
-        old_ring->mem_buf_tx_release(tmp_list, true);
+        old_ring->mem_buf_tx_release(tmp_list);
     }
     if (tmp_list_zc) {
-        old_ring->mem_buf_tx_release(tmp_list_zc, true);
+        old_ring->mem_buf_tx_release(tmp_list_zc);
     }
 
     m_p_net_dev_val->release_ring(&old_key);
@@ -768,13 +768,13 @@ void dst_entry::return_buffers_pool()
 
     if (m_b_tx_mem_buf_desc_list_pending && m_p_ring) {
         if (m_p_tx_mem_buf_desc_list) {
-            count = m_p_ring->mem_buf_tx_release(m_p_tx_mem_buf_desc_list, true, true);
+            count = m_p_ring->mem_buf_tx_release(m_p_tx_mem_buf_desc_list, true);
             if (count) {
                 m_p_tx_mem_buf_desc_list = nullptr;
             }
         }
         if (m_p_zc_mem_buf_desc_list) {
-            count = m_p_ring->mem_buf_tx_release(m_p_zc_mem_buf_desc_list, true, true);
+            count = m_p_ring->mem_buf_tx_release(m_p_zc_mem_buf_desc_list, true);
             if (count) {
                 m_p_zc_mem_buf_desc_list = nullptr;
             }

--- a/src/core/proto/dst_entry.h
+++ b/src/core/proto/dst_entry.h
@@ -231,7 +231,7 @@ protected:
             } else {
                 /* free the buffer if dummy send is not supported */
                 mem_buf_desc_t *p_mem_buf_desc = (mem_buf_desc_t *)(p_send_wqe->wr_id);
-                m_p_ring->mem_buf_tx_release(p_mem_buf_desc, true);
+                m_p_ring->mem_buf_tx_release(p_mem_buf_desc);
             }
         } else {
             m_p_ring->send_ring_buffer(id, p_send_wqe, attr);

--- a/src/core/proto/dst_entry_tcp.h
+++ b/src/core/proto/dst_entry_tcp.h
@@ -59,7 +59,7 @@ public:
     ssize_t slow_send_neigh(const iovec *p_iov, size_t sz_iov,
                             struct xlio_rate_limit_t &rate_limit);
 
-    mem_buf_desc_t *get_buffer(pbuf_type type, pbuf_desc *desc, bool b_blocked = false);
+    mem_buf_desc_t *get_buffer(pbuf_type type, pbuf_desc *desc);
     void put_buffer(mem_buf_desc_t *p_desc);
     void put_zc_buffer(mem_buf_desc_t *p_desc);
 

--- a/src/core/proto/dst_entry_udp.cpp
+++ b/src/core/proto/dst_entry_udp.cpp
@@ -157,7 +157,7 @@ bool dst_entry_udp::fast_send_fragmented_ipv6(mem_buf_desc_t *p_mem_buf_desc, co
         if (ret != (int)sz_user_data_to_copy) {
             __log_err("memcpy_fromiovec error (sz_user_data_to_copy=%zu, ret=%d)\n",
                       sz_user_data_to_copy, ret);
-            p_ring->mem_buf_tx_release(p_mem_buf_desc, true);
+            p_ring->mem_buf_tx_release(p_mem_buf_desc);
             return false;
         }
         BULLSEYE_EXCLUDE_BLOCK_END
@@ -296,7 +296,7 @@ inline ssize_t dst_entry_udp::fast_send_not_fragmented(const iovec *p_iov, const
         if (ret != (int)sz_data_payload) {
             dst_udp_logerr("memcpy_fromiovec error (sz_user_data_to_copy=%lu, ret=%d)",
                            sz_data_payload, ret);
-            m_p_ring->mem_buf_tx_release(p_mem_buf_desc, true);
+            m_p_ring->mem_buf_tx_release(p_mem_buf_desc);
             errno = EINVAL;
             return -1;
         }
@@ -386,7 +386,7 @@ inline bool dst_entry_udp::fast_send_fragmented_ipv4(mem_buf_desc_t *p_mem_buf_d
         if (ret != (int)sz_user_data_to_copy) {
             dst_udp_logerr("memcpy_fromiovec error (sz_user_data_to_copy=%lu, ret=%d)",
                            sz_user_data_to_copy, ret);
-            m_p_ring->mem_buf_tx_release(p_mem_buf_desc, true);
+            m_p_ring->mem_buf_tx_release(p_mem_buf_desc);
             return false;
         }
         BULLSEYE_EXCLUDE_BLOCK_END

--- a/src/core/proto/neighbour.cpp
+++ b/src/core/proto/neighbour.cpp
@@ -475,7 +475,7 @@ bool neigh_entry::post_send_udp_ipv4(neigh_send_data *n_send_data)
                  n_num_frags, ntohs(h->get_udp_hdr()->source), ntohs(h->get_udp_hdr()->dest));
 
     // Get all needed tx buf descriptor and data buffers
-    p_mem_buf_desc = m_p_ring->mem_buf_tx_get(m_id, false, PBUF_RAM, n_num_frags);
+    p_mem_buf_desc = m_p_ring->mem_buf_tx_get(m_id, PBUF_RAM, n_num_frags);
 
     if (unlikely(!p_mem_buf_desc)) {
         neigh_logdbg("Packet dropped. not enough tx buffers");
@@ -583,7 +583,7 @@ bool neigh_entry::post_send_udp_ipv6_fragmented(neigh_send_data *n_send_data, si
     int n_num_frags =
         (sz_udp_payload + max_payload_size_per_packet - 1) / max_payload_size_per_packet;
 
-    mem_buf_desc_t *p_mem_buf_desc = m_p_ring->mem_buf_tx_get(m_id, false, PBUF_RAM, n_num_frags);
+    mem_buf_desc_t *p_mem_buf_desc = m_p_ring->mem_buf_tx_get(m_id, PBUF_RAM, n_num_frags);
     if (unlikely(!p_mem_buf_desc)) {
         neigh_logdbg("Packet dropped. not enough tx buffers");
         return false;
@@ -598,7 +598,7 @@ bool neigh_entry::post_send_udp_ipv6_fragmented(neigh_send_data *n_send_data, si
 bool neigh_entry::post_send_udp_ipv6_not_fragmented(neigh_send_data *n_send_data)
 {
     neigh_logdbg("ENTER post_send_udp_ipv6_not_fragmented");
-    mem_buf_desc_t *p_mem_buf_desc = m_p_ring->mem_buf_tx_get(m_id, false, PBUF_RAM);
+    mem_buf_desc_t *p_mem_buf_desc = m_p_ring->mem_buf_tx_get(m_id, PBUF_RAM);
     if (unlikely(!p_mem_buf_desc)) {
         neigh_logdbg("Packet dropped. not enough tx buffers");
         return false;
@@ -671,7 +671,7 @@ bool neigh_entry::post_send_tcp(neigh_send_data *p_data)
     size_t total_packet_len = 0;
     header *h = p_data->m_header;
 
-    p_mem_buf_desc = m_p_ring->mem_buf_tx_get(m_id, false, PBUF_RAM, 1);
+    p_mem_buf_desc = m_p_ring->mem_buf_tx_get(m_id, PBUF_RAM, 1);
 
     BULLSEYE_EXCLUDE_BLOCK_START
     if (unlikely(!p_mem_buf_desc)) {
@@ -1634,7 +1634,7 @@ bool neigh_eth::send_arp_request(bool is_broadcast)
                                  netdevice_eth->get_vlan() ? htons(ETH_P_8021Q) : htons(ETH_P_ARP),
                                  htons(ETH_P_ARP), ip_address::any_addr(), ip_address::any_addr(),
                                  0, 0);
-    mem_buf_desc_t *p_mem_buf_desc = m_p_ring->mem_buf_tx_get(m_id, false, PBUF_RAM, 1);
+    mem_buf_desc_t *p_mem_buf_desc = m_p_ring->mem_buf_tx_get(m_id, PBUF_RAM, 1);
     BULLSEYE_EXCLUDE_BLOCK_START
     if (unlikely(!p_mem_buf_desc)) {
         neigh_logdbg("No free TX buffer, not sending ARP");
@@ -1726,7 +1726,7 @@ bool neigh_eth::send_neighbor_solicitation()
     m_id = m_p_ring->generate_id(src_mac->get_address(), dst_mac.get_address(),
                                  net_dev->get_vlan() ? htons(ETH_P_8021Q) : htons(ETH_P_IPV6),
                                  htons(ETH_P_IPV6), m_src_addr, dst_snm, 0, 0);
-    mem_buf_desc_t *p_mem_buf_desc = m_p_ring->mem_buf_tx_get(m_id, false, PBUF_RAM, 1);
+    mem_buf_desc_t *p_mem_buf_desc = m_p_ring->mem_buf_tx_get(m_id, PBUF_RAM, 1);
     BULLSEYE_EXCLUDE_BLOCK_START
     if (unlikely(!p_mem_buf_desc)) {
         neigh_logdbg("No free TX buffer - not sending NS");

--- a/src/core/proto/neighbour.cpp
+++ b/src/core/proto/neighbour.cpp
@@ -534,7 +534,7 @@ bool neigh_entry::post_send_udp_ipv4(neigh_send_data *n_send_data)
         if (ret != (int)sz_user_data_to_copy) {
             neigh_logerr("memcpy_fromiovec error (sz_user_data_to_copy=%zd, ret=%d)",
                          sz_user_data_to_copy, ret);
-            m_p_ring->mem_buf_tx_release(p_mem_buf_desc, true);
+            m_p_ring->mem_buf_tx_release(p_mem_buf_desc);
             errno = EINVAL;
             return false;
         }
@@ -637,7 +637,7 @@ bool neigh_entry::post_send_udp_ipv6_not_fragmented(neigh_send_data *n_send_data
     if (ret != (int)sz_data_payload) {
         neigh_logerr("memcpy_fromiovec error (sz_user_data_to_copy=%zd, ret=%d)", sz_data_payload,
                      ret);
-        m_p_ring->mem_buf_tx_release(p_mem_buf_desc, true);
+        m_p_ring->mem_buf_tx_release(p_mem_buf_desc);
         errno = EINVAL;
         return false;
     }

--- a/src/core/sock/sockinfo.h
+++ b/src/core/sock/sockinfo.h
@@ -181,7 +181,7 @@ struct epoll_fd_rec {
     void reset()
     {
         this->events = 0;
-        memset(&this->epdata, 0, sizeof(this->epdata));
+        epdata.ptr = nullptr;
         this->offloaded_index = 0;
     }
 };


### PR DESCRIPTION
## Description
1. Removed DOCA code from CQ mgr TX - CQ mgrs are planned to be removed
2. Removed mem_buf_tx_get inner polling   
3. Removed debug only variable in data path

##### What
Inner polling inside mem_buf_tx_get tries to mitigate bad app behavior or misconfiguration. 
XLIO focuses on HPC apps and it is better to avoid such unnecessary logics.
Additionally, the implementation introduces a race in working with notification mechanism.

##### Why ?
DOCA integration

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [X] Code follows the style de facto guidelines of this project
- [X] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

