### PR TITLE
[CI] issue: HPCINFRA-3633 Migrate CI test steps to containers - Test

### DIFF
--- a/.ci/dockerfiles/Dockerfile.ubuntu22.04
+++ b/.ci/dockerfiles/Dockerfile.ubuntu22.04
@@ -18,6 +18,22 @@ RUN apt-get update && \
     valgrind \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
+FROM tests AS test
+RUN apt-get update && \
+    apt-get install -y \
+    openssh-server psmisc \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+# setup ssh server and passwordless login for root for tests flows (verifyer.pl)
+RUN mkdir -p /var/run/sshd ~/.ssh && \
+    rm -rf ~/.ssh/id_rsa* && ssh-keygen -t rsa -N '' -f ~/.ssh/id_rsa && \
+    cat ~/.ssh/id_rsa.pub > ~/.ssh/authorized_keys && \
+    sed -i 's|#PermitRootLogin.*|PermitRootLogin without-password|g' /etc/ssh/sshd_config && \
+    sed -i 's|#PasswordAuthentication.*|PasswordAuthentication no|g' /etc/ssh/sshd_config && \
+    echo "Host *" >> ~/.ssh/config && \
+    echo "   StrictHostKeyChecking no" >> ~/.ssh/config && \
+    echo "   UserKnownHostsFile /dev/null" >> ~/.ssh/config && \
+    echo "   LogLevel ERROR" >> ~/.ssh/config
+
 # Style target, installs clang-format-15
 FROM build AS style
 RUN apt-get update \
