### PR TITLE
issue: 4397660 Fix reading flow_tag from CQE minu 4

### DIFF
--- a/src/core/dev/cq_mgr_rx_regrq.cpp
+++ b/src/core/dev/cq_mgr_rx_regrq.cpp
@@ -117,7 +117,7 @@ void cq_mgr_rx_regrq::cqe_to_mem_buff_desc(struct xlio_mlx5_cqe *cqe,
         p_rx_wc_buf_desc->rx.tls_decrypted = (cqe->pkt_info >> 3) & 0x3;
 #endif /* DEFINED_UTLS */
         p_rx_wc_buf_desc->rx.timestamps.hw_raw = ntohll(cqe->timestamp);
-        p_rx_wc_buf_desc->rx.flow_tag_id = ntohl((uint32_t)(cqe->sop_drop_qpn));
+        p_rx_wc_buf_desc->rx.flow_tag_id = ntohl(cqe->sop_rxdrop_qpn_flowtag) & 0x00FFFFFF;
         p_rx_wc_buf_desc->rx.is_sw_csum_need =
             !(m_b_is_rx_hw_csum_on && (cqe->hds_ip_ext & MLX5_CQE_L4_OK) &&
               (cqe->hds_ip_ext & MLX5_CQE_L3_OK));

--- a/src/core/dev/cq_mgr_rx_strq.cpp
+++ b/src/core/dev/cq_mgr_rx_strq.cpp
@@ -224,7 +224,7 @@ inline bool cq_mgr_rx_strq::strq_cqe_to_mem_buff_desc(struct xlio_mlx5_cqe *cqe,
         _current_wqe_consumed_bytes += _hot_buffer_stride->sz_buffer;
 
         _hot_buffer_stride->rx.timestamps.hw_raw = ntohll(cqe->timestamp);
-        _hot_buffer_stride->rx.flow_tag_id = ntohl((uint32_t)(cqe->sop_drop_qpn));
+        _hot_buffer_stride->rx.flow_tag_id = ntohl(cqe->sop_rxdrop_qpn_flowtag) & 0x00FFFFFF;
         _hot_buffer_stride->rx.is_sw_csum_need =
             !(m_b_is_rx_hw_csum_on && (cqe->hds_ip_ext & MLX5_CQE_L4_OK) &&
               (cqe->hds_ip_ext & MLX5_CQE_L3_OK));

--- a/src/core/ib/mlx5/ib_mlx5.h
+++ b/src/core/ib/mlx5/ib_mlx5.h
@@ -178,7 +178,7 @@ typedef struct xlio_mlx5_cqe {
     uint8_t rsvd4[4];
     __be32 byte_cnt;
     __be64 timestamp;
-    __be32 sop_drop_qpn;
+    __be32 sop_rxdrop_qpn_flowtag;
     __be16 wqe_counter;
     uint8_t rsvd5;
     uint8_t op_own;


### PR DESCRIPTION
The flow_tag field in the CQE format is 24 bits, but it was handled as if it were 32 bits. The additional 8 bits are reserved for the rx_drop_counter.
Consequently, when there were RX drops, the flow_tag was incorrect because the most significant 8 bits were not zero.

## Description
Please provide a summary of the change.

##### What
_Subject: what this PR is doing in one line._ 

##### Why ?
_Justification for the PR. If there is existing issue/bug please reference._

##### How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc._

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

