### PR TITLE
issue: 4183221 propagate socket errors

### DIFF
--- a/src/core/dev/cq_mgr_tx.cpp
+++ b/src/core/dev/cq_mgr_tx.cpp
@@ -246,6 +246,8 @@ int cq_mgr_tx::poll_and_process_element_tx(uint64_t *p_cq_poll_sn)
         if (unlikely(cqe->op_own & 0x80) && is_error_opcode(cqe->op_own >> 4)) {
             // m_p_cq_stat->n_tx_cqe_error++; Future counter
             log_cqe_error(cqe, index, m_hqtx_ptr->m_sq_wqe_idx_to_prop[index].credits);
+
+            m_hqtx_ptr->m_sq_wqe_idx_to_prop[index].buf->m_flags |= mem_buf_desc_t::HAD_CQE_ERROR;
         }
 
         handle_sq_wqe_prop(index);

--- a/src/core/proto/mem_buf_desc.h
+++ b/src/core/proto/mem_buf_desc.h
@@ -69,7 +69,12 @@ struct timestamps_t {
  */
 class mem_buf_desc_t {
 public:
-    enum flags { TYPICAL = 0, CLONED = 0x01, ZCOPY = 0x02 };
+    enum flags {
+        TYPICAL = 0,
+        CLONED = 0x01,
+        ZCOPY = 0x02,
+        HAD_CQE_ERROR = 0x04,
+    };
 
 public:
     mem_buf_desc_t(uint8_t *buffer, size_t size, pbuf_type type)


### PR DESCRIPTION
In case we got an ECQE - set the socket in a closing state. Effectively this sends a TCP-RST.

## Description
Currently, in case we got an ECQE - we don't notify our callers we got to an invalid state.
The callers will keep trying to transmit TX segments, unaware of any issues.
This causes callers to not be able to identify and overcome error states, causing issues like 4183221.

##### What
Propagates the pcb to sq_wqe_prop, so when getting an ECQE - we could notify the TCP/IP stack.

##### Why ?
https://github.com/Mellanox/libxlio/pull/276

##### How ?
1. Tested sockperf gets correct error + errno
2. Tested xlio_socket_api.c test gets correct error

## Change type
What kind of change does this PR introduce?
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