@@ -26,4 +42,3 @@ RUN apt-get update \
  && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-15 100 \
                     --slave /usr/bin/clang++ clang++ /usr/bin/clang++-15 \
  && apt-get clean && rm -rf /var/lib/apt/lists/*
- 

--- a/.ci/matrix_job.yaml
+++ b/.ci/matrix_job.yaml
@@ -118,6 +118,23 @@ runs_on_dockers:
      cloud: swx-k8s-spray,
      namespace: xlio-ci
     }
+  - {
+      file: '.ci/dockerfiles/Dockerfile.ubuntu22.04',
+      arch: 'x86_64',
+      name: 'test',
+      uri: 'xlio/$arch/ubuntu22.04/$name',
+      tag: '20250219',
+      build_args: '--no-cache --target test',
+      category: 'tests',
+      annotations: [{ key: 'k8s.v1.cni.cncf.io/networks', value: 'sriov-cx6dx-p1' }],
+      limits: '{memory: 10Gi, cpu: 10000m, hugepages-2Mi: 10Gi, mellanox.com/sriov_cx6dx_p1: 1}',
+      requests: '{memory: 10Gi, cpu: 10000m, hugepages-2Mi: 10Gi, mellanox.com/sriov_cx6dx_p1: 1}',
+      caps_add: '[ IPC_LOCK, SYS_RESOURCE ]',
+      runAsUser: '0',
+      runAsGroup: '0',
+      cloud: swx-k8s-spray,
+      namespace: xlio-ci
+    }
 
 runs_on_agents:
   - {nodeLabel: 'beni09', category: 'base'}
@@ -153,6 +170,7 @@ steps:
   - name: Install Doca-host
     containerSelector:
       - "{category: 'base'}"
+      - "{category: 'tests'}"
       - "{name: 'vg'}"
     agentSelector:
       - "{nodeLabel: 'skip-agent'}"
@@ -189,6 +207,7 @@ steps:
     enable: ${do_build}
     containerSelector:
       - "{category: 'base'}"
+      - "{category: 'tests'}"
     agentSelector:
       - "{category: 'base'}"
     run: |
@@ -320,9 +339,9 @@ steps:
   - name: Test
     enable: ${do_test}
     containerSelector:
-      - "{name: 'skip-container'}"
+      - "{name: 'test'}"
     agentSelector:
-      - "{nodeLabel: 'beni09'}"
+      - "{nodeLabel: 'skip-agent'}"
     run: |
       [ "x${do_test}" == "xtrue" ] && action=yes || action=no
       env WORKSPACE=$PWD TARGET=${flags} jenkins_test_run=${action} ./contrib/test_jenkins.sh
@@ -385,6 +404,7 @@ steps:
     containerSelector:
       - "{category: 'base'}"
       - "{name: 'vg'}"
+      - "{category: 'tests'}"
     agentSelector:
       - "{nodeLabel: 'beni09'}"
     run: |

--- a/contrib/jenkins_tests/test.sh
+++ b/contrib/jenkins_tests/test.sh
@@ -2,22 +2,20 @@
 
 source $(dirname $0)/globals.sh
 
+# Fix hugepages for docker environments
+do_hugepages
+
 echo "Checking for test ..."
 if [ $(test -d ${install_dir} >/dev/null 2>&1 || echo $?) ]; then
 	echo "[SKIP] Not found ${install_dir} : build should be done before this stage"
 	exit 1
 fi
 
-if [ $(command -v ibdev2netdev >/dev/null 2>&1 || echo $?) ]; then
-	echo "[SKIP] ibdev2netdev tool does not exist"
-	exit 0
-fi
+cd ${WORKSPACE}
 
-cd $WORKSPACE
-
-rm -rf $test_dir
-mkdir -p $test_dir
-cd $test_dir
+rm -rf ${test_dir}
+mkdir -p ${test_dir}
+cd ${test_dir}
 
 test_app="sockperf"
 
@@ -29,68 +27,31 @@ cd sockperf
 if [ $(command -v ${test_app} >/dev/null 2>&1 || echo $?) ]; then
     set +e
     ./autogen.sh
-    ./configure --prefix=$PWD/install CPPFLAGS="-I${install_dir}/include"
+    ./configure --prefix=${PWD}/install CPPFLAGS="-I${install_dir}/include"
     make install
-    test_app="$PWD/install/bin/sockperf"
+    test_app="${PWD}/install/bin/sockperf"
     set -e
 
     if [ $(command -v ${test_app} >/dev/null 2>&1 || echo $?) ]; then
-        echo "[SKIP] $test_app does not exist"
+        echo "[SKIP] ${test_app} does not exist"
         exit 1
     fi
 else
     test_app="$(command -v ${test_app})"
 fi
 
-test_ip_list=""
 test_list="tcp-pp tcp-tp tcp-ul"
 test_lib=$install_dir/lib/${prj_lib}
 
-if [ ! -z "${test_remote_ip}" ] ; then
-	[[ "${test_remote_ip}" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]] || {\
-		echo ">> FAIL wrong ip address ${test_remote_ip}"
+if [[ -f /.dockerenv ]] || [[ -f /run/.containerenv ]] || [[ -n "${KUBERNETES_SERVICE_HOST}" ]]; then
+	test_ip_list_v4=$(ip -f inet addr show net1 | awk '/inet / {print $2}' | cut -d/ -f1)
+	test_ip_list_v6=$(ip -f inet6 addr show net1 | grep global | awk '/inet6 / {print $2}' | cut -d/ -f1)
+
+	if [ -z "${test_ip_list_v4}" ] || [ -z "${test_ip_list_v6}" ]; then
+		echo "ERROR: Cannot get IPv4/6 address of net1 interface!"
 		exit 1
-	}
-	test_ip_list="eth:${test_remote_ip}"
-	[ -z "${NODE_NAME}" ] && NODE_NAME=${HOSTNAME}
-	sperf_exec_dir="/tmp/sockperf_exec_${NODE_NAME}"
-	rmt_user=root
- 
-	rmt_os=$(${sudo_cmd} ssh ${rmt_user}@${test_remote_ip} ". /etc/os-release ; echo \${NAME,,} | awk '{print \$1}'")
-	[ ! -z "${test_remote_rebuild}" ] && rmt_os="rebuld"
-	local_os=$(. /etc/os-release ; echo ${NAME,,} | awk '{print $1}')
-
-	#skip_remote_prep=1
-	if [ -z "${skip_remote_prep}" ] ; then
-		${sudo_cmd} ssh ${rmt_user}@${test_remote_ip} "rm -rf ${sperf_exec_dir} && mkdir ${sperf_exec_dir}"
-
-		if [[ "${rmt_os}" =~ .*"${local_os}".* ]] ; then
-			${sudo_cmd} scp -q ${test_app} ${rmt_user}@${test_remote_ip}:${sperf_exec_dir}
-			${sudo_cmd} scp -q ${test_lib} ${rmt_user}@${test_remote_ip}:${sperf_exec_dir}
-			eval "pid=$(${sudo_cmd} ssh ${rmt_user}@${test_remote_ip} pidof ${prj_service})"
-			if [ ! -z "${pid}" ] ;  then 
-				echo "${prj_service} pid=${pid}"
-				eval "${sudo_cmd} ssh ${rmt_user}@${test_remote_ip} kill -9 ${pid}"
-			fi
-			${sudo_cmd} scp -q ${install_dir}/sbin/${prj_service} ${rmt_user}@${test_remote_ip}:${sperf_exec_dir}
-			eval "${sudo_cmd} ssh ${rmt_user}@${test_remote_ip} ${sudo_cmd} ${sperf_exec_dir}/${prj_service} &"
-		else
-			${sudo_cmd} -E rsync -q -I -a -r --exclude jenkins --exclude '*.o' --exclude '.deps' --exclude '*.l*' \
-			-e ssh ${WORKSPACE} ${rmt_user}@${test_remote_ip}:${sperf_exec_dir}
-			${sudo_cmd} scp -q ${test_dir}/sockperf_v2.zip ${rmt_user}@${test_remote_ip}:${sperf_exec_dir}
-			if [ $? -eq 0 ] ; then
-				subdir=${WORKSPACE##*/}
-				cmd="cd ${sperf_exec_dir}/${subdir} && "
-				cmd+="./autogen.sh && ./configure && make ${make_opt} && "
-				cmd+="cp src/core/.libs/*.so ${sperf_exec_dir} &&"
-				cmd+="cd ${sperf_exec_dir} && "
-				cmd+="unzip sockperf_v2.zip && cd sockperf-sockperf_v2 && "
-				cmd+="./autogen.sh && ./configure && make ${make_opt} && cp sockperf ${sperf_exec_dir}"
-				${sudo_cmd} ssh ${rmt_user}@${test_remote_ip} "${cmd}"
-			else
-				exit 1
-			fi
-		fi
+	else
+		test_ip_list="eth_ip4:${test_ip_list_v4} eth_ip6:${test_ip_list_v6}"
 	fi
 else
 	if [ ! -z $(do_get_ip 'ib') ]; then
