### PR TITLE
issue: 4183221 propogate socket errors

### DIFF
--- a/src/core/dev/ring.h
+++ b/src/core/dev/ring.h
@@ -48,6 +48,7 @@ struct xlio_tls_info;
 class sockinfo;
 class rfs_rule;
 class poll_group;
+struct xlio_send_attr;
 
 #define ring_logpanic   __log_info_panic
 #define ring_logerr     __log_info_err
@@ -99,7 +100,7 @@ public:
     virtual void send_ring_buffer(ring_user_id_t id, xlio_ibv_send_wr *p_send_wqe,
                                   xlio_wr_tx_packet_attr attr) = 0;
     virtual int send_lwip_buffer(ring_user_id_t id, xlio_ibv_send_wr *p_send_wqe,
-                                 xlio_wr_tx_packet_attr attr, xlio_tis *tis) = 0;
+                                 xlio_send_attr &attr) = 0;
 
     virtual int get_num_resources() const = 0;
     virtual int *get_rx_channel_fds(size_t &length) const
@@ -231,7 +232,7 @@ public:
     };
 
     virtual int get_supported_nvme_feature_mask() const { return 0; }
-    virtual void post_nop_fence(void) {}
+    virtual void post_nop_fence(void) { }
     virtual void post_dump_wqe(xlio_tis *tis, void *addr, uint32_t len, uint32_t lkey, bool first)
     {
         NOT_IN_USE(tis);

--- a/src/core/dev/ring_bond.cpp
+++ b/src/core/dev/ring_bond.cpp
@@ -442,14 +442,14 @@ void ring_bond::send_ring_buffer(ring_user_id_t id, xlio_ibv_send_wr *p_send_wqe
 }
 
 int ring_bond::send_lwip_buffer(ring_user_id_t id, xlio_ibv_send_wr *p_send_wqe,
-                                xlio_wr_tx_packet_attr attr, xlio_tis *tis)
+                                xlio_send_attr &attr)
 {
     mem_buf_desc_t *p_mem_buf_desc = (mem_buf_desc_t *)(p_send_wqe->wr_id);
 
     std::lock_guard<decltype(m_lock_ring_tx)> lock(m_lock_ring_tx);
 
     if (is_active_member(p_mem_buf_desc->p_desc_owner, id)) {
-        return m_xmit_rings[id]->send_lwip_buffer(id, p_send_wqe, attr, tis);
+        return m_xmit_rings[id]->send_lwip_buffer(id, p_send_wqe, attr);
     }
 
     ring_logfunc("active ring=%p, silent packet drop (%p), (HA event?)", m_xmit_rings[id],

--- a/src/core/dev/ring_bond.h
+++ b/src/core/dev/ring_bond.h
@@ -81,7 +81,7 @@ public:
     virtual void send_ring_buffer(ring_user_id_t id, xlio_ibv_send_wr *p_send_wqe,
                                   xlio_wr_tx_packet_attr attr);
     virtual int send_lwip_buffer(ring_user_id_t id, xlio_ibv_send_wr *p_send_wqe,
-                                 xlio_wr_tx_packet_attr attr, xlio_tis *tis);
+                                 xlio_send_attr &attr);
     virtual void mem_buf_desc_return_single_to_owner_tx(mem_buf_desc_t *p_mem_buf_desc);
     virtual void mem_buf_desc_return_single_multi_ref(mem_buf_desc_t *p_mem_buf_desc, unsigned ref);
     virtual bool is_member(ring_slave *rng);

--- a/src/core/dev/ring_simple.h
+++ b/src/core/dev/ring_simple.h
@@ -81,8 +81,7 @@ public:
     void mem_buf_desc_return_to_owner_tx(mem_buf_desc_t *p_mem_buf_desc);
     void mem_buf_desc_return_to_owner_rx(mem_buf_desc_t *p_mem_buf_desc,
                                          void *pv_fd_ready_array = nullptr);
-    inline int send_buffer(xlio_ibv_send_wr *p_send_wqe, xlio_wr_tx_packet_attr attr,
-                           xlio_tis *tis);
+    inline int send_buffer(xlio_ibv_send_wr *p_send_wqe, xlio_send_attr &attr);
     bool is_up() override;
     void start_active_queue_tx();
     void start_active_queue_rx();
@@ -95,7 +94,7 @@ public:
     void send_ring_buffer(ring_user_id_t id, xlio_ibv_send_wr *p_send_wqe,
                           xlio_wr_tx_packet_attr attr) override;
     int send_lwip_buffer(ring_user_id_t id, xlio_ibv_send_wr *p_send_wqe,
-                         xlio_wr_tx_packet_attr attr, xlio_tis *tis) override;
+                         xlio_send_attr &attr) override;
     void mem_buf_desc_return_single_to_owner_tx(mem_buf_desc_t *p_mem_buf_desc) override;
     void mem_buf_desc_return_single_multi_ref(mem_buf_desc_t *p_mem_buf_desc,
                                               unsigned ref) override;

