### PR TITLE
issue: Adding XLIO threads skeleton 

### DIFF
--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -98,6 +98,8 @@ libxlio_la_SOURCES := \
 	dev/ring_simple.cpp \
 	dev/ring_tap.cpp \
 	dev/ring_allocation_logic.cpp \
+	dev/xlio_thread.cpp \
+	dev/xlio_thread_manager.cpp \
 	\
 	event/delta_timer.cpp \
 	event/event_handler_manager.cpp \
@@ -206,6 +208,8 @@ libxlio_la_SOURCES := \
 	dev/ring_allocation_logic.h \
 	dev/wqe_send_handler.h \
 	dev/xlio_ti.h \
+	dev/xlio_thread.h \
+	dev/xlio_thread_manager.h \
 	\
 	event/command.h \
 	event/delta_timer.h \

--- a/src/core/dev/xlio_thread.cpp
+++ b/src/core/dev/xlio_thread.cpp
@@ -1,0 +1,78 @@
+/*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+ * Copyright (c) 2001-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: GPL-2.0-only or BSD-3-Clause
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "xlio_thread.h"
+
+#define MODULE_NAME "xlio_thread"
+
+#define xt_logpanic   __log_panic
+#define xt_logerr     __log_err
+#define xt_logwarn    __log_warn
+#define xt_loginfo    __log_info
+#define xt_logdbg     __log_dbg
+
+xlio_thread::xlio_thread()
+{
+
+}
+
+xlio_thread::~xlio_thread()
+{
+
+}
+
+void xlio_thread::xlio_thread_loop(xlio_thread& t)
+{
+    xt_loginfo("Started");
+
+    while (t.m_running.load(std::memory_order_relaxed)) {
+
+    }
+
+    xt_loginfo("Terminated");
+}
+
+void xlio_thread::start_thread()
+{
+    xt_loginfo("Starting XLIO thread");
+    m_running.store(true);
+    m_thread = std::move(std::thread(xlio_thread_loop, std::ref(*this)));
+}
+
+void xlio_thread::stop_thread()
+{
+    xt_loginfo("Stopping XLIO thread");
+    m_running.store(false);
+    m_thread.join();
+}

--- a/src/core/dev/xlio_thread.cpp
+++ b/src/core/dev/xlio_thread.cpp
@@ -74,7 +74,7 @@ void xlio_thread::socket_rx_cb(xlio_socket_t sock, uintptr_t userdata_sq, void *
                                struct xlio_buf *buf)
 {
     sockinfo_tcp *tcp_sock = reinterpret_cast<sockinfo_tcp *>(sock);
-    __log_info("sock-fd: %d, len: %sz", tcp_sock->get_fd(), len);
+    __log_info("sock-fd: %d, len: %zu", tcp_sock->get_fd(), len);
 
     NOT_IN_USE(userdata_sq);
     NOT_IN_USE(data);
@@ -103,6 +103,14 @@ int xlio_thread::add_listen_socket(sockinfo_tcp *si)
     return rc;
 }
 
+int xlio_thread::add_accepted_socket(sockinfo_tcp *si)
+{
+    int rc = si->attach_xlio_group(m_poll_group, true);
+
+    xt_loginfo("Socket added tid: %d, fd: %d, rc: %d", (int)gettid(), si->get_fd(), rc);
+    return rc;
+}
+
 void xlio_thread::xlio_thread_loop()
 {
     while (m_running.load(std::memory_order_relaxed)) {
@@ -120,7 +128,7 @@ void xlio_thread::xlio_thread_main(xlio_thread& t)
         socket_event_cb,
         socket_comp_cb,
         socket_rx_cb,
-        socket_accept_cb
+        nullptr
     };
 
     t.m_poll_group = new poll_group(&pollg_attr);

--- a/src/core/dev/xlio_thread.cpp
+++ b/src/core/dev/xlio_thread.cpp
@@ -91,6 +91,18 @@ void xlio_thread::socket_accept_cb(xlio_socket_t sock, xlio_socket_t parent,
     NOT_IN_USE(parent_userdata_sq);
 }
 
+int xlio_thread::add_listen_socket(sockinfo_tcp *si)
+{
+    si->set_xlio_socket_thread(m_poll_group);
+    m_poll_group->add_socket(si);
+
+    // TODO handle positive return code from prepareListen() and convert it to errno
+    int rc = (si->prepareListen() ?: si->listen(-1));
+
+    xt_loginfo("Socket added tid: %d, fd: %d, rc: %d", (int)gettid(), si->get_fd(), rc);
+    return rc;
+}
+
 void xlio_thread::xlio_thread_loop()
 {
     while (m_running.load(std::memory_order_relaxed)) {

--- a/src/core/dev/xlio_thread.cpp
+++ b/src/core/dev/xlio_thread.cpp
@@ -33,6 +33,7 @@
  */
 
 #include "xlio_thread.h"
