### PR TITLE
issue: 4457054 Fix segfault at exit if initialization fails

### DIFF
--- a/src/core/dev/net_device_table_mgr.cpp
+++ b/src/core/dev/net_device_table_mgr.cpp
@@ -457,12 +457,11 @@ int net_device_table_mgr::global_ring_epfd_get()
     return m_global_ring_epfd;
 }
 
-uint64_t net_device_table_mgr::global_get_rx_drop_counter()
+uint64_t net_device_table_mgr::get_rx_drop_counter()
 {
     // coverity[missing_lock:FALSE] /*Turn off coverity missing_lock check*/
-    uint64_t accumulator = this->m_closed_rings_rx_cq_drop_counter;
-    std::for_each(g_p_net_device_table_mgr->m_net_device_map_index.begin(),
-                  g_p_net_device_table_mgr->m_net_device_map_index.end(),
+    uint64_t accumulator = m_closed_rings_rx_cq_drop_counter;
+    std::for_each(m_net_device_map_index.begin(), m_net_device_map_index.end(),
                   [&accumulator](const auto &net_dev_map_iter) {
                       accumulator += net_dev_map_iter.second->get_accumulative_rx_cq_drop_counter();
                   });
@@ -472,7 +471,7 @@ uint64_t net_device_table_mgr::global_get_rx_drop_counter()
 void net_device_table_mgr::print_report(vlog_levels_t log_level,
                                         bool print_only_critical /*=false*/)
 {
-    uint64_t accumulator = global_get_rx_drop_counter();
+    uint64_t accumulator = get_rx_drop_counter();
     if (print_only_critical && !accumulator) {
         return;
     }

--- a/src/core/dev/net_device_table_mgr.h
+++ b/src/core/dev/net_device_table_mgr.h
@@ -76,7 +76,7 @@ public:
      * This will get accumlated RX out of buffer drops
      * for all net devices.
      */
-    uint64_t global_get_rx_drop_counter(void);
+    uint64_t get_rx_drop_counter(void);
     void print_report(vlog_levels_t log_level, bool print_only_critical = false);
 
     void handle_timer_expired(void *user_data);

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -102,7 +102,9 @@ static int free_libxlio_resources()
         bool print_only_critical = (safe_mce_sys().print_report == option_3::AUTO);
         buffer_pool::print_full_report(VLOG_INFO, print_only_critical);
         g_hugepage_mgr.print_report(VLOG_INFO, print_only_critical);
-        g_p_net_device_table_mgr->print_report(VLOG_INFO, print_only_critical);
+        if (g_p_net_device_table_mgr) {
+            g_p_net_device_table_mgr->print_report(VLOG_INFO, print_only_critical);
+        }
     }
 
     // Destroy polling groups before fd_collection to clear XLIO sockets from the fd_collection


### PR DESCRIPTION
## Description
In free_libxlio_resources(), we try to print report for g_p_net_device_table_mgr, however, it can be NULL if XLIO initialization fails. Check the pointer to avoid NULL pointer dereference.

##### What
Segfault fix.

##### Why ?
Segfault fix.

## Change type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

