### PR TITLE
issue: 4347777 Replace thread-local dummy lock with global one

### DIFF
--- a/src/core/dev/ring_slave.cpp
+++ b/src/core/dev/ring_slave.cpp
@@ -21,13 +21,13 @@
 // AF_INET address 0.0.0.0:0, used for 3T flow spec keys.
 static const sock_addr s_sock_addrany;
 
-static thread_local lock_dummy t_lock_dummy_ring;
+static padded_lock_dummy g_lock_dummy_ring;
 
 static lock_base *get_new_lock(const char *name, bool real_lock)
 {
     return (real_lock
                 ? static_cast<lock_base *>(multilock::create_new_lock(MULTILOCK_RECURSIVE, name))
-                : static_cast<lock_base *>(&t_lock_dummy_ring));
+                : static_cast<lock_base *>(&g_lock_dummy_ring.lock));
 }
 
 ring_slave::ring_slave(int if_index, ring *parent, ring_type_t type, bool use_locks)

--- a/src/core/sock/sockinfo_tcp.cpp
+++ b/src/core/sock/sockinfo_tcp.cpp
@@ -57,7 +57,8 @@ extern global_stats_t g_global_stat_static;
 tcp_timers_collection *g_tcp_timers_collection = nullptr;
 thread_local thread_local_tcp_timers g_thread_local_tcp_timers;
 bind_no_port *g_bind_no_port = nullptr;
-static thread_local lock_dummy t_lock_dummy_socket;
+
+static padded_lock_dummy g_lock_dummy_socket;
 
 /*
  * The following socket options are inherited by a connected TCP socket from the listening socket:
@@ -137,7 +138,7 @@ static lock_base *get_new_tcp_lock()
     return (
         safe_mce_sys().tcp_ctl_thread != option_tcp_ctl_thread::CTL_THREAD_DELEGATE_TCP_TIMERS
             ? static_cast<lock_base *>(multilock::create_new_lock(MULTILOCK_RECURSIVE, "tcp_con"))
-            : static_cast<lock_base *>(&t_lock_dummy_socket));
+            : static_cast<lock_base *>(&g_lock_dummy_socket.lock));
 }
 
 inline void sockinfo_tcp::lwip_pbuf_init_custom(mem_buf_desc_t *p_desc)

--- a/src/utils/lock_wrapper.h
+++ b/src/utils/lock_wrapper.h
@@ -473,6 +473,14 @@ public:
     int is_locked_by_me() override { return 1; }
 };
 
+// Users of lock_dummy may wish to alignas(64) to place this lock in in a different cache-line and
+// prevent false sharing
+struct alignas(64) padded_lock_dummy {
+    lock_dummy lock;
+    // Padding to fill a full cache line
+    char padding[64 - sizeof(lock_dummy)];
+};
+
 static inline void lock_deleter_func(lock_base *lock)
 {
     lock->delete_obj();


### PR DESCRIPTION
## Description
This change replaces a thread-local dummy locker with a global one in ring_slave.cpp to fix a use-after-free issue.

#### What
Replace thread-local dummy locker with a global one in ring_slave.

#### Why ?
During XLIO shutdown, when one thread attempts to access a socket's locker that was created by a terminated thread, a use-after-free issue occurs because the thread-local dummy locker object is freed when its creator thread terminates. This can lead to segmentation faults during cleanup.

#### How ?
The solution is straightforward:
1. Replace static thread_local lock_dummy t_lock_dummy_ring with a global static lock_dummy g_lock_dummy_ring
2. Update get_new_lock() to use this global locker
4. The global locker is initialized with a name for better debugging: "global_dummy_ring"

This change ensures the dummy locker remains valid throughout the program's lifetime, regardless of thread termination status.

#### Performance considerations

Pros of global implementation:
1. The dummy lock is accessed frequently in the data path
2. Each access to a thread-local variable requires the more complex memory access pattern
3. This compounds the overhead across many accesses

The global was aligned to be in a different cache line to prevent false-sharing - thus not introducing perf hit,

#### Tests
added a system-test (gtest) that discovered same issue occured on src/core/sock/sockinfo_tcp.cpp.
Applied the same fix there as well for the test to pass.

## Change type
What kind of change does this PR introduce?
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [X] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