+#include "core/sock/sockinfo_tcp.h"
 
 #define MODULE_NAME "xlio_thread"
 
@@ -52,13 +53,69 @@ xlio_thread::~xlio_thread()
 
 }
 
-void xlio_thread::xlio_thread_loop(xlio_thread& t)
+void xlio_thread::socket_event_cb(xlio_socket_t sock, uintptr_t userdata_sq, int event, int value)
+{
+    sockinfo_tcp *tcp_sock = reinterpret_cast<sockinfo_tcp *>(sock);
+    __log_info("sock-fd: %d, event: %d, value: %d", tcp_sock->get_fd(), event, value);
+
+    NOT_IN_USE(userdata_sq);
+}
+
+void xlio_thread::socket_comp_cb(xlio_socket_t sock, uintptr_t userdata_sq, uintptr_t userdata_op)
+{
+    sockinfo_tcp *tcp_sock = reinterpret_cast<sockinfo_tcp *>(sock);
+    __log_info("sock-fd: %d", tcp_sock->get_fd());
+
+    NOT_IN_USE(userdata_sq);
+    NOT_IN_USE(userdata_op);
+}
+
+void xlio_thread::socket_rx_cb(xlio_socket_t sock, uintptr_t userdata_sq, void *data, size_t len,
+                               struct xlio_buf *buf)
+{
+    sockinfo_tcp *tcp_sock = reinterpret_cast<sockinfo_tcp *>(sock);
+    __log_info("sock-fd: %d, len: %sz", tcp_sock->get_fd(), len);
+
+    NOT_IN_USE(userdata_sq);
+    NOT_IN_USE(data);
+    NOT_IN_USE(buf);
+}
+
+void xlio_thread::socket_accept_cb(xlio_socket_t sock, xlio_socket_t parent,
+                                   uintptr_t parent_userdata_sq)
+{
+    sockinfo_tcp *tcp_sock = reinterpret_cast<sockinfo_tcp *>(sock);
+    sockinfo_tcp *tcp_sock_parent = reinterpret_cast<sockinfo_tcp *>(parent);
+    __log_info("sock-fd: %d, parent: %d", tcp_sock->get_fd(), tcp_sock_parent->get_fd());
+
+    NOT_IN_USE(parent_userdata_sq);
+}
+
+void xlio_thread::xlio_thread_loop()
+{
+    while (m_running.load(std::memory_order_relaxed)) {
+        m_poll_group->poll();
+        m_poll_group->flush();
+    }
+}
+
+void xlio_thread::xlio_thread_main(xlio_thread& t)
 {
     xt_loginfo("Started");
 
-    while (t.m_running.load(std::memory_order_relaxed)) {
+    xlio_poll_group_attr pollg_attr {
+        XLIO_GROUP_FLAG_SAFE | XLIO_GROUP_FLAG_DIRTY,
+        socket_event_cb,
+        socket_comp_cb,
+        socket_rx_cb,
+        socket_accept_cb
+    };
 
-    }
+    t.m_poll_group = new poll_group(&pollg_attr);
+
+    t.xlio_thread_loop();
+
+    delete t.m_poll_group;
 
     xt_loginfo("Terminated");
 }
@@ -67,7 +124,7 @@ void xlio_thread::start_thread()
 {
     xt_loginfo("Starting XLIO thread");
     m_running.store(true);
-    m_thread = std::move(std::thread(xlio_thread_loop, std::ref(*this)));
+    m_thread = std::move(std::thread(xlio_thread_main, std::ref(*this)));
 }
 
 void xlio_thread::stop_thread()

--- a/src/core/dev/xlio_thread.h
+++ b/src/core/dev/xlio_thread.h
@@ -38,6 +38,7 @@
 #include <thread>
 #include <atomic>
 #include "core/util/wakeup_pipe.h"
