### PR TITLE
[CI] issue: HPCINFRA-3180 Move build steps to Blossom K8s

### DIFF
--- a/.ci/matrix_job.yaml
+++ b/.ci/matrix_job.yaml
@@ -9,9 +9,9 @@ registry_path: /swx-infra/media
 
 kubernetes:
   privileged: true
-  cloud: swx-k8s-spray
+  cloud: il-ipp-blossom-prod
   nodeSelector: 'beta.kubernetes.io/os=linux'
-  namespace: xlio-ci
+  namespace: swx-media
   limits: '{memory: 8Gi, cpu: 7000m}'
   requests: '{memory: 8Gi, cpu: 7000m}'
 


### PR DESCRIPTION
## Description
We want to move all build steps and test CI steps to the Blossom K8s cluster.

##### What
Switch to the Blossom K8s cluster.

##### Why ?
Blossom cluster is more stable, visibly managed and has 24/7 SRE/NOC support.

##### How ?

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

