### PR TITLE
issue: 4219010 XLIO support for kernel 6.10

### DIFF
--- a/src/core/proto/netlink_socket_mgr.cpp
+++ b/src/core/proto/netlink_socket_mgr.cpp
@@ -32,7 +32,6 @@
  * SOFTWARE.
  */
 
-#include "core/sock/sock-redirect.h"
 #include "core/util/utils.h"
 #include "vlogger/vlogger.h"
 #include "utils/bullseye.h"
@@ -40,165 +39,65 @@
 
 #include <linux/rtnetlink.h>
 #include <linux/netlink.h>
-#include <stdlib.h>
 #include <unistd.h> // getpid()
+
+#include <netlink/route/route.h>
+#include <netlink/route/rule.h>
+#include <netlink/route/link.h>
 
 #ifndef MODULE_NAME
 #define MODULE_NAME "netlink_socket_mgr:"
 #endif
 
-#define MSG_BUFF_SIZE 81920
-
-// This function builds Netlink request to retrieve data (Rule, Route) from kernel.
-// Parameters :
-//      data_type   : either RULE_DATA_TYPE or ROUTE_DATA_TYPE
-//      pid         : opaque pid for netlink request
-//      seq         : opaque seq for netlink request
-//      buf         : buffer for the request
-//      nl_msg      : [out] pointer to request
-void netlink_socket_mgr::build_request(nl_data_t data_type, uint32_t pid, uint32_t seq, char *buf,
-                                       struct nlmsghdr **nl_msg)
-{
-    struct rtmsg *rt_msg;
-
-    assert(MSG_BUFF_SIZE >= NLMSG_SPACE(sizeof(struct rtmsg)));
-    memset(buf, 0, NLMSG_SPACE(sizeof(struct rtmsg)));
-
-    // point the header and the msg structure pointers into the buffer
-    *nl_msg = (struct nlmsghdr *)buf;
-    rt_msg = (struct rtmsg *)NLMSG_DATA(*nl_msg);
-
-    // Fill in the nlmsg header
-    (*nl_msg)->nlmsg_len = NLMSG_LENGTH(sizeof(struct rtmsg));
-    (*nl_msg)->nlmsg_seq = seq;
-    (*nl_msg)->nlmsg_pid = pid;
-    (*nl_msg)->nlmsg_type = data_type == RULE_DATA_TYPE ? RTM_GETRULE : RTM_GETROUTE;
-    (*nl_msg)->nlmsg_flags = NLM_F_DUMP | NLM_F_REQUEST;
-
-    rt_msg->rtm_family = AF_UNSPEC;
-}
-
-// Query built request and receive requested data (Rule, Route)
-// Parameters:
-//      nl_msg  : request that is built previously.
-//      buf     : [out] buffer for the reply
-//      len     : [out] length of received data.
-bool netlink_socket_mgr::query(const struct nlmsghdr *nl_msg, char *buf, int &len)
-{
-    int sockfd;
-
-    // Opaque information in the request. To track expected reply.
-    uint32_t nl_pid = nl_msg->nlmsg_pid;
-    uint32_t nl_seq = nl_msg->nlmsg_seq;
-
-    BULLSEYE_EXCLUDE_BLOCK_START
-    if ((sockfd = SYSCALL(socket, PF_NETLINK, SOCK_DGRAM, NETLINK_ROUTE)) < 0) {
-        __log_err("NL socket creation failed, errno = %d", errno);
-        return false;
-    }
-    if (SYSCALL(fcntl, sockfd, F_SETFD, FD_CLOEXEC) != 0) {
-        __log_warn("Fail in fcntl, errno = %d", errno);
-    }
-    if ((len = SYSCALL(send, sockfd, nl_msg, nl_msg->nlmsg_len, 0)) < 0) {
-        __log_err("Write to NL socket failed, errno = %d", errno);
-    }
-    if (len > 0 && (len = recv_info(sockfd, nl_pid, nl_seq, buf)) < 0) {
-        __log_err("Read from NL socket failed...");
-    }
-    BULLSEYE_EXCLUDE_BLOCK_END
-
-    close(sockfd);
-    return len > 0;
-}
-
-// Receive requested data and save it to buffer.
-// Return length of received data.
-// Parameters:
-//      sockfd  : netlink socket
-//      pid     : expected opaque pid value
-//      seq     : expected opaque seq value
-//      buf     : [out] read reply
-int netlink_socket_mgr::recv_info(int sockfd, uint32_t pid, uint32_t seq, char *buf)
-{
-    struct nlmsghdr *nlHdr;
-    int readLen;
-    int msgLen = 0;
-    char *buf_ptr = buf;
-
-    do {
-        // Receive response from the kernel
-        BULLSEYE_EXCLUDE_BLOCK_START
-        if ((readLen = SYSCALL(recv, sockfd, buf_ptr, MSG_BUFF_SIZE - msgLen, 0)) < 0) {
-            __log_err("NL socket read failed, errno = %d", errno);
-            return -1;
-        }
-
-        nlHdr = (struct nlmsghdr *)buf_ptr;
-
-        // Check if the header is valid
-        if ((NLMSG_OK(nlHdr, (u_int)readLen) == 0) || (nlHdr->nlmsg_type == NLMSG_ERROR)) {
-            __log_err("Error in received packet, readLen = %d, msgLen = %d, type=%d, bufLen = %d",
-                      readLen, nlHdr->nlmsg_len, nlHdr->nlmsg_type, MSG_BUFF_SIZE);
-            if ((int)nlHdr->nlmsg_len >= MSG_BUFF_SIZE - msgLen) {
-                __log_err("The buffer we pass to netlink is too small for reading the whole table");
-            }
-            return -1;
-        }
-        BULLSEYE_EXCLUDE_BLOCK_END
-
-        if ((nlHdr->nlmsg_seq != seq) || (nlHdr->nlmsg_pid != pid)) {
-            // Skip not expected messages
-            continue;
-        }
-
-        buf_ptr += readLen;
-        msgLen += readLen;
-
-        // Loop until this is the last message of expected reply
-    } while (nlHdr->nlmsg_type != NLMSG_DONE && (nlHdr->nlmsg_flags & NLM_F_MULTI));
-
-    return msgLen;
-}
-
 // Update data in a table
 void netlink_socket_mgr::update_tbl(nl_data_t data_type)
 {
-    struct nlmsghdr *nl_msg = nullptr;
-    char *buf;
-    int len = 0;
+    nl_sock *sockfd = nullptr;
 
-    // Opaque netlink information
-    uint32_t nl_pid = getpid();
-    uint32_t nl_seq = static_cast<uint32_t>(data_type);
+    BULLSEYE_EXCLUDE_BLOCK_START
 
-    __log_dbg("");
-
-    buf = new char[MSG_BUFF_SIZE];
-    if (!buf) {
-        __log_err("NL message buffer allocation failed");
-        return;
+    sockfd = nl_socket_alloc();
+    if (sockfd == nullptr) {
+        __log_err("NL socket Creation: ");
+        throw_xlio_exception("Failed nl_socket_alloc");
     }
 
-    build_request(data_type, nl_pid, nl_seq, buf, &nl_msg);
-    if (query(nl_msg, buf, len)) {
-        parse_tbl(buf, len);
+    if (nl_connect(sockfd, NETLINK_ROUTE) < 0) {
+        __log_err("NL socket Connection: ");
+        nl_socket_free(sockfd);
+        throw_xlio_exception("Failed nl_connect");
     }
 
-    delete[] buf;
-    __log_dbg("Done");
+    struct nl_cache *cache_state = {0};
+    int err = 0;
+
+    // cache allocation fetches the latest existing rules/routes
+    if (data_type == RULE_DATA_TYPE) {
+
+        err = rtnl_rule_alloc_cache(sockfd, AF_INET, &cache_state);
+    } else if (data_type == ROUTE_DATA_TYPE) {
+
+        err = rtnl_route_alloc_cache(sockfd, AF_INET, 0, &cache_state);
+    }
+
+    if (err < 0) {
+        throw_xlio_exception("Failed to allocate route cache");
+    }
+
+    parse_tbl(cache_state);
 }
 
 // Parse received data in a table
-// Parameters:
-//      buf : buffer with netlink reply.
-//      len : length of received data.
-void netlink_socket_mgr::parse_tbl(char *buf, int len)
+void netlink_socket_mgr::parse_tbl(struct nl_cache *cache_state)
 {
-    struct nlmsghdr *nl_header = (struct nlmsghdr *)buf;
-
-    for (; NLMSG_OK(nl_header, (u_int)len); nl_header = NLMSG_NEXT(nl_header, len)) {
-        parse_entry(nl_header);
-    }
+    // a lambda can't be casted to a c-fptr with ref captures - so we provide context ourselves
+    nl_cache_foreach(
+        cache_state,
+        [](struct nl_object *nl_obj, void *context) {
+            netlink_socket_mgr *this_ptr = reinterpret_cast<netlink_socket_mgr *>(context);
+            this_ptr->parse_entry(nl_obj);
+        },
+        this);
 }
 
 #undef MODULE_NAME

--- a/src/core/proto/netlink_socket_mgr.h
+++ b/src/core/proto/netlink_socket_mgr.h
@@ -34,25 +34,18 @@
 
 #ifndef NETLINK_SOCKET_MGR_H
 #define NETLINK_SOCKET_MGR_H
-
-// Forward declarations
-struct nlmsghdr;
-
+#include <netlink/netlink.h>
 // This enum specify the type of data to be retrieve using netlink socket.
 enum nl_data_t { RULE_DATA_TYPE, ROUTE_DATA_TYPE };
 
 // This class manages retrieving data (Rule, Route) from kernel using netlink socket.
 class netlink_socket_mgr {
 protected:
-    virtual void parse_entry(struct nlmsghdr *nl_header) = 0;
+    virtual void parse_entry(struct nl_object *nl_obj) = 0;
     virtual void update_tbl(nl_data_t data_type);
 
 private:
-    void build_request(nl_data_t data_type, uint32_t pid, uint32_t seq, char *buf,
-                       struct nlmsghdr **nl_msg);
-    bool query(const struct nlmsghdr *nl_msg, char *buf, int &len);
-    int recv_info(int sockfd, uint32_t pid, uint32_t seq, char *buf);
-    void parse_tbl(char *buf, int len);
+    void parse_tbl(struct nl_cache *cache_state);
 };
 
 #endif /* NETLINK_SOCKET_MGR_H */

--- a/src/core/proto/route_table_mgr.cpp
+++ b/src/core/proto/route_table_mgr.cpp
@@ -152,113 +152,117 @@ void route_table_mgr::update_tbl(nl_data_t data_type)
     netlink_socket_mgr::update_tbl(data_type);
 }
 
-void route_table_mgr::parse_entry(struct nlmsghdr *nl_header)
+void route_table_mgr::parse_entry(struct nl_object *nl_obj)
 {
-    int len;
-    struct rtmsg *rt_msg;
-    struct rtattr *rt_attribute;
     route_val val;
 
-    // get route entry header
-    rt_msg = (struct rtmsg *)NLMSG_DATA(nl_header);
+    // Cast the generic nl_object to a specific route or rule object
+    struct rtnl_route *route = reinterpret_cast<struct rtnl_route *>(nl_obj);
 
-    if (rt_msg->rtm_family != AF_INET && rt_msg->rtm_family != AF_INET6) {
-        return;
+    val.set_family(rtnl_route_get_family(route));
+    val.set_protocol(rtnl_route_get_protocol(route));
+    val.set_scope(rtnl_route_get_scope(route));
+    val.set_type(rtnl_route_get_type(route));
+    val.set_table_id(rtnl_route_get_table(route));
+
+    // Set destination mask and prefix length
+    struct nl_addr *dst = rtnl_route_get_dst(route);
+    if (dst) {
+        val.set_dst_pref_len(nl_addr_get_prefixlen(dst));
     }
 
-    val.set_family(rt_msg->rtm_family);
-    val.set_protocol(rt_msg->rtm_protocol);
-    val.set_scope(rt_msg->rtm_scope);
-    val.set_type(rt_msg->rtm_type);
-    val.set_table_id(rt_msg->rtm_table);
-    val.set_dst_pref_len(rt_msg->rtm_dst_len);
+    parse_attr(route, val);
 
-    len = RTM_PAYLOAD(nl_header);
-    rt_attribute = (struct rtattr *)RTM_RTA(rt_msg);
-
-    for (; RTA_OK(rt_attribute, len); rt_attribute = RTA_NEXT(rt_attribute, len)) {
-        parse_attr(rt_attribute, val);
-    }
     val.set_state(true);
 
     route_table_t &table = val.get_family() == AF_INET ? m_table_in4 : m_table_in6;
     table.push_back(val);
 }
 
-void route_table_mgr::parse_attr(struct rtattr *rt_attribute, route_val &val)
+void route_table_mgr::parse_attr(struct rtnl_route *route, route_val &val)
 {
-    char if_name[IFNAMSIZ];
+    struct nl_addr *addr;
 
-    switch (rt_attribute->rta_type) {
-    case RTA_DST:
-        val.set_dst_addr(ip_address((void *)RTA_DATA(rt_attribute), val.get_family()));
-        break;
-    // next hop address
-    case RTA_GATEWAY:
-        val.set_gw(ip_address((void *)RTA_DATA(rt_attribute), val.get_family()));
-        break;
-    // unique ID associated with the network interface
-    case RTA_OIF:
-        val.set_if_index(*(int *)RTA_DATA(rt_attribute));
-        if_indextoname(val.get_if_index(), if_name);
+    // Destination Address
+    addr = rtnl_route_get_dst(route);
+    if (addr) {
+        val.set_dst_addr(ip_address(nl_addr_get_binary_addr(addr), val.get_family()));
+    }
+
+    // Gateway Address (Next Hop)
+    struct rtnl_nexthop *nh = rtnl_route_nexthop_n(route, 0); // Assuming the first nexthop
+    if (nh) {
+        addr = rtnl_route_nh_get_gateway(nh);
+        if (addr) {
+            val.set_gw(ip_address(nl_addr_get_binary_addr(addr), val.get_family()));
+        }
+    }
+
+    // Output Interface Index and Name
+    const int if_index = rtnl_route_nh_get_ifindex(nh);
+    if (if_index > 0) {
+        val.set_if_index(if_index);
+
+        char if_name[IFNAMSIZ] = {0};
+        if_indextoname(if_index, if_name);
         val.set_if_name(if_name);
-        break;
-    case RTA_SRC:
-    case RTA_PREFSRC:
-        val.set_src_addr(ip_address((void *)RTA_DATA(rt_attribute), val.get_family()));
-        break;
-    case RTA_TABLE:
-        val.set_table_id(*(uint32_t *)RTA_DATA(rt_attribute));
-        break;
-    case RTA_METRICS: {
-        struct rtattr *rta = (struct rtattr *)RTA_DATA(rt_attribute);
-        int len = RTA_PAYLOAD(rt_attribute);
-        uint16_t type;
-        while (RTA_OK(rta, len)) {
-            type = rta->rta_type;
-            switch (type) {
-            case RTAX_MTU:
-                val.set_mtu(*(uint32_t *)RTA_DATA(rta));
-                break;
-            default:
-                rt_mgr_logdbg("got unexpected METRICS %d %x", type, *(uint32_t *)RTA_DATA(rta));
-                break;
-            }
-            rta = RTA_NEXT(rta, len);
-        }
-        break;
     }
-    case RTA_MULTIPATH: {
-        struct rtnexthop *rtnh = (struct rtnexthop *)RTA_DATA(rt_attribute);
-        int rtnh_len = RTA_PAYLOAD(rt_attribute);
-        while (RTNH_OK(rtnh, rtnh_len)) {
-            val.set_if_index(rtnh->rtnh_ifindex);
-            if_indextoname(val.get_if_index(), if_name);
-            val.set_if_name(if_name);
 
-            int len = rtnh->rtnh_len - sizeof(*rtnh);
-            for (struct rtattr *rta = RTNH_DATA(rtnh); RTA_OK(rta, len); rta = RTA_NEXT(rta, len)) {
-                parse_attr(rta, val);
-            }
-
-            const ip_address &gw_addr = val.get_gw_addr();
-            if (!gw_addr.is_anyaddr() && !gw_addr.is_linklocal(val.get_family())) {
-                // Currently, we support only a single nexthop per multipath route
-                // and we found a good one.
-                // If the gw is link-local we will check the next nexthop if present.
-                // FIXME We cannot rely on that the next entry overwrites all the attributes.
-                break;
-            }
-
-            rtnh = RTNH_NEXT(rtnh);
-            rtnh_len -= RTNH_ALIGN(rtnh->rtnh_len);
-        }
-        break;
+    // Source Address
+    addr = rtnl_route_get_pref_src(route);
+    if (addr) {
+        val.set_src_addr(ip_address(nl_addr_get_binary_addr(addr), val.get_family()));
     }
-    default:
-        rt_mgr_logdbg("got unexpected type %d %x", rt_attribute->rta_type,
-                      *(uint32_t *)RTA_DATA(rt_attribute));
-        break;
+
+    // Metrics (e.g., MTU)
+    uint32_t mtu = 0;
+    int get_metric_result = rtnl_route_get_metric(route, RTAX_MTU, &mtu);
+    if (get_metric_result == 0) {
+        if (mtu > 0) {
+            val.set_mtu(mtu);
+        }
+    }
+
+    struct nexthop_iterator_context {
+        struct rtnl_nexthop *best_next_hop;
+        uint8_t best_next_hop_weight;
+
+    } best_next_hop_context = {.best_next_hop = nullptr, .best_next_hop_weight = 0xff};
+
+    // Multi-path
+    rtnl_route_foreach_nexthop(
+        route,
+        [](struct rtnl_nexthop *next_hop, void *context) {
+            nexthop_iterator_context *best_next_hop = (nexthop_iterator_context *)context;
+            const uint8_t current_nh_weight = rtnl_route_nh_get_weight(next_hop);
+
+            // min valid weight is 1
+            if (current_nh_weight > 0 && current_nh_weight < best_next_hop->best_next_hop_weight) {
+                best_next_hop->best_next_hop_weight = current_nh_weight;
+                best_next_hop->best_next_hop = next_hop;
+            }
+        },
+        &best_next_hop_context);
+
+    if (best_next_hop_context.best_next_hop != nullptr) {
+        struct rtnl_nexthop *best_next_hop = best_next_hop_context.best_next_hop;
+        const auto nh_gateway = rtnl_route_nh_get_gateway(best_next_hop);
+
+        const ip_address &gw_addr =
+            ip_address(nl_addr_get_binary_addr(nh_gateway), nl_addr_get_family(nh_gateway));
+
+        val.set_if_index(rtnl_route_nh_get_ifindex(best_next_hop));
+        char nh_if_name[IFNAMSIZ] = {0};
+        if_indextoname(val.get_if_index(), nh_if_name);
+        val.set_if_name(nh_if_name);
+
+        val.set_gw(gw_addr);
+
+        // Set destination mask and prefix length
+        struct nl_addr *dst = rtnl_route_nh_get_newdst(best_next_hop);
+        if (dst) {
+            val.set_dst_pref_len(nl_addr_get_prefixlen(dst));
+        }
     }
 }
 

--- a/src/core/proto/route_table_mgr.h
+++ b/src/core/proto/route_table_mgr.h
@@ -77,14 +77,14 @@ public:
     void dump_tbl();
 
 protected:
-    virtual void parse_entry(struct nlmsghdr *nl_header) override;
+    virtual void parse_entry(struct nl_object *nl_obj) override;
 
     route_entry *create_new_entry(route_rule_table_key key, const observer *obs) override;
 
 private:
     // save current main rt table
     void update_tbl(nl_data_t data_type) override;
-    void parse_attr(struct rtattr *rt_attribute, route_val &val);
+    void parse_attr(struct rtnl_route *route, route_val &val);
     void print_tbl();
 
     void update_entry(INOUT route_entry *p_ent, bool b_register_to_net_dev = false);

--- a/src/core/proto/rule_table_mgr.cpp
+++ b/src/core/proto/rule_table_mgr.cpp
@@ -101,33 +101,28 @@ void rule_table_mgr::update_tbl(nl_data_t data_type)
 }
 
 // Parse received rule entry into custom object (rule_val).
-// Parameters:
-//		nl_header	: object that contain rule entry.
-//		p_val		: custom object that contain parsed rule data.
-// return true if its not related to local or default table, false otherwise.
-void rule_table_mgr::parse_entry(struct nlmsghdr *nl_header)
+void rule_table_mgr::parse_entry(struct nl_object *nl_obj)
 {
-    int len;
-    struct rtmsg *rt_msg;
-    struct rtattr *rt_attribute;
+    int err = 0;
     rule_val val;
 
-    // get rule entry header
-    rt_msg = (struct rtmsg *)NLMSG_DATA(nl_header);
+    // Cast the generic nl_object to a specific route or rule object
+    struct rtnl_rule *rule = reinterpret_cast<struct rtnl_rule *>(nl_obj);
 
-    val.set_family(rt_msg->rtm_family);
-    val.set_protocol(rt_msg->rtm_protocol);
-    val.set_scope(rt_msg->rtm_scope);
-    val.set_type(rt_msg->rtm_type);
-    val.set_tos(rt_msg->rtm_tos);
-    val.set_table_id(rt_msg->rtm_table);
-
-    len = RTM_PAYLOAD(nl_header);
-    rt_attribute = (struct rtattr *)RTM_RTA(rt_msg);
-
-    for (; RTA_OK(rt_attribute, len); rt_attribute = RTA_NEXT(rt_attribute, len)) {
-        parse_attr(rt_attribute, val);
+    // Set rule properties in p_val using libnl getters
+    uint8_t protocol = 0;
+    err = rtnl_rule_get_protocol(rule, &protocol);
+    if (err < 0) {
+        throw_xlio_exception("Failed to get rule protocol");
     }
+
+    val.set_family(rtnl_rule_get_family(rule));
+    val.set_protocol(protocol);
+    val.set_tos(rtnl_rule_get_dsfield(rule));
+    val.set_table_id(rtnl_rule_get_table(rule));
+
+    parse_attr(rule, val);
+
     val.set_state(true);
 
     rule_table_t &table = val.get_family() == AF_INET ? m_table_in4 : m_table_in6;
@@ -135,37 +130,45 @@ void rule_table_mgr::parse_entry(struct nlmsghdr *nl_header)
 }
 
 // Parse received rule attribute for given rule.
-// Parameters:
-//		rt_attribute	: object that contain rule attribute.
-//		p_val			: custom object that contain parsed rule data.
-void rule_table_mgr::parse_attr(struct rtattr *rt_attribute, rule_val &val)
+void rule_table_mgr::parse_attr(struct rtnl_rule *rule, rule_val &val)
 {
-    switch (rt_attribute->rta_type) {
-    case FRA_PRIORITY:
-        val.set_priority(*(uint32_t *)RTA_DATA(rt_attribute));
-        break;
-    case FRA_DST:
-        val.set_dst_addr(ip_address((void *)RTA_DATA(rt_attribute), val.get_family()));
-        break;
-    case FRA_SRC:
-        val.set_src_addr(ip_address((void *)RTA_DATA(rt_attribute), val.get_family()));
-        break;
-    case FRA_IFNAME:
-        val.set_iif_name((char *)RTA_DATA(rt_attribute));
-        break;
-    case FRA_TABLE:
-        val.set_table_id(*(uint32_t *)RTA_DATA(rt_attribute));
-        break;
-#if DEFINED_FRA_OIFNAME
-    case FRA_OIFNAME:
-        val.set_oif_name((char *)RTA_DATA(rt_attribute));
-        break;
-#endif
-    default:
-        rr_mgr_logdbg("got undetected rta_type %d %x", rt_attribute->rta_type,
-                      *(uint32_t *)RTA_DATA(rt_attribute));
-        break;
+    // FRA_PRIORITY: Rule Priority
+    uint32_t priority = rtnl_rule_get_prio(rule);
+    if (priority) {
+        val.set_priority(priority);
     }
+
+    // FRA_DST: Destination Address
+    struct nl_addr *dst = rtnl_rule_get_dst(rule);
+    if (dst) {
+        val.set_dst_addr(ip_address(nl_addr_get_binary_addr(dst), val.get_family()));
+    }
+
+    // FRA_SRC: Source Address
+    struct nl_addr *src = rtnl_rule_get_src(rule);
+    if (src) {
+        val.set_src_addr(ip_address(nl_addr_get_binary_addr(src), val.get_family()));
+    }
+
+    // FRA_IFNAME: Input Interface Name
+    char *iif_name = rtnl_rule_get_iif(rule);
+    if (iif_name) {
+        val.set_iif_name(iif_name);
+    }
+
+    // FRA_TABLE: Table ID
+    uint32_t table_id = rtnl_rule_get_table(rule);
+    if (table_id) {
+        val.set_table_id(table_id);
+    }
+
+#if DEFINED_FRA_OIFNAME
+    // FRA_OIFNAME: Output Interface Name (if available)
+    char *oif_name = rtnl_rule_get_oif(rule);
+    if (oif_name) {
+        val.set_oif_name(oif_name);
+    }
+#endif
 }
 
 void rule_table_mgr::print_tbl()

--- a/src/core/proto/rule_table_mgr.h
+++ b/src/core/proto/rule_table_mgr.h
@@ -35,11 +35,12 @@
 #ifndef RULE_TABLE_MGR_H
 #define RULE_TABLE_MGR_H
 
-#include "core/infra/cache_subject_observer.h"
 #include "core/proto/netlink_socket_mgr.h"
 #include "route_rule_table_key.h"
 #include "rule_entry.h"
 #include "rule_val.h"
+#include <netlink/route/rule.h>
+#include <netlink/route/link.h>
 
 #include <vector>
 
@@ -57,13 +58,13 @@ public:
     std::vector<uint32_t> rule_resolve(route_rule_table_key key);
 
 protected:
-    virtual void parse_entry(struct nlmsghdr *nl_header) override;
+    virtual void parse_entry(struct nl_object *nl_obj) override;
     virtual void update_tbl(nl_data_t data_type) override;
 
     rule_entry *create_new_entry(route_rule_table_key key, const observer *obs) override;
 
 private:
-    void parse_attr(struct rtattr *rt_attribute, rule_val &val);
+    void parse_attr(struct rtnl_rule *rule, rule_val &val);
     void print_tbl();
 
     void update_entry(rule_entry *p_ent);


### PR DESCRIPTION
## Description
Kernel 6.10 netlink has breaked XLIO functionality. Transitioned to libnl - an abstraction that wraps netlink.

This both solves the issue and makes us more robust.

##### What
Build routing and rules table using libnl instead of netlink.

##### Why ?
solves https://redmine.mellanox.com/issues/4219010

##### How ?
Tested on kernel 5.21 and kernel 6.10

## Change type
What kind of change does this PR introduce?
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

