### PR TITLE
issue: 4158085 DOCA TX credits

### DIFF
--- a/README
+++ b/README
@@ -88,6 +88,7 @@ Example:
  XLIO DETAILS: TCP max syn rate               0 (no limit)               [XLIO_TCP_MAX_SYN_RATE]
  XLIO DETAILS: Zerocopy Mem Bufs              200000                     [XLIO_ZC_BUFS]
  XLIO DETAILS: Zerocopy Cache Threshold       10 GB                      [XLIO_ZC_CACHE_THRESHOLD]
+ XLIO DETAILS: Tx Queue Max Elements          32K                        [XLIO_TX_QUEUE_MAX_ELEMENTS]
  XLIO DETAILS: Tx Mem Buf size                0                          [XLIO_TX_BUF_SIZE]
  XLIO DETAILS: ZC TX size                     32 KB                      [XLIO_ZC_TX_SIZE]
  XLIO DETAILS: Tx QP WRE                      32768                      [XLIO_TX_WRE]
@@ -313,6 +314,12 @@ Default value is 200000
 XLIO_ZC_CACHE_THRESHOLD
 Memory limit for the mapping cache which is use by sendfile().
 Default value is 10GB
+
+Name: XLIO_TX_QUEUE_MAX_ELEMENTS
+Defines the max queue size for TX queues.
+Higher values allow buffering more tasks internally, which improves NIC utilization. However, this may introduce delays in NIC recovery if a burst persists for extended periods.
+Lower values help the NIC to recover more quickly from bursts but may limit its capacity to efficiently manage large bursts of data.
+Default value is 32K
 
 XLIO_TX_BUF_SIZE
 Size of Tx data buffer elements allocation.

--- a/src/core/dev/hw_queue_tx.cpp
+++ b/src/core/dev/hw_queue_tx.cpp
@@ -334,6 +334,8 @@ bool hw_queue_tx::prepare_doca_txq()
         return false;
     }
 
