### PR TITLE
[CI]: Implement weekly builds on DR site

### DIFF
--- a/.ci/pipeline/dr_weekly_jjb.yaml
+++ b/.ci/pipeline/dr_weekly_jjb.yaml
@@ -1,0 +1,68 @@
+- job-template:
+    name: "{jjb_proj}"
+    project-type: pipeline
+    folder: pdc
+    properties:
+        - github:
+            url: "https://github.com/Mellanox/libxlio"
+        - build-discarder:
+            days-to-keep: 120
+            num-to-keep: 20
+        - inject:
+            keep-system-variables: true
+            properties-content: |
+              jjb_proj={jjb_proj}
+    description: Do NOT edit this job through the Web GUI !
+    concurrent: false
+    parameters:
+        - string: 
+            name: "sha1"
+            default: "vNext"
+            description: "Branch or sha1 to check out"
+        - string:
+            name: "release_tag"
+            default: ""
+            description: "Tag to release"
+        - string:
+            name: "release_folder"
+            default: "/tmp"
+            description: "Folder to release packages into. For NFS tests use /auto/sw/release/sw_acceleration/xlio/dr/weekly"
+        - string:
+            name: "CONF_FILE"
+            default: ".ci/pipeline/dr_weekly_matrix.yaml"
+            description: "Regex to select job config file"
+        - string:
+            name: "MAIL_TO"
+            default: "c2a304c7.NVIDIA.onmicrosoft.com@amer.teams.ms"
+            description: "Email address to send the report to"
+    triggers:
+        - timed: 'H 17 * * *'
+    pipeline-scm:
+        scm:
+            - git:
+                url: "{jjb_git}"
+                credentials-id: 'swx-jenkins_ssh_key'
+                branches: ['$sha1']
+                shallow-clone: false
+                # depth: 10
+                do-not-fetch-tags: false
+                # honor-refspec: true
+                refspec: "+refs/heads/*:refs/remotes/origin/* +refs/pull/*:refs/remotes/origin/pr/* +refs/tags/*:refs/remotes/origin/tags/*"
+                browser: githubweb
+                browser-url: "{jjb_git}"
+                submodule:
+                    disable: false
+                    recursive: true
+                    tracking: true
+                    parent-credentials: true
+        script-path: "{jjb_jenkinsfile}"
+
+- project:
+    name: libxlio
+    jjb_email: 'vlogin@nvidia.com'
+    jjb_proj: 'LIBXLIO-dr-weekly-launcher'
+    jjb_git: 'git@github.com:Mellanox/libxlio.git'
+    jjb_owner: 'Viacheslav Login'
+    jjb_jenkinsfile: '.ci/Jenkinsfile'
+    jobs:
+        - "{jjb_proj}"

--- a/.ci/pipeline/dr_weekly_matrix.yaml
+++ b/.ci/pipeline/dr_weekly_matrix.yaml
@@ -1,0 +1,91 @@
+---
+job: LIBXLIO-dr-weekly-launcher
+failFast: false
+timeout_minutes: 120
+
+runs_on_agents:
+  - {nodeLabel: 'master', category: 'base'}
+
+env:
+  MAIL_FROM: jenkins@nvidia.com
+
+pipeline_start:
+  shell: action
+  module: groovy
+  run: |
+    if (!params.MAIL_TO.isEmpty()) {
+      currentBuild.displayName += "_weekly-on-${sha1}"
+      mail from: "${MAIL_FROM}",
+        mimeType: 'text/html',
+        to: "${MAIL_TO}",
+        subject: 'LibXLIO weekly DR build has been started',
+        body: """
+          <p><b>Branch:</b> ${sha1}</p>
+          <p><b>Build url:</b> <a href=${currentBuild.absoluteUrl}>link</a></p>"""
+    }
+
+steps:
+  - name: Determine release_tag
+    agentSelector:
+      - "{category: 'base'}"
+    shell: action
+    module: groovy
+    run: |
+      if (params.release_tag.isEmpty()) {
+        env.RELEASE_TAG = sh (returnStdout: true, script: "git describe --tags --abbrev=0 2>/dev/null").trim()
+      } else {
+        env.RELEASE_TAG = "${params.release_tag}"
+      }
+      echo "Release tag for build: ${env.RELEASE_TAG}"
+
+  - name: Check job state
+    shell: action
+    module: groovy
+    run: |
+      def job = Jenkins.instance.getItemByFullName('libxlio/LibXLIO-release-dr')
+      if (!job.isBuildable()) {
+          echo "The job '${env.JOB}' is disabled. Enabling..."
+          job.setDisabled(false)
+      } 
+      echo "The Job is enabled. Starting..."
+
+  - name: Run Job with parameters
+    shell: action
+    module: groovy
+    run: |
+      echo "Release tag we're building on: ${env.RELEASE_TAG}"
+      if (env.RELEASE_TAG) {
+        def build = build job: 'libxlio/LibXLIO-release-dr',
+          parameters: [
+            string(name: 'release_tag', value: RELEASE_TAG),
+            string(name: 'release_folder', value: "${release_folder}"),
+            string(name: 'notification_email', value: MAIL_TO),
+            string(name: 'sha1', value: sha1),
+          ],
+          propagate: false
+
+        env.LINUX_BUILD_URL = build.absoluteUrl
+        env.LINUX_BUILD_RES = build.result
+        if (!build.resultIsBetterOrEqualTo('SUCCESS')) {
+          currentBuild.result = 'FAILURE'
+          error("Weekly build failed")
+        }
+      }
+
+pipeline_stop:
+    shell: action
+    module: groovy
+    agentSelector:
+      - "{category: 'base'}"
+    run: |
+      if (!params.MAIL_TO.isEmpty()) {
+        mail from: "${MAIL_FROM}",
+          mimeType: 'text/html',
+          to: "${MAIL_TO}",
+          subject: "LibXLIO weekly DR build has ended - ${currentBuild.currentResult}",
+          body: """
+            <p><b>Branch:</b> ${sha1}</p>
+            <p><b>Version:</b> ${env.RELEASE_TAG ?: "NA"}</p>
+            <p><b>Weekly DR build:</b> <a href=${currentBuild.absoluteUrl}>${currentBuild.currentResult}</a></p>
+            """
+      }


### PR DESCRIPTION
## Description
This change implements weekly builds on the DR site

##### What
weekly_laucher Job that stays unchanged and triggers the release job on the DR site

##### Why ?
We need to do periodic checks of DR Jenkins instance and Infra entities by running CI workloads

##### How ?
weekly_laucher scheduled job

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

