### PR TITLE
[CI] issue: HPCINFRA-3512 add support for C++14 in cppcheck container

### DIFF
--- a/.ci/dockerfiles/Dockerfile.rhel8.6
+++ b/.ci/dockerfiles/Dockerfile.rhel8.6
@@ -13,14 +13,28 @@ RUN echo "${_LOGIN} ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \
     chown -R ${_LOGIN} ${_HOME} && \
     mkdir /build && chown -R ${_LOGIN} /build
 
-FROM core as static
-ARG _LOGIN=swx-jenkins
+FROM core as cppcheck
+ENV CPPCHECK_VERSION="2.17.1"
+RUN yum install -y curl make gcc gcc-c++ sudo procps-ng autoconf \
+    automake make libtool libnl3-devel libnl3 rdma-core-devel \
+    rdma-core bc git \
+ && yum clean all \
+ && pushd /tmp \
+ && curl -L -o "${CPPCHECK_VERSION}".tar.gz "https://github.com/danmar/cppcheck/archive/${CPPCHECK_VERSION}.tar.gz" \
+ && tar xvf "$CPPCHECK_VERSION".tar.gz \
+ && cd cppcheck-"$CPPCHECK_VERSION" \
+ && make -j8 FILESDIR=/usr/share/cppcheck \
+ && make install FILESDIR=/usr/share/cppcheck \
+ && popd \
+ && rm -rf /tmp/cppcheck-"$CPPCHECK_VERSION"* 
+ ENTRYPOINT [ "/bin/bash", "--login", "--rcfile", "/etc/bashrc", "-c" ]
 
+FROM core as csbuild
+ARG _LOGIN=swx-jenkins
 RUN yum install -y yum-utils \
- && yum-config-manager --add-repo https://archives.fedoraproject.org/pub/archive/epel/7/x86_64/ \
- && yum --nogpgcheck install -y cppcheck \
  && yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm \
- && yum install -y csbuild clang-tools-extra sudo curl autoconf automake make libtool \
+ && yum --nogpgcheck install -y curl make gcc gcc-c++ \
+ && yum install -y csbuild clang-tools-extra sudo autoconf automake libtool \
     libnl3-devel libnl3 rdma-core-devel rdma-core bc \
  && yum clean all
 

--- a/.ci/matrix_job.yaml
+++ b/.ci/matrix_job.yaml
@@ -95,16 +95,16 @@ runs_on_dockers:
      arch: 'x86_64',
      name: 'xlio_static.cppcheck',
      uri: '$arch/$name',
-     tag: '20250304',
-     build_args: '--no-cache --target static',
+     tag: '20250425',
+     build_args: '--no-cache --target cppcheck',
      category: 'tool'
      }
   - {file: '.ci/dockerfiles/Dockerfile.rhel8.6',
      arch: 'x86_64',
      name: 'xlio_static.csbuild',
      uri: '$arch/$name',
-     tag: '20250304',
-     build_args: '--no-cache --target static',
+     tag: '20250425',
+     build_args: '--no-cache --target csbuild',
      category: 'tool'
      }
 

--- a/contrib/jenkins_tests/cppcheck.sh
+++ b/contrib/jenkins_tests/cppcheck.sh
@@ -24,7 +24,7 @@ ${WORKSPACE}/configure $jenkins_test_custom_configure > "${cppcheck_dir}/cppchec
 
 set +eE
 eval "find ${WORKSPACE}/src -name '*.h' -o -name '*.cpp' -o -name '*.c' -o -name '*.hpp' | \
-	${tool_app} --std=c++11 --language=c++ --force --enable=information \
+	${tool_app} --std=c++14 --language=c++ --force --enable=information \
 	-I${WORKSPACE}/src \
 	-I${WORKSPACE}/src/stats \
 	-I${WORKSPACE}/src/utils \


### PR DESCRIPTION
## Description
Add C++14 support in cppcheck container

##### What
Update the cppcheck static analysis tool to version 2.12.1 with C++14 support in the cppcheck container.

##### Why ?
The current cppcheck version from EPEL7 repository is outdated and lacks proper support for C++14 features

##### How ?
Build cppcheck 2.12.1 from source in the CI container, update cppcheck.sh to use --std=c++14 flag

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

