### PR TITLE
issue: 4262473 Deprecate XLIO_SELECT_POLL_OS_FORCE

### DIFF
--- a/README
+++ b/README
@@ -115,7 +115,6 @@ Example:
  XLIO DETAILS: ETH MC L2 only rules           Disabled                   [performance.steering_rules.udp.only_mc_l2_rules]
  XLIO DETAILS: Force Flowtag for MC           Disabled                   [network.multicast.mc_flowtag_acceleration]
  XLIO DETAILS: Select Poll (usec)             100000                     [performance.polling.iomux.poll_usec]
- XLIO DETAILS: Select Poll OS Force           Disabled                   [performance.polling.iomux.poll_os_force]
  XLIO DETAILS: Select Poll OS Ratio           10                         [performance.polling.iomux.poll_os_ratio]
  XLIO DETAILS: Select Skip OS                 4                          [performance.polling.iomux.skip_os]
  XLIO DETAILS: CQ Drain Interval (msec)       10                         [performance.completion_queue.periodic_drain_msec]
@@ -687,10 +686,6 @@ Default value is 64 KB
 performance.polling.blocking_rx_poll_usec
 The number of times to poll on Rx path for ready packets before going to sleep (wait for interrupt in blocked mode) or return -1 (in non-blocked mode). This Rx polling is done when the application is working with direct blocked calls to read(), recv(), recvfrom() & recvmsg(). When Rx path has successful poll hits, the latency is improved dramatically. This comes at the expense of CPU utilization. Value range is -1, 0 to 100,000,000. Where value of -1 is used for infinite polling and 0 means interrupt-driven only. Maps to **XLIO_RX_POLL** environment variable.
 Default value is 100000
-
-performance.polling.iomux.poll_os_force
-This flag forces to poll the OS file descriptors while user thread calls select(), poll() or epoll_wait() even when no offloaded sockets are mapped. Enabling this flag causes XLIO to set the OS file descriptor polling ratio and OS skip values to 1. This will result in polling the OS file descriptors, along side with offloaded sockets (if such sockets exists), the number of times specified in the select/poll duration setting. Maps to **XLIO_SELECT_POLL_OS_FORCE** environment variable.
-Default value is 0 (Disabled)
 
 performance.polling.iomux.poll_os_ratio
 This will enable polling of the OS file descriptors while user thread calls select() or poll() and XLIO is busy in the offloaded sockets polling loop. This will result in a single poll of the not-offloaded sockets every N offloaded sockets (CQ) polls. When disabled (value of 0), only offloaded sockets are polled. Maps to **XLIO_SELECT_POLL_OS_RATIO** environment variable.

--- a/src/core/config/descriptor_providers/xlio_config_schema.json
+++ b/src/core/config/descriptor_providers/xlio_config_schema.json
@@ -908,12 +908,6 @@
                                     "title": "Select/poll duration (µsec)",
                                     "description": "The duration in micro-seconds (usec) in which to poll the hardware on Rx path before going to sleep (pending an interrupt blocking on OS select(), poll() or epoll_wait(). The max polling duration will be limited by the timeout the user is using when calling select(), poll() or epoll_wait(). When select(), poll() or epoll_wait() path has successful receive poll hits the latency is improved dramatically. This comes on account of CPU utilization. Value range is -1, 0 to 100,000,000. Where value of -1 is used for infinite polling and 0 is used for no polling (interrupt driven). Maps to XLIO_SELECT_POLL environment variable."
                                 },
