### PR TITLE
[CI] issue: HPCINFRA-3581 Clang-tools-extra 20.1.8

### DIFF
--- a/.ci/dockerfiles/Dockerfile.rhel8.6
+++ b/.ci/dockerfiles/Dockerfile.rhel8.6
@@ -5,6 +5,7 @@ ARG _UID=6213
 ARG _GID=101
 ARG _LOGIN=swx-jenkins
 ARG _HOME=/var/home/$_LOGIN
+
 RUN echo "${_LOGIN} ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \
     echo "root ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \
     mkdir -p ${_HOME} && \
@@ -16,13 +17,14 @@ RUN echo "${_LOGIN} ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \
 FROM core as static
 ARG _LOGIN=svc-nbu-swx-media
 
-RUN yum install -y yum-utils \
- && yum-config-manager --add-repo https://archives.fedoraproject.org/pub/archive/epel/7/x86_64/ \
- && yum --nogpgcheck install -y cppcheck \
- && yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm \
- && yum install -y csbuild clang-tools-extra sudo curl autoconf automake make libtool \
-    libnl3-devel libnl3 rdma-core-devel rdma-core bc \
- && yum clean all
+RUN yum makecache && \
+    yum install -y yum-utils clang-tools-extra-20.1.8 sudo curl autoconf automake make libtool \
+    libnl3-devel libnl3 rdma-core-devel rdma-core bc && \
+    yum-config-manager --add-repo https://archives.fedoraproject.org/pub/archive/epel/7/x86_64/ && \
+    yum --nogpgcheck install -y cppcheck && \
+    yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \
+    yum install -y csbuild && \
+    yum clean all
 
 RUN pip3 install -U pip --no-cache-dir \
  && pip3 install compiledb --no-cache-dir

--- a/.ci/matrix_job.yaml
+++ b/.ci/matrix_job.yaml
@@ -89,7 +89,14 @@ runs_on_dockers:
      limits: '{memory: 8Gi, cpu: 4000m}',
      requests: '{memory: 8Gi, cpu: 4000m}'
      }
-  - {name: 'xlio_static.csbuild', url: '${registry_host}/swx-infra/media/x86_64/xlio_static.csbuild-clang18:20250515', category: 'tool', arch: 'x86_64', limits: '{memory: 5Gi, cpu: 4000m}', requests: '{memory: 5Gi, cpu: 4000m}'}
+  - {file: '.ci/dockerfiles/Dockerfile.rhel8.6',
+     arch: 'x86_64',
+     name: 'xlio_static.csbuild',
+     uri: '$arch/$name',
+     tag: '20260427',
+     build_args: '--no-cache --target static',
+     category: 'tool'
+    }
 # tests
   - {
      file: '.ci/dockerfiles/Dockerfile.ubuntu22.04',

--- a/src/core/dev/hw_queue_rx.cpp
+++ b/src/core/dev/hw_queue_rx.cpp
@@ -177,11 +177,14 @@ void hw_queue_rx::release_rx_buffers()
     hwqrx_logdbg("draining cq_mgr_rx %p (last_posted_rx_wr_id = %lu)", m_p_cq_mgr_rx,
                  m_last_posted_rx_wr_id);
     uintptr_t last_polled_rx_wr_id = 0;
-    while (m_p_cq_mgr_rx && last_polled_rx_wr_id != m_last_posted_rx_wr_id && errno != EIO &&
+    int drain_err = 0;
+    while (m_p_cq_mgr_rx && last_polled_rx_wr_id != m_last_posted_rx_wr_id && drain_err != EIO &&
            !is_rq_empty() && !m_p_ib_ctx_handler->is_removed()) {
 
         // Process the FLUSH'ed WQE's
+        errno = 0;
         int ret = m_p_cq_mgr_rx->drain_and_proccess(&last_polled_rx_wr_id);
+        drain_err = errno;
         hwqrx_logdbg("draining completed on cq_mgr_rx (%d wce) last_polled_rx_wr_id = %lu", ret,
                      last_polled_rx_wr_id);
 

--- a/src/core/dev/ring_slave.h
+++ b/src/core/dev/ring_slave.h
@@ -272,7 +272,7 @@ public:
 
 #ifdef DEFINED_UTLS
     /* Call this method in an RX ring. */
-    rfs_rule *tls_rx_create_rule(const flow_tuple &flow_spec_5t, xlio_tir *tir);
+    rfs_rule *tls_rx_create_rule(const flow_tuple &flow_spec_5t, xlio_tir *tir) override;
 #endif /* DEFINED_UTLS */
 
     transport_type_t get_transport_type() const { return m_transport_type; }

--- a/src/core/util/sys_vars_configurator.cpp
+++ b/src/core/util/sys_vars_configurator.cpp
@@ -1255,14 +1255,6 @@ void sys_var_configurator::configure_after_user_settings()
                     CONFIG_VAR_RING_MIGRATION_RATIO_TX.name, -1, CONFIG_VAR_TSO.name);
     }
 #ifdef DEFINED_UTLS
-    m_runtime_registry.set_value(
-        CONFIG_VAR_UTLS_HIGH_WMARK_DEK_CACHE_SIZE,
-        static_cast<int64_t>(std::max(m_sys_vars.utls_high_wmark_dek_cache_size, 0LU)),
-        change_reason::AutoCorrected, "Minimum 0");
-    m_runtime_registry.set_value(
-        CONFIG_VAR_UTLS_LOW_WMARK_DEK_CACHE_SIZE,
-        static_cast<int64_t>(std::max(m_sys_vars.utls_low_wmark_dek_cache_size, 0LU)),
-        change_reason::AutoCorrected, "Minimum 0");
     if (m_sys_vars.utls_low_wmark_dek_cache_size >= m_sys_vars.utls_high_wmark_dek_cache_size) {
         m_runtime_registry.set_value(
             CONFIG_VAR_UTLS_LOW_WMARK_DEK_CACHE_SIZE,

--- a/src/core/util/utils.cpp
+++ b/src/core/util/utils.cpp
@@ -1268,7 +1268,7 @@ int validate_lro(int if_index)
     int ret = -1;
     int fd = -1;
     struct ifreq req;
-    struct ethtool_value eval;
+    struct ethtool_value eval = {};
 
     fd = SYSCALL(socket, AF_INET, SOCK_DGRAM, 0);
     if (fd < 0) {

--- a/tools/daemon/daemon.c
+++ b/tools/daemon/daemon.c
@@ -376,7 +376,7 @@ ssize_t sys_sendto(int sockfd, const void *buf, size_t len, int flags,
     nb = 0;
     do {
         n = sendto(sockfd, data, len, flags, dest_addr, addrlen);
-        if (n <= 0) {
+        if (n < 0) {
             if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR) {
                 if (flags & MSG_DONTWAIT) {
                     break;
@@ -384,6 +384,9 @@ ssize_t sys_sendto(int sockfd, const void *buf, size_t len, int flags,
                 continue;
             }
             return -errno;
+        }
+        if (n == 0) {
+            break;
         }
         len -= n;
         data += n;


### PR DESCRIPTION
## Description
Clang version in CSbuild is old, and needs to be updated

##### What
Upgrade Clang-tools-extra from 18.1 to 19.1

##### Why ?
[HPCINFRA-3581](https://jirasw.nvidia.com/browse/HPCINFRA-3581)

##### How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc._

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in network queue operations with proper state tracking.
  * Fixed uninitialized memory access in system configuration to prevent undefined behavior.
  * Enhanced system call error handling for better reliability.

* **Refactor**
  * Simplified cache configuration validation logic.

* **Chores**
  * Updated build infrastructure and toolchain configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->