### PR TITLE
Tls robustness

### DIFF
--- a/src/core/sock/sockinfo_tcp.cpp
+++ b/src/core/sock/sockinfo_tcp.cpp
@@ -4345,6 +4345,13 @@ int sockinfo_tcp::tcp_setsockopt(int __level, int __optname, __const void *__opt
                         ret = -1;
                         break;
                     }
+                    ops = dynamic_cast<sockinfo_tcp_ops_tls *>(m_ops);
+                    if (ops) {
+                        si_tcp_loginfo("(TCP_ULP) val: tls, ULP is already TLS");
+                        errno = EEXIST;
+                        ret = -1;
+                        break;
+                    }
                     ops = new sockinfo_tcp_ops_tls(this);
                 }
             }

--- a/src/core/sock/sockinfo_tcp.cpp
+++ b/src/core/sock/sockinfo_tcp.cpp
@@ -4325,8 +4325,8 @@ int sockinfo_tcp::tcp_setsockopt(int __level, int __optname, __const void *__opt
             break;
         case TCP_ULP: {
             sockinfo_tcp_ops *ops {nullptr};
+            pass_to_os_cond = false;
             if (__optval && __optlen >= 4 && strncmp((char *)__optval, "nvme", 4) == 0) {
-                pass_to_os_cond = false;
                 auto nvme_feature_mask = get_supported_nvme_feature_mask();
                 if (nvme_feature_mask == 0U) {
                     errno = ENOTSUP;
@@ -4365,8 +4365,6 @@ int sockinfo_tcp::tcp_setsockopt(int __level, int __optname, __const void *__opt
             lock_tcp_con();
             set_ops(ops);
             unlock_tcp_con();
-            /* On success we call kernel setsockopt() in case this socket is not connected
-               and is unoffloaded later.  */
             break;
         }
         case TCP_CONGESTION:


### PR DESCRIPTION
## Description
Improve KTLS compliancy with kernel.
setsockopt(TCP_ULP) has different behavior than kernel if an application calls it multiple times by mistake.
Skip calling to kernel, because kernel will always fail this option for the shadow socket.

##### What
Improve KTLS compliancy with kernel.

##### Why ?
Improve KTLS compliancy with kernel.

## Change type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

