### PR TITLE
[CI] issue:HPCINFRA-3085 seperate Doca CI from Xlio CI

### DIFF
--- a/.ci/matrix_job.yaml
+++ b/.ci/matrix_job.yaml
@@ -40,8 +40,8 @@ runs_on_dockers:
       file: '.ci/dockerfiles/Dockerfile.ubuntu22.04',
       arch: 'x86_64',
       name: 'ubuntu22.04',
-      uri: 'xlio/$arch/$name/build',
-      tag: '20240813',
+      uri: 'xlio_doca/$arch/$name/build',
+      tag: '20250115',
       build_args: '--no-cache --target build',
       category: 'base'
     }
@@ -49,8 +49,8 @@ runs_on_dockers:
       file: '.ci/dockerfiles/Dockerfile.ubuntu22.04',
       arch: 'aarch64',
       name: 'ubuntu22.04',
-      uri: 'xlio/$arch/ubuntu22.04/build',
-      tag: '20240813',
+      uri: 'xlio_doca/$arch/ubuntu22.04/build',
+      tag: '20250115',
       build_args: '--target build --no-cache --build-arg ARCH=aarch64 --build-arg REPO_ARCH=arm64',
       category: 'base'
     }
@@ -59,8 +59,8 @@ runs_on_dockers:
      file: '.ci/dockerfiles/Dockerfile.ubuntu22.04',
      arch: 'x86_64',
      name: 'toolbox',
-     uri: 'xlio/$arch/ubuntu22.04/$name',
-     tag: '20240813',
+     uri: 'xlio_doca/$arch/ubuntu22.04/$name',
+     tag: '20250115',
      build_args: '--no-cache --target toolbox',
      category: 'tool'
     }
@@ -71,8 +71,8 @@ runs_on_dockers:
      file: '.ci/dockerfiles/Dockerfile.ubuntu22.04',
      arch: 'x86_64',
      name: 'static',
-     uri: 'xlio/$arch/ubuntu22.04/$name',
-     tag: '20240813',
+     uri: 'xlio_doca/$arch/ubuntu22.04/$name',
+     tag: '20250115',
      build_args: '--no-cache --target static',
      category: 'tool'
     }
@@ -81,8 +81,8 @@ runs_on_dockers:
       file: '.ci/dockerfiles/Dockerfile.ubuntu22.04',
       arch: 'x86_64',
       name: 'test',
-      uri: 'xlio/$arch/ubuntu22.04/$name',
-      tag: '20240813',
+      uri: 'xlio_doca/$arch/ubuntu22.04/$name',
+      tag: '20250115',
       build_args: '--no-cache --target test',
       category: 'tests',
       annotations: [{ key: 'k8s.v1.cni.cncf.io/networks', value: 'sriov-cx6dx-p1' }],
@@ -96,8 +96,8 @@ runs_on_dockers:
      file: '.ci/dockerfiles/Dockerfile.ubuntu22.04',
      arch: 'x86_64',
      name: 'vg',
-     uri: 'xlio/$arch/ubuntu22.04/$name',
-     tag: '20240813',
+     uri: 'xlio_doca/$arch/ubuntu22.04/$name',
+     tag: '20250115',
      build_args: '--no-cache --target vg',
      category: 'tool',
      annotations: [{ key: 'k8s.v1.cni.cncf.io/networks', value: 'sriov-cx6dx-p2' }],
@@ -107,13 +107,13 @@ runs_on_dockers:
      runAsUser: '0',
      runAsGroup: '0'
     }
-  # The Gtest step is disabled until Oct'24 release, Jira HPCINFRA-1968, RM #3981627, #3981654 
+  # The Gtest step is disabled until Oct'24 release, Jira HPCINFRA-1968, RM #3981627, #3981654
   # - {
   #    file: '.ci/dockerfiles/Dockerfile.ubuntu22.04',
   #    arch: 'x86_64',
   #    name: 'gtest',
-  #    uri: 'xlio/$arch/ubuntu22.04/$name',
-  #    tag: '20240813',
+  #    uri: 'xlio_doca/$arch/ubuntu22.04/$name',
+  #    tag: '20250115',
   #    build_args: '--no-cache --target gtest',
   #    category: 'tests',
   #    annotations: [{ key: 'k8s.v1.cni.cncf.io/networks', value: 'sriov-cx6dx-p1@net1,sriov-cx6dx-p2@net2' }],
@@ -311,7 +311,7 @@ steps:
     archiveArtifacts-onfail: |
       jenkins/**/arch-*.tar.gz
 
-  # The Gtest step is disabled until Oct'24 release, Jira HPCINFRA-1968, RM #3981627, #3981654 
+  # The Gtest step is disabled until Oct'24 release, Jira HPCINFRA-1968, RM #3981627, #3981654
   # - name: Gtest
   #   enable: ${do_gtest}
   #   containerSelector:

--- a/.ci/pipeline/xlio_doca_ci_jjb.yaml
+++ b/.ci/pipeline/xlio_doca_ci_jjb.yaml
@@ -1,0 +1,133 @@
+- job-template:
+    name: "{jjb_proj}"
+    project-type: pipeline
+    folder: libxlio
+    properties:
+        - github:
+             url: "https://github.com/Mellanox/libxlio"
+        - build-discarder:
+            days-to-keep: 50
+            num-to-keep: 20
+        - inject:
+            keep-system-variables: true
+            properties-content: |
+              jjb_proj={jjb_proj}
+    description: Do NOT edit this job through the Web GUI !
+    concurrent: true
+    parameters:
+        - string:
+            name: "sha1"
+            default: doca_xlio_vNext
+            description: "Commit to be checked, set by PR"
+        - bool:
+            name: "do_build"
+            default: true
+            description: "This verifies different configuration using gcc compiler."
+        - bool:
+            name: "do_compiler"
+            default: true
+            description: "Check ability to be built under icc, clang."
+        - bool:
+            name: "do_package"
+            default: true
+            description: "Check tar, source and binary packages."
+        - bool:
+            name: "do_cppcheck"
+            default: true
+            description: "Run static analysis using cppcheck tool."
+        - bool:
+            name: "do_csbuild"
+            default: true
+            description: "Run static analysis using csbuild tool."
+        - bool:
+            name: "do_service"
+            default: true
+            description: "Verify service."
+        - bool:
+            name: "do_style"
+            default: true
+            description: "Analysis source code for coding style."
+        - bool:
+            name: "do_coverity"
+            default: true
+            description: "Launch coverity verification."
+        - bool:
+            name: "do_coverity_snapshot"
+            default: false
+            description: "Submit Coverity Static Analysis as a snapshot (normally it should be checked only for master branch after proper defects review)"
+        - bool:
+            name: "do_test"
+            default: true
+            description: "Use runtime verification."
+        - bool:
+            name: "do_gtest"
+            default: true
+            description: "Use google tests."
+        - bool:
+            name: "do_valgrind"
+            default: true
+            description: "Use valgrind."
+        - bool:
+            name: "do_commit"
+            default: true
+            description: "Use commit message check."
+        - bool:
+            name: "do_artifact"
+            default: true
+            description: "Collect artifacts."
+        - bool:
+            name: "do_blackduck"
+            default: false
+            description: "Run BlackDuck."
+        - bool:
+            name: "do_copyrights"
+            default: true
+            description: "Check copyrights in source headers"
+        - bool:
+            name: "build_dockers"
+            default: false
+            description: "Rebuild docker containers. Check this box if .ci/DockerFile* was changed"
+        - string:
+            name: "conf_file"
+            default: ".ci/matrix_job.yaml"
+            description: "Regex to select job config file. Do not change it"
+        - string:
+            name: "DEBUG"
+            default: 0
+            description: "Enable debug prints and traces, valid values are 0-9."
+    triggers:
+        - github-pull-request:
+            cron: 'H/5 * * * *'
+            trigger-phrase: '.*\bbot:retest\b.*'
+            status-context: "xlio-doca"
+            success-status: "[PASS]"
+            failure-status: "[FAIL]"
+            error-status:   "[FAIL]"
+            status-add-test-results: true
+            auth-id: 'swx-jenkins5_gh_token'
+            org-list: ["Mellanox"]
+            white-list: ["swx-jenkins","swx-jenkins2","swx-jenkins3","mellanox-github"]
+            white-list-target-branches:
+              - doca_xlio_vNext
+            allow-whitelist-orgs-as-admins: true
+            cancel-builds-on-update: true
+    pipeline-scm:
+        scm:
+            - git:
+                url: "{jjb_git}"
+                credentials-id: 'swx-jenkins_ssh_key'
+                branches: ['$sha1']
+                shallow-clone: true
+                depth: 2
+                refspec: "+refs/pull/*:refs/remotes/origin/pr/*"
+                browser: githubweb
+                browser-url: "{jjb_git}"
+        script-path: ".ci/Jenkinsfile"
+- project:
+    name: LibXLIO-Doca
+    jjb_email: 'danielpr@nvidia.com'
+    jjb_proj: 'LibXLIO-Doca'
+    jjb_git: 'git@github.com:Mellanox/libxlio.git'
+    jjb_owner: 'Daniel Pressler'
+    jobs:
+        - "{jjb_proj}"


### PR DESCRIPTION
## Description
vNext CI job is limited to 1 concurrent build due to the limitation of beni09 environment.
On doca_xlio branch we use containers, and we can run in parallel to increase productivity.

##### What
Create new jjb file for the new job definition

##### Why ?
Run parallel CI runs

##### How ?
Add new separate CI job just for doca_xlio branch

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