--- a/src/core/dev/ring_tap.h
+++ b/src/core/dev/ring_tap.h
@@ -63,7 +63,7 @@ public:
     virtual void send_ring_buffer(ring_user_id_t id, xlio_ibv_send_wr *p_send_wqe,
                                   xlio_wr_tx_packet_attr attr);
     virtual int send_lwip_buffer(ring_user_id_t id, xlio_ibv_send_wr *p_send_wqe,
-                                 xlio_wr_tx_packet_attr attr, xlio_tis *tis);
+                                 xlio_send_attr &attr);
     virtual void mem_buf_desc_return_single_to_owner_tx(mem_buf_desc_t *p_mem_buf_desc);
     virtual void mem_buf_desc_return_single_multi_ref(mem_buf_desc_t *p_mem_buf_desc, unsigned ref);
     virtual mem_buf_desc_t *mem_buf_tx_get(ring_user_id_t id, bool b_block, pbuf_type type,
@@ -82,7 +82,7 @@ public:
         NOT_IN_USE(poll_sn);
         return 0;
     }
-    virtual void adapt_cq_moderation() {}
+    virtual void adapt_cq_moderation() { }
 
     virtual int socketxtreme_poll(struct xlio_socketxtreme_completion_t *xlio_completions,
                                   unsigned int ncompletions, int flags)
@@ -98,7 +98,7 @@ public:
         NOT_IN_USE(rate_limit);
         return 0;
     }
-    void inc_cq_moderation_stats() {}
+    void inc_cq_moderation_stats() { }
     virtual uint32_t get_tx_user_lkey(void *addr, size_t length)
     {
         NOT_IN_USE(addr);
@@ -131,7 +131,7 @@ private:
     int prepare_flow_message(xlio_msg_flow &data, msg_flow_t flow_action);
     int process_element_rx(void *pv_fd_ready_array);
     bool request_more_rx_buffers();
-    int send_buffer(xlio_ibv_send_wr *p_send_wqe, xlio_wr_tx_packet_attr attr);
+    int send_buffer(xlio_ibv_send_wr *p_send_wqe, xlio_send_attr &attr);
     void send_status_handler(int ret, xlio_ibv_send_wr *p_send_wqe);
     void tap_create(net_device_val *p_ndev);
     void tap_destroy();

--- a/src/core/proto/dst_entry_tcp.cpp
+++ b/src/core/proto/dst_entry_tcp.cpp
@@ -65,7 +65,7 @@ transport_t dst_entry_tcp::get_transport(const sock_addr &to)
     return TRANS_XLIO;
 }
 
-ssize_t dst_entry_tcp::fast_send(const iovec *p_iov, const ssize_t sz_iov, xlio_send_attr attr)
+ssize_t dst_entry_tcp::fast_send(const iovec *p_iov, const ssize_t sz_iov, xlio_send_attr &attr)
 {
     int ret = 0;
     void *p_pkt;
@@ -253,7 +253,7 @@ ssize_t dst_entry_tcp::fast_send(const iovec *p_iov, const ssize_t sz_iov, xlio_
             }
         }
 
-        ret = send_lwip_buffer(m_id, p_send_wqe, attr.flags, attr.tis);
+        ret = send_lwip_buffer(m_id, p_send_wqe, attr);
     } else { // We don'nt support inline in this case, since we believe that this a very rare case
         mem_buf_desc_t *p_mem_buf_desc;
         size_t total_packet_len = 0;
@@ -313,7 +313,7 @@ out:
     return ret;
 }
 
