### PR TITLE
HPCINFRA-3413 BD source scan startup fix

### DIFF
--- a/.ci/blackduck_source.sh
+++ b/.ci/blackduck_source.sh
@@ -1,0 +1,48 @@
+#!/bin/bash -Exel
+
+topdir=$(git rev-parse --show-toplevel)
+cd "$topdir"
+
+# Check if the variables and pipeline attributes are set
+[[ -z "${WORKSPACE}" ]] && { echo "Error: WORKSPACE variable is not set"; exit 1; }
+[[ -z "$BLACKDUCK_API_TOKEN" ]] && { echo "Error: BLACKDUCK_API_TOKEN variable is not set"; exit 1; }
+[[ ! -d "${WORKSPACE}/logs" ]] && mkdir -p "${WORKSPACE}/logs"
+
+# Create valid JSON for further authentication in BlackDuck server
+json=$(jq -n \
+  --arg token "$BLACKDUCK_API_TOKEN" \
+  '{"blackduck.url": "https://blackduck.mellanox.com/", "blackduck.api.token": $token }')
+
+export SPRING_APPLICATION_JSON="$json"
+export PROJECT_NAME=libxlio
+export PROJECT_VERSION="$sha1"
+export PROJECT_SRC_PATH="$topdir"/src/
+
+echo "Running BlackDuck (SRC) on $name"
+
+echo "CONFIG:"
+echo "        NAME: ${PROJECT_NAME}"
+echo "     VERSION: ${PROJECT_VERSION}"
+echo "    SRC_PATH: ${PROJECT_SRC_PATH}"
+
+[[ -d /tmp/blackduck ]] && rm -rf /tmp/blackduck
+sudo -u swx-jenkins git clone -c core.sshCommand="ssh -i ~/.ssh/id_ed25519" -b master --single-branch --depth=1 ssh://git-nbu.nvidia.com:12023/DevOps/Tools/blackduck /tmp/blackduck
+cd /tmp/blackduck
+
+# disable check errors
+set +e
+timeout 3600 ./run_bd_scan.sh
+exit_code=$?
+#enable back
+set -e
+
+# copy run log to a place that jenkins job will archive it
+REPORT_NAME="BlackDuck_source_${PROJECT_NAME}_${PROJECT_VERSION}"
+cat "log/${PROJECT_NAME}_${PROJECT_VERSION}"*.log > "${WORKSPACE}/logs/${REPORT_NAME}.log" || true
+cat "log/${PROJECT_NAME}_${PROJECT_VERSION}"*.log || true
+
+if [ "$exit_code" == "0" ]; then
+    cp -v /tmp/blackduck/report/*.pdf "${WORKSPACE}/logs/${REPORT_NAME}.pdf"
+fi
+
+exit $exit_code

--- a/.ci/dockerfiles/Dockerfile.rhel8.6
+++ b/.ci/dockerfiles/Dockerfile.rhel8.6
@@ -55,3 +55,12 @@ RUN yum install --allowerasing -y \
 
 FROM harbor.mellanox.com/hpcx/$ARCH/rhel8.6/base as build
 RUN yum install -y json-c-devel
+
+
+FROM core as bduck
+ARG WEBREPO_URL=webrepo.gtm.nvidia.com
+RUN sed -i "s/webrepo/${WEBREPO_URL}/" /etc/yum.repos.d/* && \
+    yum install --allowerasing -y \
+    jq git java-11-openjdk sudo && \
+    yum clean all && \
+    rm -rf /var/cache/yum

--- a/.ci/matrix_job.yaml
+++ b/.ci/matrix_job.yaml
@@ -79,9 +79,17 @@ runs_on_dockers:
      category: 'tool'
     }
   - {name: 'toolbox', url: 'harbor.mellanox.com/hpcx/x86_64/rhel8.6/builder:inbox', category: 'tool', arch: 'x86_64'}
-  - {name: 'blackduck', url: 'harbor.mellanox.com/toolbox/blackduck_post_scan:latest', category: 'tool', arch: 'x86_64'}
   - {name: 'header-check', url: 'harbor.mellanox.com/toolbox/header_check:0.0.58', category: 'tool', arch: 'x86_64', tag: '0.0.58'}
 # static tests
+  - {
+     file: '.ci/dockerfiles/Dockerfile.rhel8.6',
+     arch: 'x86_64',
+     name: 'xlio_static.bduck',
+     uri: '$arch/$name',
+     tag: '20250418',
+     build_args: '--no-cache --target bduck',
+     category: 'tool'
+    }
   - {file: '.ci/dockerfiles/Dockerfile.rhel8.6',
      arch: 'x86_64',
      name: 'xlio_static.cppcheck',
@@ -372,23 +380,16 @@ steps:
   - name: Blackduck
     enable: ${do_blackduck}
     containerSelector:
-      - "{name: 'blackduck', category:'tool', variant:1}"
+      - "{name: 'xlio_static.bduck', category:'tool'}"
     agentSelector:
       - "{nodeLabel: 'skip-agent'}"
-    shell: action
-    module: ngci
-    run: NGCIBlackDuckScan
-    args:
-      projectName: "libxlio"
-      projectVersion: "${sha1}"
-      projectSrcPath: "src"
-      attachArtifact: true
-      reportName: "BlackDuck report"
-      scanMode: "source"
-      skipDockerDaemonCheck: true
-      credentialsId: "swx-jenkins3-svc_git-nbu_token"
-    env:
-      SPRING_APPLICATION_JSON: '{"blackduck.url":"https://blackduck.mellanox.com/","blackduck.api.token":"ODMwOWYwMzEtODA2ZC00MzBjLWI1ZDEtNmFiMjBkYzQzMzkwOjNmNjExN2M1LWE2ZmEtNDZlYS1hZjRiLTZlNDgwNjAwOTVjNw=="}'
+    run: |
+      export BLACKDUCK_API_TOKEN="ODMwOWYwMzEtODA2ZC00MzBjLWI1ZDEtNmFiMjBkYzQzMzkwOjNmNjExN2M1LWE2ZmEtNDZlYS1hZjRiLTZlNDgwNjAwOTVjNw=="
+      # WA for possible CI-Demo bug: HPCINFRA-1614
+      if ${do_blackduck} ; then
+        .ci/blackduck_source.sh
+      fi
+    archiveArtifacts: 'logs/'
 
 pipeline_start:
   run: |


### PR DESCRIPTION
## Description
Replaced NGCI-based BlackDuck source scan with custom BlackDuck script execution

##### What
This change removes the NGCI module previously used for running BlackDuck source scans and replaces it with a custom script that uses SSH authentication and provides clearer run logs

##### Why ?
NGCI relied on a Gerrit user token for cloning BlackDuck, which was subject to frequent rotation and caused recurring CI failures. 

##### How ?
We move to scan execution via a custom script using a service account with stable SSH-based authentication.

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

