### PR TITLE
issue: 4043235 TCP_USER_TIMER wrong RTO behavior

### DIFF
--- a/src/utils/rdtsc.h
+++ b/src/utils/rdtsc.h
@@ -154,7 +154,7 @@ inline int gettimefromtsc(struct timespec *ts)
 
 static inline int gettime(struct timespec *ts)
 {
-    return gettimefromtsc(ts);
+    return clock_gettime(CLOCK_MONOTONIC, ts);
 }
 
 static inline int gettime(struct timeval *tv)


### PR DESCRIPTION
## Description
RTO calculations were producing wrong results over our incorrect TSC-based logic.

We were using /proc/cpuinfo which is not standardized, nor accurate:
https://github.com/htop-dev/htop/issues/953

TSC is also x86 specific and considered unreliable in cases like dynamic frequency scaling.

Hence, we switch to platform clock which is more performant than chrono as can be seen here:
https://gcc.gnu.org/legacy-ml/gcc-help/2019-07/msg00068.html

##### What
Fix timers and RTO issues.

##### Why ?
Fix https://redmine.mellanox.com/issues/4043235.

## Change type
What kind of change does this PR introduce?
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

