### PR TITLE
issue: 4183221 propagate socket errors

### DIFF
--- a/src/core/dev/cq_mgr_tx.cpp
+++ b/src/core/dev/cq_mgr_tx.cpp
@@ -214,6 +214,8 @@ int cq_mgr_tx::poll_and_process_element_tx(uint64_t *p_cq_poll_sn)
         if (unlikely(cqe->op_own & 0x80) && is_error_opcode(cqe->op_own >> 4)) {
             // m_p_cq_stat->n_tx_cqe_error++; Future counter
             log_cqe_error(cqe);
+
+            m_hqtx_ptr->m_sq_wqe_idx_to_prop[index].buf->m_flags |= mem_buf_desc_t::HAD_CQE_ERROR;
         }
 
         handle_sq_wqe_prop(index);

--- a/src/core/proto/mem_buf_desc.h
+++ b/src/core/proto/mem_buf_desc.h
@@ -69,7 +69,12 @@ struct timestamps_t {
  */
 class mem_buf_desc_t {
 public:
-    enum flags { TYPICAL = 0, CLONED = 0x01, ZCOPY = 0x02 };
+    enum flags {
+        TYPICAL = 0,
+        CLONED = 0x01,
+        ZCOPY = 0x02,
+        HAD_CQE_ERROR = 0x04,
+    };
 
 public:
     mem_buf_desc_t(uint8_t *buffer, size_t size, pbuf_type type)

--- a/src/core/sock/sockinfo_tcp.cpp
+++ b/src/core/sock/sockinfo_tcp.cpp
@@ -1347,6 +1347,18 @@ ssize_t sockinfo_tcp::tcp_tx_slow_path(xlio_tx_call_attr_t &tx_arg)
     return tcp_tx_handle_done_and_unlock(total_tx, errno_tmp, is_dummy, is_send_zerocopy);
 }
 
+static bool inspect_socket_error_state(const mem_buf_desc_t *mem_buf_desc, struct tcp_pcb *pcb)
+{
+    // this means a retransmit happened - let's check the error_state we'll put if we got error
+    // cqe
+    if (mem_buf_desc->m_flags & mem_buf_desc_t::HAD_CQE_ERROR) {
+        TCP_EVENT_ERR(pcb->errf, pcb->my_container, ERR_RST);
+        return true;
+    }
+
+    return false;
+}
+
 /*
  * TODO Remove 'p' from the interface and use 'seg'.
  * There are multiple places where ip_output() is used without allocating
@@ -1371,6 +1383,13 @@ err_t sockinfo_tcp::ip_output(struct pbuf *p, struct tcp_seg *seg, void *v_p_con
         p_si_tcp->m_pcb.mss, 0, nullptr};
     int count = 0;
     void *cur_end;
+
+    if (unlikely(flags & XLIO_TX_PACKET_REXMIT)) {
+        if (unlikely(inspect_socket_error_state(reinterpret_cast<const mem_buf_desc_t *>(p),
+                                                reinterpret_cast<struct tcp_pcb *>(v_p_conn)))) {
+            return ERR_RST;
+        }
+    }
 
     int rc = p_si_tcp->m_ops->postrouting(p, seg, attr);
     if (rc != 0) {
@@ -1582,7 +1601,8 @@ void sockinfo_tcp::err_lwip_cb(void *pcb_container, err_t err)
             } else {
                 NOTIFY_ON_EVENTS(conn, (EPOLLIN | EPOLLERR | EPOLLHUP | EPOLLRDHUP));
             }
-            /* TODO what about no route to host type of errors, need to add EPOLLERR in this case ?
+            /* TODO what about no route to host type of errors, need to add EPOLLERR in this
+             * case ?
              */
         } else { // ERR_TIMEOUT
             NOTIFY_ON_EVENTS(conn, (EPOLLIN | EPOLLHUP));
@@ -1590,8 +1610,9 @@ void sockinfo_tcp::err_lwip_cb(void *pcb_container, err_t err)
 
         /* SOCKETXTREME comment:
          * Add this fd to the ready fd list
-         * Note: No issue is expected in case socketxtreme_poll() usage because 'pv_fd_ready_array'
-         * is null in such case and as a result update_fd_array() call means nothing
+         * Note: No issue is expected in case socketxtreme_poll() usage because
+         * 'pv_fd_ready_array' is null in such case and as a result update_fd_array() call means
+         * nothing
          */
 
         io_mux_call::update_fd_array(conn->m_iomux_ready_fd_array, conn->m_fd);
@@ -1630,7 +1651,8 @@ bool sockinfo_tcp::process_peer_ctl_packets(xlio_desc_list_t &peer_packets)
             return false;
         }
 
-        // Listen socket is 3T and so rx.src/dst are set as part of rx_process_buffer_no_flow_id.
+        // Listen socket is 3T and so rx.src/dst are set as part of
+        // rx_process_buffer_no_flow_id.
         struct tcp_pcb *pcb = get_syn_received_pcb(desc->rx.src, desc->rx.dst);
 
         // 2.1.2 get the pcb and sockinfo
@@ -1743,8 +1765,8 @@ void sockinfo_tcp::process_my_ctl_packets()
         }
         // prepare for next map iteration
         if (peer_packets.empty()) {
-            m_rx_peer_packets.erase(itr++); // // advance itr before invalidating it by erase (itr++
-                                            // returns the value before advance)
+            m_rx_peer_packets.erase(itr++); // // advance itr before invalidating it by erase
+                                            // (itr++ returns the value before advance)
         } else {
             ++itr;
         }
@@ -1879,9 +1901,9 @@ void sockinfo_tcp::handle_incoming_handshake_failure(sockinfo_tcp *child_conn)
         // we finish with the current processing.
         XLIO_CALL(close, child_conn->get_fd());
     } else {
-        // With delegate mode calling close() will destroy the socket object and cause access after
-        // free in the subsequent flows. Instead, we add the socket for postponed close that will be
-        // as part of the delegate timer.
+        // With delegate mode calling close() will destroy the socket object and cause access
+        // after free in the subsequent flows. Instead, we add the socket for postponed close
+        // that will be as part of the delegate timer.
         g_event_handler_manager_local.add_close_postponed_socket(child_conn);
     }
 }
@@ -6048,7 +6070,8 @@ void tcp_timers_collection::remove_timer(sockinfo_tcp *sock)
         __log_dbg("TCP socket [%p] timer was removed", sock);
     } else {
         // Listen sockets are not added to timers.
-        // As part of socket general unregister and destroy they will get here and will no be found.
+        // As part of socket general unregister and destroy they will get here and will no be
+        // found.
         __log_dbg("TCP socket [%p] timer was not found (listen socket)", sock);
     }
 }


### PR DESCRIPTION
In case we got an ECQE - set the socket in a closing state. Effectively this sends a TCP-RST.

## Description
Currently, in case we got an ECQE - we don't notify our callers we got to an invalid state.
The callers will keep trying to transmit TX segments, unaware of any issues.
This causes callers to not be able to identify and overcome error states, causing issues like 4183221.

##### What
Propagates the pcb to sq_wqe_prop, so when getting an ECQE - we could notify the TCP/IP stack.

##### Why ?
_Justification for the PR. If there is existing issue/bug please reference._

##### How ?
1. Tested sockperf gets correct error + errno
2. Tested xlio_socket_api.c test gets correct error

## Change type
What kind of change does this PR introduce?
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