@@ -104,42 +65,23 @@ else
 	fi
 fi
 
+# start the ssh server as verifyer.pl requiers
+/etc/init.d/ssh start
+
 nerrors=0
 
-for test_link in $test_ip_list; do
-	for test in $test_list; do
+for test_link in ${test_ip_list}; do
+	for test in ${test_list}; do
 		IFS=':' read test_in test_ip <<< "$test_link"
 		test_name=${test_in}-${test}
 		test_tap=${WORKSPACE}/${prefix}/test-${test_name}.tap
 
 		for i in $(seq 3); do
-			if [ ! -z "${test_remote_ip}" ] ; then
+			${sudo_cmd} ${timeout_exe} ${PWD}/tests/verifier/verifier.pl -a ${test_app} -x " --debug  " \
+				-t ${test}:tc[1-9]$ -s ${test_ip} -l ${test_dir}/${test_name}.log \
+				-e " LD_PRELOAD=${test_lib} " --progress=0
 
-				eval "pid=$(${sudo_cmd} pidof ${prj_service})"
-				[ ! -z "${pid}" ] && eval "${sudo_cmd} kill -9 ${pid}" 
-				eval "${sudo_cmd} ${install_dir}/sbin/${prj_service} --console -v5 & "
-
-				echo "BUILD_NUMBER=${BUILD_NUMBER}"
-				eval "pid=$(${sudo_cmd} ssh ${rmt_user}@${test_remote_ip} pidof ${prj_service})"
-				if [ ! -z "${pid}" ] ;  then
-					echo "${prj_service} pid=${pid}"
-					eval "${sudo_cmd} ssh ${rmt_user}@${test_remote_ip} kill -9 ${pid}"
-				fi
-				${sudo_cmd} scp -q ${install_dir}/sbin/${prj_service} ${rmt_user}@${test_remote_ip}:${sperf_exec_dir}
-				eval "${sudo_cmd} ssh ${rmt_user}@${test_remote_ip} ${sudo_cmd} ${sperf_exec_dir}/${prj_service} &"
-
-				vutil="$(dirname $0)/vutil.sh"
-				[ ! -e "${vutil}" ] && { echo "error vutil not found" ; exit 1 ; }
-
-				${sudo_cmd} $timeout_exe ${vutil}  -a "${test_app}" -x "--load-vma=${test_lib} " -t "${test}:tc[1-9]$" \
-						-s "${test_remote_ip}" -p "${test_remote_port}" -l "${test_dir}/${test_name}.log"
-			else
-				${sudo_cmd} $timeout_exe $PWD/tests/verifier/verifier.pl -a ${test_app} -x " --load-vma=$test_lib " \
-					-t ${test}:tc[1-9]$ -s ${test_ip} -l ${test_dir}/${test_name}.log \
-					--progress=0
-			fi
-
-			cp $PWD/${test_name}.dump ${test_dir}/${test_name}.dump
+			cp ${PWD}/${test_name}.dump ${test_dir}/${test_name}.dump
 			if grep -q 'FAIL' ${test_dir}/${test_name}.dump; then
 				rm -fv ${test_dir}/${test_name}.log ${test_dir}/${test_name}.dump
 			else
