### PR TITLE
[CI] Block CI triggers from doca_xlio_vnext branch

### DIFF
--- a/.ci/opensource_jjb.yaml
+++ b/.ci/opensource_jjb.yaml
@@ -125,6 +125,8 @@
             auth-id: 'swx-jenkins5_gh_token'
             org-list: ["Mellanox"]
             white-list: ["swx-jenkins","swx-jenkins2","swx-jenkins3","mellanox-github"]
+            black-list-target-branches:
+              - doca_xlio_vNext
             allow-whitelist-orgs-as-admins: true
             cancel-builds-on-update: true
     pipeline-scm:


### PR DESCRIPTION
## Description
We have separate CI job for doca_xlio branch, we want to avoid running vNext CI job on doca_xlio branch changes

##### What
Do not trigger CI on doca_xlio branch changes

##### Why ?
No need to trigger both jobs

##### How ?
Add doca_xlio branch to branch blacklist in GH pull request plugin definition

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

