### PR TITLE
[CI] issue: HPCINFRA-3635 Use Clang-18 docker image for csbuild

### DIFF
--- a/.ci/matrix_job.yaml
+++ b/.ci/matrix_job.yaml
@@ -99,14 +99,7 @@ runs_on_dockers:
      build_args: '--no-cache --target static',
      category: 'tool'
      }
-  - {file: '.ci/dockerfiles/Dockerfile.rhel8.6',
-     arch: 'x86_64',
-     name: 'xlio_static.csbuild',
-     uri: '$arch/$name',
-     tag: '20250304',
-     build_args: '--no-cache --target static',
-     category: 'tool'
-     }
+  - {name: 'xlio_static.csbuild', url: 'harbor.mellanox.com/swx-infra/media/x86_64/xlio_static.csbuild-clang18:20250515', category: 'tool', arch: 'x86_64' }
 # tests
   - {
      file: '.ci/dockerfiles/Dockerfile.ubuntu22.04',


### PR DESCRIPTION
## Description
Csbuild fails due to issues with some cpp files, which were previously not found in Clang18, but are found in Clang19
Until these issues are resolved, we will use Clang18

##### What
Change csbuild docker image

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

