### PR TITLE
issue: 4287937 Fix a crash on shrinking a FIN segment with data

### DIFF
--- a/src/core/sock/sockinfo_tcp.cpp
+++ b/src/core/sock/sockinfo_tcp.cpp
@@ -1393,7 +1393,7 @@ err_t sockinfo_tcp::ip_output(struct pbuf *p, struct tcp_seg *seg, void *v_p_con
     void *cur_end;
 
     if (unlikely(flags & XLIO_TX_PACKET_REXMIT)) {
-        if (unlikely(inspect_socket_error_state(reinterpret_cast<const mem_buf_desc_t *>(p),
+        if (unlikely(inspect_socket_error_state(reinterpret_cast<const mem_buf_desc_t *>(seg->p),
                                                 reinterpret_cast<struct tcp_pcb *>(v_p_conn)))) {
             return ERR_RST;
         }


### PR DESCRIPTION
## Description
This fixes 2 bugs that lead to a crash if combined:
1. ip_output() converts a pbuf object from stack to mem_buf_desc_t which leads to reading of garbage;
2. Acknowledging all the data in a FIN segment but not the FIN flag itself leads to removing all the pbufs from the segments and NULL pointer dereference at the end.

##### What
Fix a crash.

##### Why ?
Bugfixes.

## Change type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

