### PR TITLE
[CI] migrate CI test steps to containers - Valgrind

### DIFF
--- a/.ci/dockerfiles/Dockerfile.ubuntu22.04
+++ b/.ci/dockerfiles/Dockerfile.ubuntu22.04
@@ -4,7 +4,22 @@ RUN apt-get update \
  && apt-get install -y libjson-c-dev \
  && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-FROM build as style
+# Base for all tests (Gtest, Valgrind, test), installs utilities.
+FROM build AS tests
+RUN apt-get update && \
+    apt-get install -y \
+    net-tools unzip iproute2 wget \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Valgrind target, installs valgrind
+FROM tests AS vg
+RUN apt-get update && \
+    apt-get install -y \
+    valgrind \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Style target, installs clang-format-15
+FROM build AS style
 RUN apt-get update \
  && apt-get install -y clang-15 clang-format-15 \
  && update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-15 100 \

--- a/.ci/matrix_job.yaml
+++ b/.ci/matrix_job.yaml
@@ -12,8 +12,8 @@ kubernetes:
   cloud: il-ipp-blossom-prod
   nodeSelector: 'beta.kubernetes.io/os=linux'
   namespace: swx-media
-  limits: '{memory: 8Gi, cpu: 7000m}'
-  requests: '{memory: 8Gi, cpu: 7000m}'
+  limits: '{memory: 10Gi, cpu: 10000m}'
+  requests: '{memory: 10Gi, cpu: 10000m}'
 
 credentials:
   - {credentialsId: 'media_coverity_credentials', usernameVariable: 'XLIO_COV_USER', passwordVariable: 'XLIO_COV_PASSWORD'}
@@ -107,6 +107,24 @@ runs_on_dockers:
      build_args: '--no-cache --target static',
      category: 'tool'
      }
+# tests
+  - {
+     file: '.ci/dockerfiles/Dockerfile.ubuntu22.04',
+     arch: 'x86_64',
+     name: 'vg',
+     uri: 'xlio/$arch/ubuntu22.04/$name',
+     tag: '20250219',
+     build_args: '--no-cache --target vg',
+     category: 'tool',
+     annotations: [{ key: 'k8s.v1.cni.cncf.io/networks', value: 'sriov-cx6dx-p2' }],
+     limits: '{memory: 10Gi, cpu: 10000m, hugepages-2Mi: 10Gi, mellanox.com/sriov_cx6dx_p2: 1}',
+     requests: '{memory: 10Gi, cpu: 10000m, hugepages-2Mi: 10Gi, mellanox.com/sriov_cx6dx_p2: 1}',
+     caps_add: '[ IPC_LOCK, SYS_RESOURCE ]',
+     runAsUser: '0',
+     runAsGroup: '0',
+     cloud: swx-k8s-spray,
+     namespace: xlio-ci
+    }
 
 runs_on_agents:
   - {nodeLabel: 'beni09', category: 'base'}
@@ -142,6 +160,7 @@ steps:
   - name: Install Doca-host
     containerSelector:
       - "{category: 'base'}"
+      - "{name: 'vg'}"
     agentSelector:
       - "{nodeLabel: 'skip-agent'}"
     run: |
@@ -340,9 +359,9 @@ steps:
   - name: Valgrind
     enable: ${do_valgrind}
     containerSelector:
-      - "{name: 'skip-container'}"
+      - "{name: 'vg'}"
     agentSelector:
-      - "{nodeLabel: 'beni09'}"
+      - "{nodeLabel: 'skip-agent'}"
     run: |
       [ "x${do_valgrind}" == "xtrue" ] && action=yes || action=no
       env WORKSPACE=$PWD TARGET=${flags} jenkins_test_vg=${action} ./contrib/test_jenkins.sh
@@ -370,6 +389,11 @@ steps:
 
   - name: Artifacts
     enable: ${do_artifact}
+    containerSelector:
+      - "{category: 'base'}"
+      - "{name: 'vg'}"
+    agentSelector:
+      - "{nodeLabel: 'beni09'}"
     run: |
       ./.ci/artifacts.sh
     parallel: false
@@ -403,4 +427,4 @@ pipeline_stop:
 
 failFast: false
 
-taskName: '${flags}/${name}/${axis_index}'
+taskName: '${flags}/${arch}/${name}/${axis_index}'

--- a/contrib/jenkins_tests/globals.sh
+++ b/contrib/jenkins_tests/globals.sh
@@ -82,6 +82,17 @@ function do_archive()
 # Otherwise, return error code.
 # $1 - module name
 #
+
+function do_hugepages()
+{
+    if [[ (-f /.dockerenv || -f /run/.containerenv || -n "${KUBERNETES_SERVICE_HOST}") ]] && ! grep -q hugetlbfs /proc/mounts; then
+        mkdir -p /mnt/huge
+        mount -t hugetlbfs nodev /mnt/huge
+        grep hugetlbfs /proc/mounts
+        echo $?
+    fi
+}
+
 function do_module()
 {
     [ -z "$1" ] && return


### PR DESCRIPTION
## Description
Today we use benni09 static agent to run test/gtest/valgrind steps which is unscaleable since it can only run one pipeline at a time, causing delays in builds that can be stuck waiting for hours

The idea is to move these steps to containers, allowing running them in parallel as well as running multiple pipelines at the same time (depending on the capacity of the k8s cluster)

##### What
This commit moves Valgrind away from static agent to container running on k8s

##### Why ?
Issue: [HPCINFRA-3249](https://jirasw.nvidia.com/browse/HPCINFRA-3249)
Issue: [HPCINFRA-3559](https://jirasw.nvidia.com/browse/HPCINFRA-3559)

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