+    m_task_list_count = max_burst_size;
+
     err = doca_eth_txq_set_l3_chksum_offload(txq, DOCA_CHECKSUM_HW_L3_ENABLE);
     if (DOCA_IS_ERROR(err)) {
         PRINT_DOCA_ERR(hwqtx_logerr, err, "doca_eth_txq_set_l3_chksum_offload txq: %p",
@@ -2001,18 +2003,30 @@ bool hw_queue_tx::expand_doca_inventory()
 
 bool hw_queue_tx::expand_doca_task_pool(bool is_lso)
 {
+    if (m_task_list_count >= safe_mce_sys().tx_queue_max_elements) {
+        hwqtx_logfunc("Silent packet drop, can't expand task pool");
+        return false;
+    }
+
+    const uint16_t expand_batch_size =
+        (m_task_list_count + DOCA_EXPAND_BATCH_SIZE) >= safe_mce_sys().tx_queue_max_elements
+        ? (m_task_list_count + DOCA_EXPAND_BATCH_SIZE) % DOCA_EXPAND_BATCH_SIZE
+        : (DOCA_EXPAND_BATCH_SIZE);
+
     doca_error_t rc;
     doca_eth_txq *txq = m_doca_txq.get();
     if (is_lso) {
-        rc = doca_eth_txq_task_lso_send_num_expand(txq, DOCA_EXPAND_BATCH_SIZE);
+        rc = doca_eth_txq_task_lso_send_num_expand(txq, expand_batch_size);
     } else {
-        rc = doca_eth_txq_task_send_num_expand(txq, DOCA_EXPAND_BATCH_SIZE);
+        rc = doca_eth_txq_task_send_num_expand(txq, expand_batch_size);
     }
 
     if (DOCA_IS_ERROR(rc)) {
         PRINT_DOCA_ERR(hwqtx_logerr, rc, "DOCA expand task pool (LSO=%d) failed", is_lso);
         return false;
     }
+
+    m_task_list_count += expand_batch_size;
     return true;
 }
 

--- a/src/core/dev/hw_queue_tx.h
+++ b/src/core/dev/hw_queue_tx.h
@@ -345,6 +345,7 @@ private:
     doca_notification_handle_t m_notification_handle;
     doca_lso_metadata *m_p_doca_lso_metadata_list = nullptr;
     hw_queue_tx_stats_t m_hwq_tx_stats;
+    uint32_t m_task_list_count = 0;
 
     static void tx_task_completion_cb(doca_eth_txq_task_send *task_send, doca_data task_user_data,
                                       doca_data ctx_user_data);

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -565,6 +565,11 @@ void print_xlio_global_settings()
     VLOG_PARAM_STRING("Zerocopy Cache Threshold", safe_mce_sys().zc_cache_threshold,
                       MCE_DEFAULT_ZC_CACHE_THRESHOLD, SYS_VAR_ZC_CACHE_THRESHOLD,
                       option_size::to_str(safe_mce_sys().zc_cache_threshold));
+
+    VLOG_PARAM_STRING("Tx Queue Expansions Limit", safe_mce_sys().tx_queue_max_elements,
+                      MCE_DEFAULT_TX_QUEUE_MAX_ELEMENTS, SYS_VAR_TX_QUEUE_MAX_ELEMENTS,
+                      option_size::to_str(safe_mce_sys().tx_queue_max_elements));
+
     VLOG_PARAM_STRING("Tx Mem Buf size", safe_mce_sys().tx_buf_size, MCE_DEFAULT_TX_BUF_SIZE,
                       SYS_VAR_TX_BUF_SIZE, option_size::to_str(safe_mce_sys().tx_buf_size));
     VLOG_PARAM_NUMBER("Tx QP WRE", safe_mce_sys().tx_num_wr, MCE_DEFAULT_TX_NUM_WRE,

--- a/src/core/util/sys_vars.cpp
+++ b/src/core/util/sys_vars.cpp
@@ -31,6 +31,7 @@
  * SOFTWARE.
  */
 
+#include "doca_log.h"
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -779,6 +780,9 @@ void mce_sys_var::get_env_params()
     tcp_max_syn_rate = MCE_DEFAULT_TCP_MAX_SYN_RATE;
 
     zc_cache_threshold = MCE_DEFAULT_ZC_CACHE_THRESHOLD;
+
+    tx_queue_max_elements = MCE_DEFAULT_TX_QUEUE_MAX_ELEMENTS;
+
     tx_buf_size = MCE_DEFAULT_TX_BUF_SIZE;
     tcp_nodelay_treshold = MCE_DEFAULT_TCP_NODELAY_TRESHOLD;
     tx_num_wr = MCE_DEFAULT_TX_NUM_WRE;
@@ -1147,6 +1151,10 @@ void mce_sys_var::get_env_params()
 
     if ((env_ptr = getenv(SYS_VAR_ZC_CACHE_THRESHOLD))) {
         zc_cache_threshold = option_size::from_str(env_ptr);
+    }
+
+    if ((env_ptr = getenv(SYS_VAR_TX_QUEUE_MAX_ELEMENTS))) {
+        tx_queue_max_elements = (uint32_t)option_size::from_str(env_ptr);
     }
 
     if ((env_ptr = getenv(SYS_VAR_TX_BUF_SIZE))) {

--- a/src/core/util/sys_vars.h
+++ b/src/core/util/sys_vars.h
@@ -362,6 +362,7 @@ public:
     int tcp_max_syn_rate;
 
     size_t zc_cache_threshold;
+    uint32_t tx_queue_max_elements;
     uint32_t tx_buf_size;
     uint32_t tcp_nodelay_treshold;
     uint32_t tx_num_wr;
@@ -567,6 +568,7 @@ extern mce_sys_var &safe_mce_sys();
 #define SYS_VAR_RING_DEV_MEM_TX          "XLIO_RING_DEV_MEM_TX"
 
 #define SYS_VAR_ZC_CACHE_THRESHOLD    "XLIO_ZC_CACHE_THRESHOLD"
+#define SYS_VAR_TX_QUEUE_MAX_ELEMENTS "XLIO_TX_QUEUE_MAX_ELEMENTS"
 #define SYS_VAR_TX_BUF_SIZE           "XLIO_TX_BUF_SIZE"
 #define SYS_VAR_TCP_NODELAY_TRESHOLD  "XLIO_TCP_NODELAY_TRESHOLD"
 #define SYS_VAR_TX_NUM_WRE            "XLIO_TX_WRE"
@@ -719,6 +721,7 @@ extern mce_sys_var &safe_mce_sys();
 #define MCE_DEFAULT_TCP_MAX_SYN_RATE         (0)
 #define MCE_DEFAULT_TCP_NODELAY_TRESHOLD     (0)
 #define MCE_DEFAULT_ZC_CACHE_THRESHOLD       (10LU * 1024 * 1024 * 1024) // 10GB
+#define MCE_DEFAULT_TX_QUEUE_MAX_ELEMENTS    (32768)
 #define MCE_DEFAULT_TX_BUF_SIZE              (0)
 #define MCE_DEFAULT_TX_NUM_WRE               (32768)
 #define MCE_DEFAULT_TX_NUM_WRE_TO_SIGNAL     (64)


### PR DESCRIPTION
## Description
Using DOCA terminology to implement the equivalent to SW queue limits.

##### What
Limit the amount of TX task pool expansions.

##### Why ?
Solve https://redmine.mellanox.com/issues/4158085.

##### How ?

Utilizing the existing DOCA mechanisms for task pool limits and expansions, the following designs were evaluated:
1. A limit based on WQEBBs.
2. A limit based on in-flight bytes.

Both approaches required code duplication with doca_ether. Leveraging the existing DOCA task pool limitation mechanism achieves similar results without reinventing the wheel, albeit with reduced granularity and control.

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