-ssize_t dst_entry_tcp::slow_send(const iovec *p_iov, const ssize_t sz_iov, xlio_send_attr attr,
+ssize_t dst_entry_tcp::slow_send(const iovec *p_iov, const ssize_t sz_iov, xlio_send_attr &attr,
                                  struct xlio_rate_limit_t &rate_limit, int flags /*= 0*/,
                                  sockinfo *sock /*= 0*/, tx_call_t call_type /*= 0*/)
 {

--- a/src/core/proto/dst_entry_udp.cpp
+++ b/src/core/proto/dst_entry_udp.cpp
@@ -477,7 +477,7 @@ ssize_t dst_entry_udp::fast_send_fragmented(const iovec *p_iov, const ssize_t sz
     return sz_data_payload;
 }
 
-ssize_t dst_entry_udp::fast_send(const iovec *p_iov, const ssize_t sz_iov, xlio_send_attr attr)
+ssize_t dst_entry_udp::fast_send(const iovec *p_iov, const ssize_t sz_iov, xlio_send_attr &attr)
 {
     /* Suppress flags that should not be used anymore
      * to avoid conflicts with XLIO_TX_PACKET_L3_CSUM and XLIO_TX_PACKET_L4_CSUM
@@ -496,7 +496,7 @@ ssize_t dst_entry_udp::fast_send(const iovec *p_iov, const ssize_t sz_iov, xlio_
     }
 }
 
-ssize_t dst_entry_udp::slow_send(const iovec *p_iov, const ssize_t sz_iov, xlio_send_attr attr,
+ssize_t dst_entry_udp::slow_send(const iovec *p_iov, const ssize_t sz_iov, xlio_send_attr &attr,
                                  struct xlio_rate_limit_t &rate_limit, int flags /*= 0*/,
                                  sockinfo *sock /*= 0*/, tx_call_t call_type /*= 0*/)
 {

--- a/src/core/proto/dst_entry_udp.h
+++ b/src/core/proto/dst_entry_udp.h
@@ -41,8 +41,8 @@ public:
                   resource_allocation_key &ring_alloc_logic);
     virtual ~dst_entry_udp();
 
-    ssize_t fast_send(const iovec *p_iov, const ssize_t sz_iov, xlio_send_attr attr);
-    ssize_t slow_send(const iovec *p_iov, const ssize_t sz_iov, xlio_send_attr attr,
+    ssize_t fast_send(const iovec *p_iov, const ssize_t sz_iov, xlio_send_attr &attr);
+    ssize_t slow_send(const iovec *p_iov, const ssize_t sz_iov, xlio_send_attr &attr,
                       struct xlio_rate_limit_t &rate_limit, int flags = 0, sockinfo *sock = nullptr,
                       tx_call_t call_type = TX_UNDEF);
     static bool fast_send_fragmented_ipv6(mem_buf_desc_t *p_mem_buf_desc, const iovec *p_iov,

--- a/src/core/sock/sockinfo_tcp.cpp
+++ b/src/core/sock/sockinfo_tcp.cpp
@@ -1167,6 +1167,7 @@ ssize_t sockinfo_tcp::tcp_tx(xlio_tx_call_attr_t &tx_arg)
  */
 ssize_t sockinfo_tcp::tcp_tx_slow_path(xlio_tx_call_attr_t &tx_arg)
 {
+    // TODO - call tcp_close(pcb) if you identify the error
     iovec *p_iov = tx_arg.attr.iov;
     size_t sz_iov = tx_arg.attr.sz_iov;
     int flags = tx_arg.attr.flags;
@@ -1366,7 +1367,7 @@ err_t sockinfo_tcp::ip_output(struct pbuf *p, struct tcp_seg *seg, void *v_p_con
     tcp_iovec lwip_iovec[max_count];
     xlio_send_attr attr = {
         (xlio_wr_tx_packet_attr)(flags | (!!p_si_tcp->is_xlio_socket() * XLIO_TX_SKIP_POLL)),
-        p_si_tcp->m_pcb.mss, 0, nullptr};
+        p_si_tcp->m_pcb.mss, 0, nullptr, (tcp_pcb *)v_p_conn};
     int count = 0;
     void *cur_end;
 

--- a/src/core/sock/sockinfo_udp.cpp
+++ b/src/core/sock/sockinfo_udp.cpp
@@ -2181,7 +2181,7 @@ ssize_t sockinfo_udp::tx(xlio_tx_call_attr_t &tx_arg)
     }
 
     {
-        xlio_send_attr attr = {(xlio_wr_tx_packet_attr)0, 0, 0, nullptr};
+        xlio_send_attr attr = (xlio_wr_tx_packet_attr)0;
         bool b_blocking = m_b_blocking;
         if (unlikely(__flags & MSG_DONTWAIT)) {
             b_blocking = false;

--- a/src/core/util/sys_vars.h
+++ b/src/core/util/sys_vars.h
@@ -741,7 +741,7 @@ extern mce_sys_var &safe_mce_sys();
 #define MCE_DEFAULT_TX_NUM_BUFS              (200000)
 #define MCE_DEFAULT_TX_BUF_SIZE              (0)
 #define MCE_DEFAULT_TX_NUM_WRE               (32768)
-#define MCE_DEFAULT_TX_NUM_WRE_TO_SIGNAL     (64)
+#define MCE_DEFAULT_TX_NUM_WRE_TO_SIGNAL     (1)
 #define MCE_DEFAULT_TX_MAX_INLINE            (204) //+18(always inline ETH header) = 222
 #define MCE_DEFAULT_TX_BUILD_IP_CHKSUM       (true)
 #define MCE_DEFAULT_TX_MC_LOOPBACK           (true)


### PR DESCRIPTION
In case we got an ECQE - set the socket in a closing state. Effectively this sends a TCP-RST.

## Description
Currently, in case we got an ECQE - we don't notify our callers we got to an invalid state.
The callers will keep trying to transmit TX segments, unaware of any issues.
This causes callers to not be able to identify and overcome error states, causing issues like 4183221.

##### What
Propogates the pcb to sq_wqe_prop, so when getting an ECQE - we could notify the TCP/IP stack.

##### Why ?
Solve https://redmine.mellanox.com/issues/4183221

## Change type
What kind of change does this PR introduce?
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

