### PR TITLE
[CI] issue: HPCINFRA-3180 Move build steps to Blossom K8s

### DIFF
--- a/.ci/matrix_job.yaml
+++ b/.ci/matrix_job.yaml
@@ -9,9 +9,9 @@ registry_path: /swx-infra/media
 
 kubernetes:
   privileged: true
-  cloud: swx-k8s-spray
+  cloud: il-ipp-blossom-prod
+  namespace: swx-media
   nodeSelector: 'beta.kubernetes.io/os=linux'
-  namespace: xlio-ci
   limits: '{memory: 10Gi, cpu: 10000m}'
   requests: '{memory: 10Gi, cpu: 10000m}'
 
@@ -90,7 +90,9 @@ runs_on_dockers:
       requests: '{memory: 10Gi, cpu: 8000m, hugepages-2Mi: 10Gi, mellanox.com/sriov_cx6dx_p1: 1}',
       caps_add: '[ IPC_LOCK, SYS_RESOURCE ]',
       runAsUser: '0',
-      runAsGroup: '0'
+      runAsGroup: '0',
+      cloud: swx-k8s-spray,
+      namespace: xlio-ci
     }
   - {
      file: '.ci/dockerfiles/Dockerfile.ubuntu22.04',
@@ -105,7 +107,9 @@ runs_on_dockers:
      requests: '{memory: 10Gi, cpu: 8000m, hugepages-2Mi: 10Gi, mellanox.com/sriov_cx6dx_p2: 1}',
      caps_add: '[ IPC_LOCK, SYS_RESOURCE ]',
      runAsUser: '0',
-     runAsGroup: '0'
+     runAsGroup: '0',
+      cloud: swx-k8s-spray,
+      namespace: xlio-ci
     }
   # The Gtest step is disabled until Oct'24 release, Jira HPCINFRA-1968, RM #3981627, #3981654
   # - {


### PR DESCRIPTION
## Description
We want to move all build steps and test CI steps to the Blossom K8s cluster.

##### What
Switch to the Blossom K8s cluster.

##### Why ?
Blossom cluster is more stable, visibly managed and has 24/7 SRE/NOC support.

##### How ?

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

