### PR TITLE
Issue #4308042: Fix read of invalid data from CQE

### DIFF
--- a/src/core/dev/cq_mgr_rx_regrq.cpp
+++ b/src/core/dev/cq_mgr_rx_regrq.cpp
@@ -107,6 +107,7 @@ mem_buf_desc_t *cq_mgr_rx_regrq::poll(enum buff_status_e &status)
     xlio_mlx5_cqe *cqe = check_cqe();
     if (likely(cqe)) {
         ++m_mlx5_cq.cq_ci;
+        rmb();
         cqe_to_mem_buff_desc(cqe, m_rx_hot_buffer, status);
 
         ++m_hqrx_ptr->m_rq_data.tail;

--- a/src/core/dev/cq_mgr_rx_strq.cpp
+++ b/src/core/dev/cq_mgr_rx_strq.cpp
@@ -188,6 +188,7 @@ mem_buf_desc_t *cq_mgr_rx_strq::poll(enum buff_status_e &status, mem_buf_desc_t 
     xlio_mlx5_cqe *cqe = check_cqe();
     if (likely(cqe)) {
         ++m_mlx5_cq.cq_ci;
+        rmb();
 
         bool is_filler = false;
         bool is_wqe_complete = strq_cqe_to_mem_buff_desc(cqe, status, is_filler);

--- a/src/core/dev/cq_mgr_tx.h
+++ b/src/core/dev/cq_mgr_tx.h
@@ -144,6 +144,9 @@ inline struct xlio_mlx5_cqe *cq_mgr_tx::get_cqe_tx(uint32_t &num_polled_cqes)
                                        ((m_mlx5_cq.cq_ci & (m_mlx5_cq.cqe_count - 1))
                                         << m_mlx5_cq.cqe_size_log));
     }
+    if (cqe_ret) {
+        rmb();
+    }
     return cqe_ret;
 }
 

--- a/src/core/dev/ring_slave.cpp
+++ b/src/core/dev/ring_slave.cpp
@@ -739,8 +739,9 @@ bool ring_slave::rx_process_buffer(mem_buf_desc_t *p_rx_wc_buf_desc, void *pv_fd
 
         // Validate IP header as next protocol
         if (unlikely(h_proto != NET_ETH_P_IP) && unlikely(h_proto != NET_ETH_P_IPV6)) {
-            ring_logwarn("Rx buffer dropped - Invalid Ethr Type (%#x : %#x, %#x)", p_eth_h->h_proto,
-                         NET_ETH_P_IP, NET_ETH_P_IPV6);
+            ring_logwarn("Rx buffer dropped - Invalid Ethr Type (h_proto=%#x-p_eth_h->h_proto=%#x "
+                         ": %#x, %#x)",
+                         h_proto, p_eth_h->h_proto, NET_ETH_P_IP, NET_ETH_P_IPV6);
             return false;
         }
     } break;


### PR DESCRIPTION
According to the PRM - section 8.20.3.2:
"After seeing that the CQE is in SW ownership, 
SW should do memory barrier and re-read the CQE."

It was removed as part of commit 88436b2 - 
causing us to sometimes observe “garbage” data.

This commit returns the barrier as needed.

##### What
This patch adds a sync memory barrier as needed by the PRM, ensuring that any data we fetch after getting a CQE is correct and valid by the time we read it.

Kept a debug trace I added along the way which I think could be useful.

##### Why ?
Without conforming to the PRM, we are on the grace of our prefetch calls.
• Prefetch instructions may not complete before the actual load, especially under high concurrency or specific timing.
• This timing discrepancy has caused us to observe uninitialized or “garbage” data on verification setup - opening [bug #4308042.](https://redmine.mellanox.com/issues/4308042).

##### How ?

I added debug prints to confirm that the address (pointer to the proto - e.g. - `p_eth_h->h_proto`) was correct and that we weren’t writing any unexpected values. 
also compared reading the protocol field via a local variable (e.g., `uint16_t h_proto`) versus reading it directly from the pointer. 

Intriguingly, when reading directly from the pointer, the issue didn't occur, which hinted at a possible reordering or timing problem rather than a straightforward logic bug.

Further inspection of the difference between the generated AArch64 assembly showed identical aarch64 instructions - with some other instructions in between that data being loaded into the local variable. 

By tracking the code flow and confirming that no unexpected writes were happening, I zeroed in on a memory-ordering or synchronization problem. Testing a partial data memory barrier ("dmb ishld") around the load resolved the issue, confirming that the bug stemmed from the CPU performing loads before valid data was guaranteed, rather than from any logical or pointer misuse.

Then, using verification report, stating 3.40.2 was correct, I checked-out every commit, trying to reproduce the issue - getting to
commit 88436b2. 
Upon researching the PRM, I understood how to properly fix it, ditched the partial data memory barrier and returned a sync memory barrier after getting a CQE, as the standard demands.

## Change type
What kind of change does this PR introduce?
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

