### PR TITLE
issue: 4203242 dump wqe to log in case of ecqe

### DIFF
--- a/src/core/dev/cq_mgr_tx.h
+++ b/src/core/dev/cq_mgr_tx.h
@@ -75,7 +75,8 @@ public:
     void reset_notification_armed() { m_b_notification_armed = false; }
 
 private:
-    void log_cqe_error(struct xlio_mlx5_cqe *cqe);
+    std::string wqe_to_hexstring(uint16_t wqe_index, uint32_t credits) const;
+    void log_cqe_error(struct xlio_mlx5_cqe *cqe, uint16_t wqe_index, uint32_t credits) const;
     void handle_sq_wqe_prop(unsigned index);
 
     void get_cq_event(int count = 1) { xlio_ib_mlx5_get_cq_event(&m_mlx5_cq, count); };


### PR DESCRIPTION
dump wqe's content for further debug in case of ecqe.

## Description
Following https://redmine.mellanox.com/issues/4183221
We created a patch to dump the wqe that had the invalid state.

No reason to not have it in our vNext as well.

##### What
_Subject: what this PR is doing in one line._ 

##### Why ?
Further debug ability.

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