+#include "core/event/poll_group.h"
 
 class xlio_thread : public wakeup_pipe
 {
@@ -51,7 +52,17 @@ public:
 
 private:
 
-    static void xlio_thread_loop(xlio_thread& t);
+    static void socket_event_cb(xlio_socket_t, uintptr_t userdata_sq, int event, int value);
+    static void socket_comp_cb(xlio_socket_t, uintptr_t userdata_sq, uintptr_t userdata_op);
+    static void socket_rx_cb(xlio_socket_t, uintptr_t userdata_sq, void *data, size_t len,
+                             struct xlio_buf *buf);
+    static void socket_accept_cb(xlio_socket_t sock, xlio_socket_t parent,
+                                 uintptr_t parent_userdata_sq);
+    static void xlio_thread_main(xlio_thread& t);
+
+    void xlio_thread_loop();
+
+    poll_group *m_poll_group;
 
     std::thread m_thread;
 

--- a/src/core/dev/xlio_thread.h
+++ b/src/core/dev/xlio_thread.h
@@ -49,6 +49,7 @@ public:
 
     void start_thread();
     void stop_thread();
+    int add_listen_socket(sockinfo_tcp *si);
 
 private:
 

--- a/src/core/dev/xlio_thread.h
+++ b/src/core/dev/xlio_thread.h
@@ -1,0 +1,62 @@
+/*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+ * Copyright (c) 2001-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: GPL-2.0-only or BSD-3-Clause
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef XLIO_THREAD_H
+#define XLIO_THREAD_H
+
+#include <thread>
+#include <atomic>
+#include "core/util/wakeup_pipe.h"
+
+class xlio_thread : public wakeup_pipe
+{
+public:
+
+    xlio_thread();
+    ~xlio_thread();
+
+    void start_thread();
+    void stop_thread();
+
+private:
+
+    static void xlio_thread_loop(xlio_thread& t);
+
+    std::thread m_thread;
+
+    // Must be atomic for the start and stop to synchronize.
+    std::atomic_bool m_running{false};
+};
+
+#endif // XLIO_THREAD_H

--- a/src/core/dev/xlio_thread.h
+++ b/src/core/dev/xlio_thread.h
@@ -50,6 +50,7 @@ public:
     void start_thread();
     void stop_thread();
     int add_listen_socket(sockinfo_tcp *si);
+    int add_accepted_socket(sockinfo_tcp *si);
 
 private:
 

--- a/src/core/dev/xlio_thread_manager.cpp
+++ b/src/core/dev/xlio_thread_manager.cpp
@@ -33,6 +33,7 @@
  */
 
 #include "xlio_thread_manager.h"
+#include "core/sock/sockinfo_tcp.h"
 
 xlio_thread_manager *g_p_xlio_thread_manager = nullptr;
 
@@ -48,4 +49,11 @@ xlio_thread_manager::~xlio_thread_manager()
 {
     std::for_each(m_xlio_threads.get(), m_xlio_threads.get() + m_threads_num,
         [](xlio_thread& t) { t.stop_thread(); });
+}
+
+int xlio_thread_manager::add_listen_socket(sockinfo_tcp *sock)
+{
+    int rc = m_xlio_threads.get()[m_next_add_group++].add_listen_socket(sock);
+    m_next_add_group %= m_threads_num;
+    return rc;
 }

--- a/src/core/dev/xlio_thread_manager.cpp
+++ b/src/core/dev/xlio_thread_manager.cpp
@@ -1,0 +1,51 @@
+/*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+ * Copyright (c) 2001-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: GPL-2.0-only or BSD-3-Clause
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "xlio_thread_manager.h"
+
+xlio_thread_manager *g_p_xlio_thread_manager = nullptr;
+
+xlio_thread_manager::xlio_thread_manager(size_t threads)
+    : m_threads_num(threads)
+{
+    m_xlio_threads = std::move(std::make_unique<xlio_thread[]>(threads));
+    std::for_each(m_xlio_threads.get(), m_xlio_threads.get() + m_threads_num,
+        [](xlio_thread& t) { t.start_thread(); });
+}
+
+xlio_thread_manager::~xlio_thread_manager()
+{
+    std::for_each(m_xlio_threads.get(), m_xlio_threads.get() + m_threads_num,
+        [](xlio_thread& t) { t.stop_thread(); });
+}

--- a/src/core/dev/xlio_thread_manager.h
+++ b/src/core/dev/xlio_thread_manager.h
@@ -39,18 +39,22 @@
 #include <cstdint>
 #include "xlio_thread.h"
 
+class sockinfo_tcp;
+
 class xlio_thread_manager
 {
 public:
     xlio_thread_manager(size_t threads);
     ~xlio_thread_manager();
 
+    int add_listen_socket(sockinfo_tcp *sock);
 private:
 
     // The std::vector is not usable here since it requires the object
     // to be CopyAssignable 
     std::unique_ptr<xlio_thread[]> m_xlio_threads;
     size_t m_threads_num = 0U;
+    size_t m_next_add_group = 0U;
 };
 
 extern xlio_thread_manager *g_p_xlio_thread_manager;

--- a/src/core/dev/xlio_thread_manager.h
+++ b/src/core/dev/xlio_thread_manager.h
@@ -48,6 +48,8 @@ public:
     ~xlio_thread_manager();
 
     int add_listen_socket(sockinfo_tcp *sock);
+    int add_accepted_socket(sockinfo_tcp *sock);
+
 private:
 
     // The std::vector is not usable here since it requires the object

--- a/src/core/dev/xlio_thread_manager.h
+++ b/src/core/dev/xlio_thread_manager.h
@@ -1,0 +1,58 @@
+/*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+ * Copyright (c) 2001-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: GPL-2.0-only or BSD-3-Clause
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef XLIO_THREAD_MANAGER_H
+#define XLIO_THREAD_MANAGER_H
+
+#include <memory>
+#include <cstdint>
+#include "xlio_thread.h"
+
+class xlio_thread_manager
+{
+public:
+    xlio_thread_manager(size_t threads);
+    ~xlio_thread_manager();
+
+private:
+
+    // The std::vector is not usable here since it requires the object
+    // to be CopyAssignable 
+    std::unique_ptr<xlio_thread[]> m_xlio_threads;
+    size_t m_threads_num = 0U;
+};
+
+extern xlio_thread_manager *g_p_xlio_thread_manager;
+
+#endif // XLIO_THREAD_MANAGER_H

--- a/src/core/event/poll_group.h
+++ b/src/core/event/poll_group.h
@@ -86,6 +86,7 @@ private:
     unsigned m_group_flags;
     std::vector<sockinfo_tcp *> m_dirty_sockets;
 
+    multilock m_group_lock;
     sock_fd_api_list_t m_sockets_list;
     std::vector<std::pair<std::unique_ptr<ring_alloc_logic_attr>, net_device_val *>> m_rings_ref;
 };

--- a/src/core/sock/sock-extra.cpp
+++ b/src/core/sock/sock-extra.cpp
@@ -617,7 +617,7 @@ int xlio_socket_attach_group(xlio_socket_t sock, xlio_poll_group_t group)
     sockinfo_tcp *si = reinterpret_cast<sockinfo_tcp *>(sock);
     poll_group *grp = reinterpret_cast<poll_group *>(group);
 
-    return si->attach_xlio_group(grp);
+    return si->attach_xlio_group(grp, false);
 }
 
 static void xlio_buf_free(struct xlio_buf *buf)

--- a/src/core/sock/sockinfo_tcp.h
+++ b/src/core/sock/sockinfo_tcp.h
@@ -415,7 +415,6 @@ public:
                        void *opaque_op);
     int tcp_tx_express_inline(const struct iovec *iov, unsigned iov_len, unsigned flags);
     void flush();
-
     void set_xlio_socket_thread(poll_group *group);
     void set_xlio_socket(const struct xlio_socket_attr *attr);
     int update_xlio_socket(unsigned flags, uintptr_t userdata_sq);
@@ -423,7 +422,7 @@ public:
     void add_tx_ring_to_group();
     poll_group *get_poll_group() const { return m_p_group; }
     int detach_xlio_group();
-    int attach_xlio_group(poll_group *group);
+    int attach_xlio_group(poll_group *group, bool xlio_thread);
     void xlio_socket_event(int event, int value);
     static err_t rx_lwip_cb_xlio_socket(void *arg, struct tcp_pcb *tpcb, struct pbuf *p, err_t err);
     static void err_lwip_cb_xlio_socket(void *pcb_container, err_t err);

--- a/src/core/sock/sockinfo_tcp.h
+++ b/src/core/sock/sockinfo_tcp.h
@@ -416,6 +416,7 @@ public:
     int tcp_tx_express_inline(const struct iovec *iov, unsigned iov_len, unsigned flags);
     void flush();
 
+    void set_xlio_socket_thread(poll_group *group);
     void set_xlio_socket(const struct xlio_socket_attr *attr);
     int update_xlio_socket(unsigned flags, uintptr_t userdata_sq);
     bool is_xlio_socket() const { return m_p_group != nullptr; }

--- a/src/core/util/sys_vars.cpp
+++ b/src/core/util/sys_vars.cpp
@@ -48,6 +48,7 @@
 #include <libgen.h>
 #include <linux/igmp.h>
 #include <math.h>
+#include <thread>
 
 #include "vlogger/vlogger.h"
 #include "utils/rdtsc.h"
@@ -1827,6 +1828,9 @@ void mce_sys_var::get_env_params()
 
     if ((env_ptr = getenv(SYS_VAR_XLIO_THREADS))) {
         xlio_threads = option_size::from_str(env_ptr) ?: 1;
+        if (xlio_threads > std::thread::hardware_concurrency()) {
+            xlio_threads = std::thread::hardware_concurrency();
+        }
     }
 }
 

--- a/src/core/util/sys_vars.cpp
+++ b/src/core/util/sys_vars.cpp
@@ -901,6 +901,7 @@ void mce_sys_var::get_env_params()
     tcp_send_buffer_size = MCE_DEFAULT_TCP_SEND_BUFFER_SIZE;
     skip_poll_in_rx = MCE_DEFAULT_SKIP_POLL_IN_RX;
     multilock = MCE_DEFAULT_MULTILOCK;
+    xlio_threads = MCE_DEFAULT_XLIO_THREADS;
 
     read_hv();
 
@@ -1822,6 +1823,10 @@ void mce_sys_var::get_env_params()
             temp = 0;
         }
         multilock = (multilock_t)temp;
+    }
+
+    if ((env_ptr = getenv(SYS_VAR_XLIO_THREADS))) {
+        xlio_threads = option_size::from_str(env_ptr) ?: 1;
     }
 }
 

--- a/src/core/util/sys_vars.h
+++ b/src/core/util/sys_vars.h
@@ -851,7 +851,7 @@ extern mce_sys_var &safe_mce_sys();
 #endif /* DEFINED_UTLS */
 
 #define MCE_DEFAULT_LRO                            (option_3::AUTO)
-#define MCE_DEFAULT_DEFERRED_CLOSE                 (false)
+#define MCE_DEFAULT_DEFERRED_CLOSE                 (true)
 #define MCE_DEFAULT_TCP_ABORT_ON_CLOSE             (false)
 #define MCE_DEFAULT_RX_POLL_ON_TX_TCP              (false)
 #define MCE_DEFAULT_TRIGGER_DUMMY_SEND_GETSOCKNAME (false)

--- a/src/core/util/sys_vars.h
+++ b/src/core/util/sys_vars.h
@@ -458,6 +458,7 @@ public:
     bool internal_thread_arm_cq_enabled;
     skip_poll_in_rx_t skip_poll_in_rx;
     multilock_t multilock;
+    size_t xlio_threads;
 
     bool enable_socketxtreme;
     option_3::mode_t enable_tso;
@@ -692,6 +693,7 @@ extern mce_sys_var &safe_mce_sys();
 #define SYS_VAR_TCP_SEND_BUFFER_SIZE           "XLIO_TCP_SEND_BUFFER_SIZE"
 #define SYS_VAR_SKIP_POLL_IN_RX                "XLIO_SKIP_POLL_IN_RX"
 #define SYS_VAR_MULTILOCK                      "XLIO_MULTILOCK"
+#define SYS_VAR_XLIO_THREADS                   "XLIO_THREADS"
 
 /*
  * This block consists of default values for library specific
@@ -857,6 +859,7 @@ extern mce_sys_var &safe_mce_sys();
 #define MCE_ALIGNMENT                              ((unsigned long)63)
 #define MCE_DEFAULT_SKIP_POLL_IN_RX                (SKIP_POLL_IN_RX_DISABLE)
 #define MCE_DEFAULT_MULTILOCK                      (MULTILOCK_SPIN)
+#define MCE_DEFAULT_XLIO_THREADS                   (1)
 
 /*
  * This block consists of auxiliary constants


### PR DESCRIPTION
## Description
1. Adding xlio_thread as XLIO thread representor
2. Adding xlio_thread_manager to manage a collection of xlio_thread objects.
3. Adding XLIO_THREAD parameter to control the number of threads. Def: 1.
4. Reusing XLIO socket API in XLIO thread. Adding xlio_poll_group to each thread.
5. Making listen API to move the listen socket to XLIO thread.
6. Making accept API to move the new socket to a round robin XLIO thread. 

##### What
This is a skeleton for XLIO Threads PoC.

##### Why ?
XLIO generic multithreading support PoC

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

