### PR TITLE
[CI] issue: HPCINFRA-3523 secret scan fix

### DIFF
--- a/.ci/matrix_job.yaml
+++ b/.ci/matrix_job.yaml
@@ -18,6 +18,7 @@ kubernetes:
 credentials:
   - {credentialsId: 'media_coverity_credentials', usernameVariable: 'XLIO_COV_USER', passwordVariable: 'XLIO_COV_PASSWORD'}
   - {credentialsId: 'mellanox_github_credentials', usernameVariable: 'MELLANOX_GH_USER', passwordVariable: 'MELLANOX_GH_TOKEN'}
+  - {credentialsId: 'blackduck_api_token', type: 'string', variable: 'BLACKDUCK_API_TOKEN'}
 
 volumes:
   - {mountPath: /hpc/local/bin, hostPath: /hpc/local/bin}
@@ -384,12 +385,12 @@ steps:
     agentSelector:
       - "{nodeLabel: 'skip-agent'}"
     run: |
-      export BLACKDUCK_API_TOKEN="ODMwOWYwMzEtODA2ZC00MzBjLWI1ZDEtNmFiMjBkYzQzMzkwOjNmNjExN2M1LWE2ZmEtNDZlYS1hZjRiLTZlNDgwNjAwOTVjNw=="
       # WA for possible CI-Demo bug: HPCINFRA-1614
       if ${do_blackduck} ; then
         .ci/blackduck_source.sh
       fi
     archiveArtifacts: 'logs/'
+    credentialsId: 'blackduck_api_token'
 
 pipeline_start:
   run: |


### PR DESCRIPTION
## Description
Migrate hardcoded secrets from the CI codebase to Jenkins-managed credentials

##### What
We are removing hardcoded secrets and credential references from the CI codebase.

##### Why ?
Hardcoded secrets trigger security scan failures and reduce the overall security posture of the system.

##### How ?
By transferring secrets to Jenkins credentials storage and referencing them through environment variables.

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