-                                "poll_os_force": {
-                                    "type": "boolean",
-                                    "default": false,
-                                    "title": "Force poll OS file descriptors",
-                                    "description": "This flag forces to poll the OS file descriptors while user thread calls select(), poll() or epoll_wait() even when no offloaded sockets are mapped. Enabling this flag causes XLIO to set the OS file descriptor polling ratio and OS skip values to 1. This will result in polling the OS file descriptors, along side with offloaded sockets (if such sockets exists), the number of times specified in the select/poll duration setting. Maps to XLIO_SELECT_POLL_OS_FORCE environment variable."
-                                },
                                 "poll_os_ratio": {
                                     "type": "integer",
                                     "minimum": 0,

--- a/src/core/config/mappings.py
+++ b/src/core/config/mappings.py
@@ -84,7 +84,6 @@ config_mapping = {
     "performance.max_gro_streams": "XLIO_GRO_STREAMS_MAX",
     "performance.override_rcvbuf_limit": "XLIO_RX_BYTES_MIN",
     "performance.polling.blocking_rx_poll_usec": "XLIO_RX_POLL",
-    "performance.polling.iomux.poll_os_force": "XLIO_SELECT_POLL_OS_FORCE",
     "performance.polling.iomux.poll_os_ratio": "XLIO_SELECT_POLL_OS_RATIO",
     "performance.polling.iomux.poll_usec": "XLIO_SELECT_POLL",
     "performance.polling.iomux.skip_os": "XLIO_SELECT_SKIP_OS",

--- a/src/core/iomux/io_mux_call.cpp
+++ b/src/core/iomux/io_mux_call.cpp
@@ -417,8 +417,7 @@ int io_mux_call::call()
 
     __log_funcall("");
 
-    if (!safe_mce_sys().select_poll_os_force // TODO: evaluate/consider this logic
-        && (*m_p_num_all_offloaded_fds == 0)) {
+    if (*m_p_num_all_offloaded_fds == 0) {
         // 1st scenario
         timer_update();
         wait_os(false);
@@ -433,7 +432,8 @@ int io_mux_call::call()
             check_all_offloaded_sockets();
             if (m_n_all_ready_fds) {
                 goto done;
-            } else { // false wake-up, and we already discovered that we should be in 2nd scenario
+            } else { // false wake-up, and we already discovered that we should be in 2nd
+                     // scenario
                 timer_update();
                 if (is_timeout(m_elapsed)) {
                     goto done;

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -642,9 +642,6 @@ void print_xlio_global_settings()
                       NEW_CONFIG_VAR_STRQ_STRIDES_COMPENSATION_LEVEL);
     VLOG_PARAM_NUMBER("Select Poll (usec)", safe_mce_sys().select_poll_num,
                       MCE_DEFAULT_SELECT_NUM_POLLS, NEW_CONFIG_VAR_SELECT_NUM_POLLS);
-    VLOG_PARAM_STRING("Select Poll OS Force", safe_mce_sys().select_poll_os_force,
-                      MCE_DEFAULT_SELECT_POLL_OS_FORCE, NEW_CONFIG_VAR_SELECT_POLL_OS_FORCE,
-                      safe_mce_sys().select_poll_os_force ? "Enabled " : "Disabled");
 
     if (safe_mce_sys().select_poll_os_ratio) {
         VLOG_PARAM_NUMBER("Select Poll OS Ratio", safe_mce_sys().select_poll_os_ratio,

--- a/src/core/util/sys_vars.cpp
+++ b/src/core/util/sys_vars.cpp
@@ -827,7 +827,6 @@ void mce_sys_var::legacy_get_env_params()
     mc_force_flowtag = MCE_DEFAULT_MC_FORCE_FLOWTAG;
 
     select_poll_num = MCE_DEFAULT_SELECT_NUM_POLLS;
-    select_poll_os_force = MCE_DEFAULT_SELECT_POLL_OS_FORCE;
     select_poll_os_ratio = MCE_DEFAULT_SELECT_POLL_OS_RATIO;
     select_skip_os_fd_check = MCE_DEFAULT_SELECT_SKIP_OS;
 
@@ -1010,7 +1009,6 @@ void mce_sys_var::legacy_get_env_params()
         strcpy(internal_thread_affinity_str, "0");
         progress_engine_interval_msec = 100;
         select_poll_os_ratio = 100;
-        select_poll_os_force = 1;
         tcp_nodelay = true;
         ring_dev_mem_tx = 16384;
 
@@ -1413,15 +1411,6 @@ void mce_sys_var::legacy_get_env_params()
         vlog_printf(VLOG_WARNING, "Select Poll loops can not be below zero [%d]\n",
                     select_poll_num);
         select_poll_num = MCE_DEFAULT_SELECT_NUM_POLLS;
-    }
-
-    if ((env_ptr = getenv(SYS_VAR_SELECT_POLL_OS_FORCE))) {
-        select_poll_os_force = (uint32_t)atoi(env_ptr);
-    }
-
-    if (select_poll_os_force) {
-        select_poll_os_ratio = 1;
-        select_skip_os_fd_check = 1;
     }
 
     if ((env_ptr = getenv(SYS_VAR_SELECT_POLL_OS_RATIO))) {
@@ -2002,8 +1991,6 @@ void mce_sys_var::initialize_base_variables(const config_registry &registry)
         registry.get_default_value<bool>("network.multicast.mc_flowtag_acceleration");
 
     select_poll_num = registry.get_default_value<int>("performance.polling.iomux.poll_usec");
-    select_poll_os_force =
-        registry.get_default_value<bool>("performance.polling.iomux.poll_os_force");
     select_poll_os_ratio =
         registry.get_default_value<int>("performance.polling.iomux.poll_os_ratio");
     select_skip_os_fd_check =
@@ -2263,7 +2250,6 @@ void mce_sys_var::apply_sockperf_latency_profile()
     strcpy(internal_thread_affinity_str, "0");
     progress_engine_interval_msec = 100;
     select_poll_os_ratio = 100;
-    select_poll_os_force = 1;
     tcp_nodelay = true;
     ring_dev_mem_tx = 16384;
 
@@ -2584,14 +2570,6 @@ void mce_sys_var::configure_completion_queue(const config_registry &registry)
 
     set_value_from_registry_if_exists(select_poll_num, "performance.polling.iomux.poll_usec",
                                       registry);
-
-    set_value_from_registry_if_exists(select_poll_os_force,
-                                      "performance.polling.iomux.poll_os_force", registry);
-
-    if (select_poll_os_force) {
-        select_poll_os_ratio = 1;
-        select_skip_os_fd_check = 1;
-    }
 
     set_value_from_registry_if_exists(select_poll_os_ratio,
                                       "performance.polling.iomux.poll_os_ratio", registry);

--- a/src/core/util/sys_vars.h
+++ b/src/core/util/sys_vars.h
@@ -385,7 +385,6 @@ public:
     bool mc_force_flowtag;
 
     int32_t select_poll_num;
-    bool select_poll_os_force;
     uint32_t select_poll_os_ratio;
     uint32_t select_skip_os_fd_check;
     bool select_handle_cpu_usage_stats;
@@ -622,7 +621,6 @@ extern mce_sys_var &safe_mce_sys();
 
 #define SYS_VAR_SELECT_CPU_USAGE_STATS "XLIO_CPU_USAGE_STATS"
 #define SYS_VAR_SELECT_NUM_POLLS       "XLIO_SELECT_POLL"
-#define SYS_VAR_SELECT_POLL_OS_FORCE   "XLIO_SELECT_POLL_OS_FORCE"
 #define SYS_VAR_SELECT_POLL_OS_RATIO   "XLIO_SELECT_POLL_OS_RATIO"
 #define SYS_VAR_SELECT_SKIP_OS         "XLIO_SELECT_SKIP_OS"
 
@@ -771,7 +769,6 @@ extern mce_sys_var &safe_mce_sys();
 
 #define NEW_CONFIG_VAR_SELECT_CPU_USAGE_STATS "monitor.stats.cpu_usage"
 #define NEW_CONFIG_VAR_SELECT_NUM_POLLS       "performance.polling.iomux.poll_usec"
-#define NEW_CONFIG_VAR_SELECT_POLL_OS_FORCE   "performance.polling.iomux.poll_os_force"
 #define NEW_CONFIG_VAR_SELECT_POLL_OS_RATIO   "performance.polling.iomux.poll_os_ratio"
 #define NEW_CONFIG_VAR_SELECT_SKIP_OS         "performance.polling.iomux.skip_os"
 
@@ -940,7 +937,6 @@ extern mce_sys_var &safe_mce_sys();
 #define MCE_DEFAULT_ETH_MC_L2_ONLY_RULES          (false)
 #define MCE_DEFAULT_MC_FORCE_FLOWTAG              (false)
 #define MCE_DEFAULT_SELECT_NUM_POLLS              (100000)
-#define MCE_DEFAULT_SELECT_POLL_OS_FORCE          (0)
 #define MCE_DEFAULT_SELECT_POLL_OS_RATIO          (10)
 #define MCE_DEFAULT_SELECT_SKIP_OS                (4)
 #define MCE_DEFAULT_SELECT_CPU_USAGE_STATS        (false)


### PR DESCRIPTION
## Description
Remove the deprecated XLIO_SELECT_POLL_OS_FORCE configuration parameter
as it can be fully controlled by XLIO_SELECT_POLL_OS_RATIO and
XLIO_SELECT_SKIP_OS parameters. This aligns with the original repo's
direction to remove this configuration while maintaining compatibility.

The behavior of XLIO_SELECT_POLL_OS_FORCE can be replicated by setting:
- XLIO_SELECT_POLL_OS_RATIO=1
- XLIO_SELECT_SKIP_OS=1

##### What
Deprecate XLIO_SELECT_POLL_OS_FORCE configuration parameter and its related functionality.

##### Why ?
- The XLIO_SELECT_POLL_OS_FORCE parameter should be marked as deprecated in the README and will be removed from future libxlio releases
- The same behavior can be achieved using XLIO_SELECT_POLL_OS_RATIO and XLIO_SELECT_SKIP_OS parameters
- This aligns with the libvma to remove this configuration while maintaining compatibility (https://github.com/Mellanox/libvma/pull/1104)

##### How ?
The changes will involve:
1. Removing any logic that checks for this parameter
2. Ensuring the behavior can be replicated using XLIO_SELECT_POLL_OS_RATIO=1 and XLIO_SELECT_SKIP_OS=1
3. Updating documentation to remove references to this deprecated parameter
4. Maintaining backward compatibility by ensuring the same behavior can be achieved through the alternative parameters

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