@@ -150,20 +92,20 @@ for test_link in $test_ip_list; do
 
 		do_archive "${test_dir}/${test_name}.dump" "${test_dir}/${test_name}.log"
 
-		echo "1..$(wc -l < ${test_dir}/${test_name}.tmp)" > $test_tap
+		echo "1..$(wc -l < ${test_dir}/${test_name}.tmp)" > ${test_tap}
 
 		v1=1
 		while read line; do
-		    if [[ $(echo $line | cut -f1 -d' ') =~ 'PASS' ]]; then
+		    if [[ $(echo ${line} | cut -f1 -d' ') =~ 'PASS' ]]; then
 		        v0='ok'
-		        v2=$(echo $line | sed 's/PASS //')
+		        v2=$(echo ${line} | sed 's/PASS //')
 		    else
 		        v0='not ok'
-		        v2=$(echo $line | sed 's/FAIL //')
+		        v2=$(echo ${line} | sed 's/FAIL //')
 	            nerrors=$((nerrors+1))
 		    fi
 
-		    echo -e "$v0 ${test_in}: $v2" >> $test_tap
+		    echo -e "$v0 ${test_in}: $v2" >> ${test_tap}
 		    v1=$(($v1+1))
 		done < ${test_dir}/${test_name}.tmp
 		rm -f ${test_dir}/${test_name}.tmp
@@ -172,5 +114,5 @@ done
 
 rc=$(($rc+$nerrors))
 
-echo "[${0##*/}]..................exit code = $rc"
-exit $rc
+echo "[${0##*/}]..................exit code = ${rc}"
+exit ${rc}


### PR DESCRIPTION
## Description
Today we use benni09 static agent to run test/gtest/valgrind steps which
is unscaleable since it can only run one pipeline at a time, causing
delays in builds that can be stuck waiting for hours

The idea is to move these steps to containers, allowing running them in
parallel as well as running multiple pipelines at the same time
(depending on the capacity of the k8s cluster)

##### What
Moves test away from static agent to container running on k8s

##### Why ?
[HPCINFRA-3633](https://jirasw.nvidia.com/browse/HPCINFRA-3633)


## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

