### PR TITLE
 4367367 - Product xlio zc api

### DIFF
--- a/contrib/jenkins_tests/gtest.sh
+++ b/contrib/jenkins_tests/gtest.sh
@@ -115,6 +115,19 @@ echo "{}" > /tmp/test.json
 eval "${sudo_cmd} $timeout_exe env XLIO_USE_NEW_CONFIG=1 XLIO_CONFIG_FILE=/tmp/test.json LD_PRELOAD=$gtest_lib $gtest_app $gtest_opt --gtest_filter=keep_alive* --gtest_output=xml:${WORKSPACE}/${prefix}/test-keepalive_ipv4.xml"
 rc=$(($rc+$?))
 
+
+
+# XLIO ZC API
+
+#IPV4
+eval "${sudo_cmd} $timeout_exe env GTEST_TAP=2 LD_PRELOAD=$gtest_lib $gtest_app $gtest_opt --gtest_filter=zc_api_xlio* --gtest_output=xml:${WORKSPACE}/${prefix}/test-zc_api.xml"
+rc=$(($rc+$?))
+
+#IPV6
+eval "${sudo_cmd} $timeout_exe env GTEST_TAP=2 LD_PRELOAD=$gtest_lib $gtest_app $gtest_opt_ipv6 --gtest_filter=zc_api_xlio* --gtest_output=xml:${WORKSPACE}/${prefix}/test-zc_api-ipv6.xml"
+rc=$(($rc+$?))
+
+
 eval "${sudo_cmd} pkill -9 ${prj_service} 2>/dev/null || true"
 
 set -eE

--- a/src/core/dev/rfs.h
+++ b/src/core/dev/rfs.h
@@ -66,8 +66,8 @@ public:
      */
     bool attach_flow(sockinfo *sink); // Add a sink. If this is the first sink --> map the sink
                                       // and attach flow to QP
-    bool detach_flow(sockinfo *sink); // Delete a sink. If this is the last sink --> delete it
-                                      // and detach flow from QP
+    // Delete a sink. If this is the last sink --> delete it and detach flow from QP
+    bool detach_flow(sockinfo *sink, rfs_rule **rule_extract);
 #ifdef DEFINED_UTLS
     rfs_rule *create_rule(xlio_tir *tir,
                           const flow_tuple &flow_spec); // Create a duplicate rule which points to
@@ -95,7 +95,7 @@ protected:
     dpcp::match_params m_match_mask;
 
     bool create_flow(); // Attach flow to all queues
-    bool destroy_flow(); // Detach flow from all queues
+    bool destroy_flow(rfs_rule **rule_extract); // Detach flow from all queues
     bool add_sink(sockinfo *p_sink);
     bool del_sink(sockinfo *p_sink);
     void prepare_flow_spec_eth_ip(const ip_address &dst_ip, const ip_address &src_ip);

--- a/src/core/dev/ring.h
+++ b/src/core/dev/ring.h
@@ -49,7 +49,7 @@ public:
     virtual uint64_t get_rx_cq_out_of_buffer_drop() = 0;
 
     virtual bool attach_flow(flow_tuple &flow_spec_5t, sockinfo *sink, bool force_5t = false) = 0;
-    virtual bool detach_flow(flow_tuple &flow_spec_5t, sockinfo *sink) = 0;
+    virtual bool detach_flow(flow_tuple &flow_spec_5t, sockinfo *sink, rfs_rule **rule_extract) = 0;
 
     virtual void restart() = 0;
 

--- a/src/core/dev/ring.h
+++ b/src/core/dev/ring.h
@@ -221,6 +221,10 @@ public:
     struct tcp_seg *get_tcp_segs(uint32_t num);
     void put_tcp_segs(struct tcp_seg *seg);
 
+    // XLIO ZC API
+    void set_poll_group(poll_group *p_group) { m_p_group = p_group; }
+    poll_group *get_poll_group() const { return m_p_group; }
+
 protected:
     inline void set_parent(ring *parent) { m_parent = (parent ? parent : this); }
     inline void set_if_index(int if_index) { m_if_index = if_index; }
@@ -231,6 +235,9 @@ protected:
     struct tcp_seg *m_tcp_seg_list = nullptr;
     uint32_t m_tcp_seg_count = 0U;
     lock_spin_recursive m_tcp_seg_lock;
+
+    // XLIO ZC API
+    poll_group *m_p_group = nullptr;
 
     int m_if_index = 0; /* Interface index */
 };

--- a/src/core/dev/ring.h
+++ b/src/core/dev/ring.h
@@ -55,7 +55,7 @@ public:
 
     // Get/Release memory buffer descriptor with a linked data memory buffer
     virtual mem_buf_desc_t *mem_buf_tx_get(ring_user_id_t id, bool b_block, pbuf_type type,
-                                           int n_num_mem_bufs = 1) = 0;
+                                           int n_num_mem_bufs = 1, bool tx_skip_poll = false) = 0;
     virtual int mem_buf_tx_release(mem_buf_desc_t *p_mem_buf_desc_list, bool b_accounting,
                                    bool trylock = false) = 0;
     virtual void mem_buf_rx_release(mem_buf_desc_t *p_mem_buf_desc)

--- a/src/core/dev/ring_bond.cpp
+++ b/src/core/dev/ring_bond.cpp
@@ -339,12 +339,13 @@ void ring_bond::adapt_cq_moderation()
 }
 
 mem_buf_desc_t *ring_bond::mem_buf_tx_get(ring_user_id_t id, bool b_block, pbuf_type type,
-                                          int n_num_mem_bufs /* default = 1 */)
+                                          int n_num_mem_bufs /* default = 1 */,
+                                          bool tx_skip_poll /* default = false */)
 {
     mem_buf_desc_t *ret = nullptr;
 
     std::lock_guard<decltype(m_lock_ring_tx)> lock(m_lock_ring_tx);
-    ret = m_xmit_rings[id]->mem_buf_tx_get(id, b_block, type, n_num_mem_bufs);
+    ret = m_xmit_rings[id]->mem_buf_tx_get(id, b_block, type, n_num_mem_bufs, tx_skip_poll);
 
     return ret;
 }

--- a/src/core/dev/ring_bond.cpp
+++ b/src/core/dev/ring_bond.cpp
@@ -91,7 +91,7 @@ bool ring_bond::attach_flow(flow_tuple &flow_spec_5t, sockinfo *sink, bool force
     return ret;
 }
 
-bool ring_bond::detach_flow(flow_tuple &flow_spec_5t, sockinfo *sink)
+bool ring_bond::detach_flow(flow_tuple &flow_spec_5t, sockinfo *sink, rfs_rule **rule_extract)
 {
     bool ret = true;
     struct flow_sink_t value = {flow_spec_5t, sink};
@@ -108,7 +108,7 @@ bool ring_bond::detach_flow(flow_tuple &flow_spec_5t, sockinfo *sink)
     }
 
     for (uint32_t i = 0; i < m_recv_rings.size(); i++) {
-        bool step_ret = m_recv_rings[i]->detach_flow(flow_spec_5t, sink);
+        bool step_ret = m_recv_rings[i]->detach_flow(flow_spec_5t, sink, rule_extract);
         ret = ret && step_ret;
     }
 

--- a/src/core/dev/ring_bond.h
+++ b/src/core/dev/ring_bond.h
@@ -48,7 +48,7 @@ public:
     virtual bool detach_flow(flow_tuple &flow_spec_5t, sockinfo *sink);
     virtual void restart();
     virtual mem_buf_desc_t *mem_buf_tx_get(ring_user_id_t id, bool b_block, pbuf_type type,
-                                           int n_num_mem_bufs = 1);
+                                           int n_num_mem_bufs = 1, bool tx_skip_poll = false);
     virtual int mem_buf_tx_release(mem_buf_desc_t *p_mem_buf_desc_list, bool b_accounting,
                                    bool trylock = false);
     virtual void inc_tx_retransmissions_stats(ring_user_id_t id);

--- a/src/core/dev/ring_bond.h
+++ b/src/core/dev/ring_bond.h
@@ -45,7 +45,7 @@ public:
                                                            void *pv_fd_ready_array = nullptr);
     virtual int get_num_resources() const { return m_bond_rings.size(); };
     virtual bool attach_flow(flow_tuple &flow_spec_5t, sockinfo *sink, bool force_5t = false);
-    virtual bool detach_flow(flow_tuple &flow_spec_5t, sockinfo *sink);
+    virtual bool detach_flow(flow_tuple &flow_spec_5t, sockinfo *sink, rfs_rule **rule_extract);
     virtual void restart();
     virtual mem_buf_desc_t *mem_buf_tx_get(ring_user_id_t id, bool b_block, pbuf_type type,
                                            int n_num_mem_bufs = 1, bool tx_skip_poll = false);

--- a/src/core/dev/ring_simple.cpp
+++ b/src/core/dev/ring_simple.cpp
@@ -491,7 +491,8 @@ int ring_simple::drain_and_proccess()
 }
 
 mem_buf_desc_t *ring_simple::mem_buf_tx_get(ring_user_id_t id, bool b_block, pbuf_type type,
-                                            int n_num_mem_bufs /* default = 1 */)
+                                            int n_num_mem_bufs /* default = 1 */,
+                                            bool tx_skip_poll /* default = false */)
 {
     NOT_IN_USE(id);
     int ret = 0;
@@ -505,7 +506,9 @@ mem_buf_desc_t *ring_simple::mem_buf_tx_get(ring_user_id_t id, bool b_block, pbu
     while (!buff_list) {
 
         // Try to poll once in the hope that we get a few freed tx mem_buf_desc
-        ret = m_p_cq_mgr_tx->poll_and_process_element_tx(&poll_sn);
+        if (!tx_skip_poll) {
+            ret = m_p_cq_mgr_tx->poll_and_process_element_tx(&poll_sn);
+        }
         if (ret < 0) {
             ring_logdbg("failed polling on cq_mgr_tx (hqtx=%p, cq_mgr_tx=%p) (ret=%d %m)", m_hqtx,
                         m_p_cq_mgr_tx, ret);

--- a/src/core/dev/ring_simple.h
+++ b/src/core/dev/ring_simple.h
@@ -61,7 +61,8 @@ public:
     void stop_active_queue_tx();
     void stop_active_queue_rx();
     mem_buf_desc_t *mem_buf_tx_get(ring_user_id_t id, bool b_block, pbuf_type type,
-                                   int n_num_mem_bufs = 1) override;
+                                   int n_num_mem_bufs = 1 /* default = 1 */,
+                                   bool tx_skip_poll = false) override;
     int mem_buf_tx_release(mem_buf_desc_t *p_mem_buf_desc_list, bool b_accounting,
                            bool trylock = false) override;
     void send_ring_buffer(ring_user_id_t id, xlio_ibv_send_wr *p_send_wqe,

--- a/src/core/dev/ring_slave.cpp
+++ b/src/core/dev/ring_slave.cpp
@@ -587,6 +587,7 @@ bool ring_slave::rx_process_buffer(mem_buf_desc_t *p_rx_wc_buf_desc, void *pv_fd
         if (likely(si) && si->is_xlio_socket() &&
             unlikely(si->get_poll_group() == nullptr ||
                      si->get_poll_group() != this->get_poll_group())) {
+            m_p_ring_stat->simple.n_rx_zc_migiration_drop++;
             return false;
         }
 

--- a/src/core/dev/ring_slave.cpp
+++ b/src/core/dev/ring_slave.cpp
@@ -584,6 +584,11 @@ bool ring_slave::rx_process_buffer(mem_buf_desc_t *p_rx_wc_buf_desc, void *pv_fd
         assert(g_p_fd_collection);
         si = static_cast<sockinfo *>(
             g_p_fd_collection->get_sockfd(p_rx_wc_buf_desc->rx.flow_tag_id - 1));
+        if (likely(si) && si->is_xlio_socket() &&
+            unlikely(si->get_poll_group() == nullptr ||
+                     si->get_poll_group() != this->get_poll_group())) {
+            return false;
+        }
 
         if (likely(si)) {
             // will process packets with set flow_tag_id and enabled for the socket

--- a/src/core/dev/ring_slave.cpp
+++ b/src/core/dev/ring_slave.cpp
@@ -382,7 +382,8 @@ bool ring_slave::attach_flow(flow_tuple &flow_spec_5t, sockinfo *sink, bool forc
 }
 
 template <typename KEY4T, typename KEY2T, typename HDR>
-bool steering_handler<KEY4T, KEY2T, HDR>::detach_flow(flow_tuple &flow_spec_5t, sockinfo *sink)
+bool steering_handler<KEY4T, KEY2T, HDR>::detach_flow(flow_tuple &flow_spec_5t, sockinfo *sink,
+                                                      rfs_rule **rule_extract)
 {
     rfs *p_rfs = nullptr;
 
@@ -415,7 +416,7 @@ bool steering_handler<KEY4T, KEY2T, HDR>::detach_flow(flow_tuple &flow_spec_5t, 
         BULLSEYE_EXCLUDE_BLOCK_END
 
         p_rfs = itr->second;
-        p_rfs->detach_flow(sink);
+        p_rfs->detach_flow(sink, rule_extract);
         if (!keep_in_map) {
             m_ring.m_udp_uc_dst_port_attach_map.erase(
                 m_ring.m_udp_uc_dst_port_attach_map.find(rule_key));
@@ -450,7 +451,7 @@ bool steering_handler<KEY4T, KEY2T, HDR>::detach_flow(flow_tuple &flow_spec_5t, 
         }
         BULLSEYE_EXCLUDE_BLOCK_END
         p_rfs = itr->second;
-        p_rfs->detach_flow(sink);
+        p_rfs->detach_flow(sink, rule_extract);
         if (!keep_in_map) {
             m_ring.m_l2_mc_ip_attach_map.erase(m_ring.m_l2_mc_ip_attach_map.find(rule_key));
         }
@@ -486,7 +487,7 @@ bool steering_handler<KEY4T, KEY2T, HDR>::detach_flow(flow_tuple &flow_spec_5t, 
         BULLSEYE_EXCLUDE_BLOCK_END
 
         p_rfs = itr->second;
-        p_rfs->detach_flow(sink);
+        p_rfs->detach_flow(sink, rule_extract);
         if (!keep_in_map) {
             m_ring.m_tcp_dst_port_attach_map.erase(m_ring.m_tcp_dst_port_attach_map.find(rule_key));
         }
@@ -506,12 +507,13 @@ bool steering_handler<KEY4T, KEY2T, HDR>::detach_flow(flow_tuple &flow_spec_5t, 
     return true;
 }
 
-bool ring_slave::detach_flow(flow_tuple &flow_spec_5t, sockinfo *sink)
+bool ring_slave::detach_flow(flow_tuple &flow_spec_5t, sockinfo *sink, rfs_rule **rule_extract)
 {
     std::lock_guard<decltype(m_lock_ring_rx)> lock(m_lock_ring_rx);
 
-    return (flow_spec_5t.get_family() == AF_INET ? m_steering_ipv4.detach_flow(flow_spec_5t, sink)
-                                                 : m_steering_ipv6.detach_flow(flow_spec_5t, sink));
+    return (flow_spec_5t.get_family() == AF_INET
+                ? m_steering_ipv4.detach_flow(flow_spec_5t, sink, rule_extract)
+                : m_steering_ipv6.detach_flow(flow_spec_5t, sink, rule_extract));
 }
 
 #ifdef DEFINED_UTLS

--- a/src/core/dev/ring_slave.h
+++ b/src/core/dev/ring_slave.h
@@ -280,6 +280,10 @@ public:
 
     bool m_active; /* State indicator */
 
+    virtual mem_buf_desc_t *mem_buf_tx_get(ring_user_id_t id, bool b_block, pbuf_type type,
+                                           int n_num_mem_bufs = 1 /* default = 1 */,
+                                           bool tx_skip_poll = false) = 0;
+
 protected:
     bool request_more_tx_buffers(pbuf_type type, uint32_t count, uint32_t lkey);
     void flow_del_all_rfs();

--- a/src/core/dev/ring_slave.h
+++ b/src/core/dev/ring_slave.h
@@ -222,7 +222,7 @@ public:
     }
 
     bool attach_flow(flow_tuple &flow_spec_5t, sockinfo *sink, bool force_5t = false);
-    bool detach_flow(flow_tuple &flow_spec_5t, sockinfo *sink);
+    bool detach_flow(flow_tuple &flow_spec_5t, sockinfo *sink, rfs_rule **rule_extract);
 
     inline bool rx_process_buffer_no_flow_id(mem_buf_desc_t *p_rx_wc_buf_desc,
                                              void *pv_fd_ready_array, HDR *p_ip_h);
@@ -267,7 +267,7 @@ public:
     virtual void inc_cq_moderation_stats() = 0;
 
     virtual bool attach_flow(flow_tuple &flow_spec_5t, sockinfo *sink, bool force_5t = false);
-    virtual bool detach_flow(flow_tuple &flow_spec_5t, sockinfo *sink);
+    virtual bool detach_flow(flow_tuple &flow_spec_5t, sockinfo *sink, rfs_rule **rule_extract);
 
 #ifdef DEFINED_UTLS
     /* Call this method in an RX ring. */

--- a/src/core/dev/ring_tap.cpp
+++ b/src/core/dev/ring_tap.cpp
@@ -220,7 +220,7 @@ bool ring_tap::attach_flow(flow_tuple &flow_spec_5t, sockinfo *sink, bool force_
             if (!g_b_exit) {
                 ring_logwarn("Add TC rule failed with error=%d", rc);
             }
-            ring_slave::detach_flow(flow_spec_5t, sink);
+            ring_slave::detach_flow(flow_spec_5t, sink, nullptr);
             ret = false;
         }
     }
@@ -228,10 +228,10 @@ bool ring_tap::attach_flow(flow_tuple &flow_spec_5t, sockinfo *sink, bool force_
     return ret;
 }
 
-bool ring_tap::detach_flow(flow_tuple &flow_spec_5t, sockinfo *sink)
+bool ring_tap::detach_flow(flow_tuple &flow_spec_5t, sockinfo *sink, rfs_rule **rule_extract)
 {
     std::lock_guard<decltype(m_lock_ring_rx)> lock(m_lock_ring_rx);
-    bool ret = ring_slave::detach_flow(flow_spec_5t, sink);
+    bool ret = ring_slave::detach_flow(flow_spec_5t, sink, rule_extract);
 
     if (flow_spec_5t.is_tcp() || flow_spec_5t.is_udp_uc()) {
         int rc = 0;

--- a/src/core/dev/ring_tap.cpp
+++ b/src/core/dev/ring_tap.cpp
@@ -441,13 +441,15 @@ bool ring_tap::request_more_rx_buffers()
 }
 
 mem_buf_desc_t *ring_tap::mem_buf_tx_get(ring_user_id_t id, bool b_block, pbuf_type type,
-                                         int n_num_mem_bufs)
+                                         int n_num_mem_bufs /* default = 1 */,
+                                         bool tx_skip_poll /* default = false */)
 {
     mem_buf_desc_t *head = nullptr;
 
     NOT_IN_USE(id);
     NOT_IN_USE(b_block);
     NOT_IN_USE(type);
+    NOT_IN_USE(tx_skip_poll);
 
     ring_logfuncall("n_num_mem_bufs=%d", n_num_mem_bufs);
 

--- a/src/core/dev/ring_tap.h
+++ b/src/core/dev/ring_tap.h
@@ -42,7 +42,7 @@ public:
     virtual void mem_buf_desc_return_single_to_owner_tx(mem_buf_desc_t *p_mem_buf_desc);
     virtual void mem_buf_desc_return_single_multi_ref(mem_buf_desc_t *p_mem_buf_desc, unsigned ref);
     virtual mem_buf_desc_t *mem_buf_tx_get(ring_user_id_t id, bool b_block, pbuf_type type,
-                                           int n_num_mem_bufs = 1);
+                                           int n_num_mem_bufs = 1, bool tx_skip_poll = false);
     virtual int mem_buf_tx_release(mem_buf_desc_t *p_mem_buf_desc_list, bool b_accounting,
                                    bool trylock = false);
     virtual bool get_hw_dummy_send_support(ring_user_id_t id, xlio_ibv_send_wr *p_send_wqe)

--- a/src/core/dev/ring_tap.h
+++ b/src/core/dev/ring_tap.h
@@ -17,7 +17,7 @@ public:
 
     virtual bool is_up() { return (m_vf_ring || m_active); }
     virtual bool attach_flow(flow_tuple &flow_spec_5t, sockinfo *sink, bool force_5t = false);
-    virtual bool detach_flow(flow_tuple &flow_spec_5t, sockinfo *sink);
+    virtual bool detach_flow(flow_tuple &flow_spec_5t, sockinfo *sink, rfs_rule **rule_extract);
     virtual bool poll_and_process_element_rx(uint64_t *p_cq_poll_sn,
                                              void *pv_fd_ready_array = NULL);
     virtual int poll_and_process_element_tx(uint64_t *p_cq_poll_sn)

--- a/src/core/event/event_handler_manager.cpp
+++ b/src/core/event/event_handler_manager.cpp
@@ -156,9 +156,19 @@ void event_handler_manager::unregister_timers_event_and_delete(timer_handler *ha
     post_new_reg_action(reg_action);
 }
 
-void event_handler_manager::unregister_socket_timer_and_delete(sockinfo_tcp *sock_tcp)
+void event_handler_manager::unregister_socket_timer_event(sockinfo_tcp *sock_tcp)
 {
     evh_logdbg("Unregistering TCP socket timer: %p", sock_tcp);
+    reg_action_t reg_action;
+    memset(&reg_action, 0, sizeof(reg_action));
+    reg_action.type = UNREGISTER_TCP_SOCKET_TIMER;
+    reg_action.info.timer.user_data = sock_tcp;
+    post_new_reg_action(reg_action);
+}
+
+void event_handler_manager::unregister_socket_timer_and_delete(sockinfo_tcp *sock_tcp)
+{
+    evh_logdbg("Unregistering TCP socket timer and destroying: %p", sock_tcp);
     reg_action_t reg_action;
     memset(&reg_action, 0, sizeof(reg_action));
     reg_action.type = UNREGISTER_TCP_SOCKET_TIMER_AND_DELETE;
@@ -421,6 +431,8 @@ const char *event_handler_manager::reg_action_str(event_action_type_e reg_action
     switch (reg_action_type) {
     case REGISTER_TCP_SOCKET_TIMER:
         return "REGISTER_TCP_SOCKET_TIMER";
+    case UNREGISTER_TCP_SOCKET_TIMER:
+        return "UNREGISTER_TCP_SOCKET_TIMER";
     case UNREGISTER_TCP_SOCKET_TIMER_AND_DELETE:
         return "UNREGISTER_TCP_SOCKET_TIMER_AND_DELETE";
     case REGISTER_TIMER:
@@ -702,6 +714,10 @@ void event_handler_manager::handle_registration_action(reg_action_t &reg_action)
     case REGISTER_TCP_SOCKET_TIMER:
         sock = reinterpret_cast<sockinfo_tcp *>(reg_action.info.timer.user_data);
         sock->get_tcp_timer_collection()->add_new_timer(sock);
+        break;
+    case UNREGISTER_TCP_SOCKET_TIMER:
+        sock = reinterpret_cast<sockinfo_tcp *>(reg_action.info.timer.user_data);
+        sock->get_tcp_timer_collection()->remove_timer(sock);
         break;
     case UNREGISTER_TCP_SOCKET_TIMER_AND_DELETE:
         sock = reinterpret_cast<sockinfo_tcp *>(reg_action.info.timer.user_data);

--- a/src/core/event/event_handler_manager.h
+++ b/src/core/event/event_handler_manager.h
@@ -28,6 +28,7 @@ typedef std::map<void * /*event_handler_id*/, event_handler_rdma_cm * /*p_event_
 
 typedef enum {
     REGISTER_TCP_SOCKET_TIMER,
+    UNREGISTER_TCP_SOCKET_TIMER,
     UNREGISTER_TCP_SOCKET_TIMER_AND_DELETE,
     REGISTER_TIMER,
     WAKEUP_TIMER, /* NOT AVAILABLE FOR GROUPED TIMERS */
@@ -167,6 +168,7 @@ public:
     void unregister_timers_event_and_delete(timer_handler *handler);
 
     void register_socket_timer_event(sockinfo_tcp *sock_tcp);
+    void unregister_socket_timer_event(sockinfo_tcp *sock_tcp);
     void unregister_socket_timer_and_delete(sockinfo_tcp *sock_tcp);
 
     void register_ibverbs_event(int fd, event_handler_ibverbs *handler, void *channel,

--- a/src/core/event/poll_group.cpp
+++ b/src/core/event/poll_group.cpp
@@ -211,7 +211,6 @@ void poll_group::add_socket(sockinfo_tcp *si)
 
 void poll_group::remove_socket(sockinfo_tcp *si)
 {
-    g_p_fd_collection->clear_socket(si->get_fd());
     m_sockets_list.erase(si);
     auto iter = std::find(m_dirty_sockets.begin(), m_dirty_sockets.end(), si);
     if (iter != std::end(m_dirty_sockets)) {
@@ -228,6 +227,7 @@ void poll_group::reuse_sockfd(int fd, sockinfo_tcp *si)
 
 void poll_group::close_socket(sockinfo_tcp *si, bool force /*=false*/)
 {
+    g_p_fd_collection->clear_socket(si->get_fd());
     remove_socket(si);
     if (si->prepare_to_close(force)) {
         // The socket is already closable.

--- a/src/core/event/poll_group.cpp
+++ b/src/core/event/poll_group.cpp
@@ -145,6 +145,7 @@ void poll_group::add_ring(ring *rng, ring_alloc_logic_attr *attr)
     if (std::find(m_rings.begin(), m_rings.end(), rng) == std::end(m_rings)) {
         grp_logdbg("New ring %p in group %p", rng, this);
         m_rings.push_back(rng);
+        rng->set_poll_group(this);
 
         /*
          * Take reference to the ring. This avoids a race between socket destruction and buffer

--- a/src/core/event/poll_group.cpp
+++ b/src/core/event/poll_group.cpp
@@ -81,7 +81,7 @@ poll_group::~poll_group()
     while (!m_sockets_list.empty()) {
         sockinfo_tcp *si = dynamic_cast<sockinfo_tcp *>(m_sockets_list.front());
         if (likely(si)) {
-            close_socket_ungracefully(si, true);
+            close_socket(si, true);
         }
     }
 
@@ -122,13 +122,11 @@ int poll_group::update(const struct xlio_poll_group_attr *attr)
 
 void poll_group::poll()
 {
-    if (m_is_sockets_to_close_dirty) {
-        for (auto si : m_sockets_to_close) {
-            close_socket_gracefully(si);
-        }
-        m_sockets_to_close.clear();
-        m_is_sockets_to_close_dirty = false;
+    if (unlikely(m_is_slow_path)) {
+        slow_path_run();
+        m_is_slow_path = false;
     }
+
     for (ring *rng : m_rings) {
         uint64_t sn = 0;
         rng->poll_and_process_element_tx(&sn);
@@ -136,6 +134,26 @@ void poll_group::poll()
         rng->poll_and_process_element_rx(&sn);
     }
     m_event_handler->do_tasks();
+}
+
+void poll_group::slow_path_run()
+{
+    for (auto &iter : m_slow_path_sockets) {
+        sockinfo_tcp *si = iter.second;
+
+        switch (iter.first) {
+        case POLL_GROUP_SOCKET_CLOSE:
+            close_socket(si);
+            break;
+        case POLL_GROUP_SOCKET_DESTROY:
+            m_pending_to_remove_lst.remove(si);
+            si->clean_socket_obj();
+            break;
+        default:
+            grp_logerr("Unknown operation in the slow path: %d.", iter.first);
+        }
+    }
+    m_slow_path_sockets.clear();
 }
 
 void poll_group::add_dirty_socket(sockinfo_tcp *si)
@@ -190,65 +208,44 @@ void poll_group::add_socket(sockinfo_tcp *si)
     // For the flow_tag fast path support.
     g_p_fd_collection->set_socket(si->get_fd(), si);
 }
-void poll_group::remove_socket_helper(sockinfo_tcp *si)
+
+void poll_group::remove_socket(sockinfo_tcp *si)
 {
+    g_p_fd_collection->clear_socket(si->get_fd());
     m_sockets_list.erase(si);
     auto iter = std::find(m_dirty_sockets.begin(), m_dirty_sockets.end(), si);
     if (iter != std::end(m_dirty_sockets)) {
         m_dirty_sockets.erase(iter);
     }
 }
-void poll_group::remove_socket(sockinfo_tcp *si)
-{
-    g_p_fd_collection->clear_socket(si->get_fd());
-    remove_socket_helper(si);
-}
 
-void poll_group::close_socket_gracefully(sockinfo_tcp *si)
-{
-    remove_socket_helper(si);
-    if (si->prepare_to_close()) {
-        // the socket is already closable
-        g_p_fd_collection->clear_socket(si->get_fd());
-        si->clean_socket_obj();
-    } else {
-        // The socket is not ready for close.
-        g_p_fd_collection->clear_socket(si->get_fd());
-        m_pending_to_remove_lst.push_back(si);
-    }
-}
-void poll_group::destroy_pending_to_remove_socket(sockinfo_tcp *si)
-{
-    m_pending_to_remove_lst.remove(si);
-    si->clean_socket_obj();
-}
 void poll_group::reuse_sockfd(int fd, sockinfo_tcp *si)
 {
     m_pending_to_remove_lst.remove(si);
     g_p_fd_collection->set_socket(fd, si);
     m_sockets_list.push_back(si);
 }
-void poll_group::mark_socket_to_close(sockinfo_tcp *si)
-{
-    m_sockets_to_close.push_back(si);
-    m_is_sockets_to_close_dirty = true;
-}
-void poll_group::close_socket_ungracefully(sockinfo_tcp *si, bool force /*=false*/)
+
+void poll_group::close_socket(sockinfo_tcp *si, bool force /*=false*/)
 {
     remove_socket(si);
-
-    bool closed = si->prepare_to_close(force);
-    if (closed) {
-        /*
-         * Current implementation forces TCP reset, so the socket is expected to be closable.
-         * Do a polling iteration to increase the chance that all the relevant WQEs are completed
-         * and XLIO emitted all the TX completion before the XLIO_SOCKET_EVENT_TERMINATED event.
-         *
-         * TODO Implement more reliable mechanism of deferred socket destruction if there are
-         * not completed TX operations.
-         */
-        m_is_sockets_to_close_dirty = false; // Prevent poll() from triggering graceful closes
-        poll();
+    if (si->prepare_to_close(force)) {
+        // The socket is already closable.
         si->clean_socket_obj();
+    } else {
+        // The socket is not ready for close.
+        m_pending_to_remove_lst.push_back(si);
     }
+}
+
+void poll_group::mark_socket_to_close(sockinfo_tcp *si)
+{
+    m_slow_path_sockets.push_back(std::make_pair(POLL_GROUP_SOCKET_CLOSE, si));
+    m_is_slow_path = true;
+}
+
+void poll_group::mark_socket_to_destroy(sockinfo_tcp *si)
+{
+    m_slow_path_sockets.push_back(std::make_pair(POLL_GROUP_SOCKET_DESTROY, si));
+    m_is_slow_path = true;
 }

--- a/src/core/event/poll_group.cpp
+++ b/src/core/event/poll_group.cpp
@@ -33,6 +33,7 @@ poll_group::poll_group(const struct xlio_poll_group_attr *attr)
     : m_socket_event_cb(attr->socket_event_cb)
     , m_socket_comp_cb(attr->socket_comp_cb)
     , m_socket_rx_cb(attr->socket_rx_cb)
+    , m_socket_accept_cb(attr->socket_accept_cb)
     , m_group_flags(attr->flags)
 {
     /*
@@ -175,7 +176,7 @@ void poll_group::add_socket(sockinfo_tcp *si)
     g_p_fd_collection->set_socket(si->get_fd(), si);
 }
 
-void poll_group::close_socket(sockinfo_tcp *si, bool force /*=false*/)
+void poll_group::remove_socket(sockinfo_tcp *si)
 {
     g_p_fd_collection->clear_socket(si->get_fd());
     m_sockets_list.erase(si);
@@ -184,6 +185,11 @@ void poll_group::close_socket(sockinfo_tcp *si, bool force /*=false*/)
     if (iter != std::end(m_dirty_sockets)) {
         m_dirty_sockets.erase(iter);
     }
+}
+
+void poll_group::close_socket(sockinfo_tcp *si, bool force /*=false*/)
+{
+    remove_socket(si);
 
     bool closed = si->prepare_to_close(force);
     if (closed) {

--- a/src/core/event/poll_group.h
+++ b/src/core/event/poll_group.h
@@ -37,12 +37,16 @@ public:
     void add_ring(ring *rng, ring_alloc_logic_attr *attr);
 
     void add_socket(sockinfo_tcp *si);
+    void remove_socket_helper(sockinfo_tcp *si);
     void remove_socket(sockinfo_tcp *si);
-    void close_socket(sockinfo_tcp *si, bool force = false);
-
+    void mark_socket_to_close(sockinfo_tcp *si);
+    void close_socket_gracefully(sockinfo_tcp *si);
+    void close_socket_ungracefully(sockinfo_tcp *si, bool force = false);
     unsigned get_flags() const { return m_group_flags; }
     event_handler_manager_local *get_event_handler() const { return m_event_handler.get(); }
     tcp_timers_collection *get_tcp_timers() const { return m_tcp_timers.get(); }
+    void destroy_pending_to_remove_socket(sockinfo_tcp *si);
+    void reuse_sockfd(int fd, sockinfo_tcp *si);
 
 public:
     xlio_socket_event_cb_t m_socket_event_cb;
@@ -57,7 +61,9 @@ private:
 
     unsigned m_group_flags;
     std::vector<sockinfo_tcp *> m_dirty_sockets;
-
+    std::vector<sockinfo_tcp *> m_sockets_to_close;
+    std::list<sockinfo_tcp *> m_pending_to_remove_lst;
+    bool m_is_sockets_to_close_dirty = false;
     sock_fd_api_list_t m_sockets_list;
     std::vector<std::pair<std::unique_ptr<ring_alloc_logic_attr>, net_device_val *>> m_rings_ref;
 };

--- a/src/core/event/poll_group.h
+++ b/src/core/event/poll_group.h
@@ -37,6 +37,7 @@ public:
     void add_ring(ring *rng, ring_alloc_logic_attr *attr);
 
     void add_socket(sockinfo_tcp *si);
+    void remove_socket(sockinfo_tcp *si);
     void close_socket(sockinfo_tcp *si, bool force = false);
 
     unsigned get_flags() const { return m_group_flags; }
@@ -47,6 +48,7 @@ public:
     xlio_socket_event_cb_t m_socket_event_cb;
     xlio_socket_comp_cb_t m_socket_comp_cb;
     xlio_socket_rx_cb_t m_socket_rx_cb;
+    xlio_socket_accept_cb_t m_socket_accept_cb;
 
 private:
     std::vector<ring *> m_rings;

--- a/src/core/event/poll_group.h
+++ b/src/core/event/poll_group.h
@@ -21,6 +21,12 @@ class ring_alloc_logic_attr;
 class sockinfo_tcp;
 class tcp_timers_collection;
 
+enum poll_group_socket_op {
+    POLL_GROUP_SOCKET_INVALID = 0,
+    POLL_GROUP_SOCKET_CLOSE,
+    POLL_GROUP_SOCKET_DESTROY,
+};
+
 class poll_group {
 public:
     poll_group(const struct xlio_poll_group_attr *attr);
@@ -37,16 +43,17 @@ public:
     void add_ring(ring *rng, ring_alloc_logic_attr *attr);
 
     void add_socket(sockinfo_tcp *si);
-    void remove_socket_helper(sockinfo_tcp *si);
     void remove_socket(sockinfo_tcp *si);
+    void reuse_sockfd(int fd, sockinfo_tcp *si);
+    void close_socket(sockinfo_tcp *si, bool force = false);
     void mark_socket_to_close(sockinfo_tcp *si);
-    void close_socket_gracefully(sockinfo_tcp *si);
-    void close_socket_ungracefully(sockinfo_tcp *si, bool force = false);
+    void mark_socket_to_destroy(sockinfo_tcp *si);
     unsigned get_flags() const { return m_group_flags; }
     event_handler_manager_local *get_event_handler() const { return m_event_handler.get(); }
     tcp_timers_collection *get_tcp_timers() const { return m_tcp_timers.get(); }
-    void destroy_pending_to_remove_socket(sockinfo_tcp *si);
-    void reuse_sockfd(int fd, sockinfo_tcp *si);
+
+private:
+    void slow_path_run();
 
 public:
     xlio_socket_event_cb_t m_socket_event_cb;
@@ -55,16 +62,17 @@ public:
     xlio_socket_accept_cb_t m_socket_accept_cb;
 
 private:
+    bool m_is_slow_path = false;
+    unsigned m_group_flags;
+
     std::vector<ring *> m_rings;
     std::unique_ptr<event_handler_manager_local> m_event_handler;
     std::unique_ptr<tcp_timers_collection> m_tcp_timers;
 
-    unsigned m_group_flags;
     std::vector<sockinfo_tcp *> m_dirty_sockets;
-    std::vector<sockinfo_tcp *> m_sockets_to_close;
+    std::vector<std::pair<enum poll_group_socket_op, sockinfo_tcp *>> m_slow_path_sockets;
     std::list<sockinfo_tcp *> m_pending_to_remove_lst;
-    bool m_is_sockets_to_close_dirty = false;
-    sock_fd_api_list_t m_sockets_list;
+    sockinfo_list_t m_sockets_list;
     std::vector<std::pair<std::unique_ptr<ring_alloc_logic_attr>, net_device_val *>> m_rings_ref;
 };
 

--- a/src/core/lwip/tcp_in.c
+++ b/src/core/lwip/tcp_in.c
@@ -313,10 +313,8 @@ static void tcp_listen_input(struct tcp_pcb *pcb, tcp_in_data *in_data)
     if (in_data->flags & TCP_ACK) {
         /* For incoming segments with the ACK flag set, respond with a RST. */
         LWIP_DEBUGF(TCP_RST_DEBUG, ("tcp_listen_input: ACK in LISTEN, sending reset\n"));
-#if 0
         tcp_rst(in_data->ackno + 1, in_data->seqno + in_data->tcplen, in_data->tcphdr->dest,
                 in_data->tcphdr->src, NULL);
-#endif
     } else if (in_data->flags & TCP_SYN) {
         LWIP_DEBUGF(TCP_DEBUG,
                     ("TCP connection request %" U16_F " -> %" U16_F ".\n", in_data->tcphdr->src,

--- a/src/core/lwip/tcp_in.c
+++ b/src/core/lwip/tcp_in.c
@@ -313,8 +313,10 @@ static void tcp_listen_input(struct tcp_pcb *pcb, tcp_in_data *in_data)
     if (in_data->flags & TCP_ACK) {
         /* For incoming segments with the ACK flag set, respond with a RST. */
         LWIP_DEBUGF(TCP_RST_DEBUG, ("tcp_listen_input: ACK in LISTEN, sending reset\n"));
+#if 0
         tcp_rst(in_data->ackno + 1, in_data->seqno + in_data->tcplen, in_data->tcphdr->dest,
                 in_data->tcphdr->src, NULL);
+#endif
     } else if (in_data->flags & TCP_SYN) {
         LWIP_DEBUGF(TCP_DEBUG,
                     ("TCP connection request %" U16_F " -> %" U16_F ".\n", in_data->tcphdr->src,

--- a/src/core/proto/dst_entry_tcp.cpp
+++ b/src/core/proto/dst_entry_tcp.cpp
@@ -204,7 +204,8 @@ ssize_t dst_entry_tcp::fast_send(const iovec *p_iov, const ssize_t sz_iov, xlio_
         mem_buf_desc_t *p_mem_buf_desc;
         size_t total_packet_len = 0;
 
-        p_mem_buf_desc = get_buffer(PBUF_RAM, nullptr, is_set(attr.flags, XLIO_TX_PACKET_BLOCK));
+        p_mem_buf_desc = get_buffer(PBUF_RAM, nullptr, is_set(attr.flags, XLIO_TX_PACKET_BLOCK),
+                                    is_set(attr.flags, XLIO_TX_SKIP_POLL));
         if (!p_mem_buf_desc) {
             ret = -1;
             goto out;
@@ -248,7 +249,8 @@ ssize_t dst_entry_tcp::fast_send(const iovec *p_iov, const ssize_t sz_iov, xlio_
 
     if (unlikely(!m_p_tx_mem_buf_desc_list)) {
         m_p_tx_mem_buf_desc_list = m_p_ring->mem_buf_tx_get(
-            m_id, is_set(attr.flags, XLIO_TX_PACKET_BLOCK), PBUF_RAM, m_n_sysvar_tx_bufs_batch_tcp);
+            m_id, is_set(attr.flags, XLIO_TX_PACKET_BLOCK), PBUF_RAM, m_n_sysvar_tx_bufs_batch_tcp,
+            is_set(attr.flags, XLIO_TX_SKIP_POLL));
     }
 
 out:
@@ -321,7 +323,7 @@ ssize_t dst_entry_tcp::pass_buff_to_neigh(const iovec *p_iov, size_t sz_iov)
 }
 
 mem_buf_desc_t *dst_entry_tcp::get_buffer(pbuf_type type, pbuf_desc *desc,
-                                          bool b_blocked /*=false*/)
+                                          bool b_blocked /*=false*/, bool tx_skip_poll /*=false*/)
 {
     mem_buf_desc_t **p_desc_list;
 
@@ -331,8 +333,8 @@ mem_buf_desc_t *dst_entry_tcp::get_buffer(pbuf_type type, pbuf_desc *desc,
 
     // Get a bunch of tx buf descriptor and data buffers
     if (unlikely(!*p_desc_list)) {
-        *p_desc_list =
-            m_p_ring->mem_buf_tx_get(m_id, b_blocked, type, m_n_sysvar_tx_bufs_batch_tcp);
+        *p_desc_list = m_p_ring->mem_buf_tx_get(m_id, b_blocked, type, m_n_sysvar_tx_bufs_batch_tcp,
+                                                tx_skip_poll);
     }
 
     mem_buf_desc_t *p_mem_buf_desc = *p_desc_list;

--- a/src/core/proto/dst_entry_tcp.h
+++ b/src/core/proto/dst_entry_tcp.h
@@ -29,7 +29,8 @@ public:
     ssize_t slow_send_neigh(const iovec *p_iov, size_t sz_iov,
                             struct xlio_rate_limit_t &rate_limit);
 
-    mem_buf_desc_t *get_buffer(pbuf_type type, pbuf_desc *desc, bool b_blocked = false);
+    mem_buf_desc_t *get_buffer(pbuf_type type, pbuf_desc *desc, bool b_blocked = false,
+                               bool tx_skip_poll = false);
     void put_buffer(mem_buf_desc_t *p_desc);
     void put_zc_buffer(mem_buf_desc_t *p_desc);
 

--- a/src/core/sock/fd_collection.h
+++ b/src/core/sock/fd_collection.h
@@ -19,7 +19,7 @@
 #include "iomux/epfd_info.h"
 #include "utils/lock_wrapper.h"
 
-typedef xlio_list_t<sockinfo, sockinfo::pending_to_remove_node_offset> sock_fd_api_list_t;
+typedef xlio_list_t<sockinfo, sockinfo::pending_to_remove_node_offset> sockinfo_list_t;
 typedef xlio_list_t<epfd_info, epfd_info::epfd_info_node_offset> epfd_info_list_t;
 
 typedef std::unordered_map<pthread_t, int> offload_thread_rule_t;
@@ -117,7 +117,7 @@ public:
     inline void reuse_sockfd(int fd, sockinfo *p_sfd_api_obj);
     inline void destroy_sockfd(sockinfo *p_sfd_api_obj);
     /**
-     * Get sock_fd_api (sockinfo) by fd.
+     * Get sockinfo by fd.
      */
     inline sockinfo *get_sockfd(int fd);
 
@@ -190,7 +190,7 @@ private:
 
     epfd_info_list_t m_epfd_lst;
     // Contains fds which are in closing process
-    sock_fd_api_list_t m_pending_to_remove_lst;
+    sockinfo_list_t m_pending_to_remove_lst;
 
     const bool m_b_sysvar_offloaded_sockets;
 

--- a/src/core/sock/sock-extra.cpp
+++ b/src/core/sock/sock-extra.cpp
@@ -282,8 +282,7 @@ extern "C" int xlio_socket_destroy(xlio_socket_t sock)
     poll_group *grp = si->get_poll_group();
 
     if (likely(grp)) {
-        // We always force TCP reset not to handle FIN handshake and TIME-WAIT state.
-        grp->close_socket(si, true);
+        grp->mark_socket_to_close(si);
     } else {
         return XLIO_CALL(close, si->get_fd());
     }

--- a/src/core/sock/sock-extra.cpp
+++ b/src/core/sock/sock-extra.cpp
@@ -148,6 +148,7 @@ struct xlio_api_t *extra_api()
         SET_EXTRA_API(xlio_socket_destroy, xlio_socket_destroy, XLIO_EXTRA_API_XLIO_SOCKET);
         SET_EXTRA_API(xlio_socket_update, xlio_socket_update, XLIO_EXTRA_API_XLIO_SOCKET);
         SET_EXTRA_API(xlio_socket_setsockopt, xlio_socket_setsockopt, XLIO_EXTRA_API_XLIO_SOCKET);
+        SET_EXTRA_API(xlio_socket_getsockname, xlio_socket_getsockname, XLIO_EXTRA_API_XLIO_SOCKET);
         SET_EXTRA_API(xlio_socket_getpeername, xlio_socket_getpeername, XLIO_EXTRA_API_XLIO_SOCKET);
         SET_EXTRA_API(xlio_socket_bind, xlio_socket_bind, XLIO_EXTRA_API_XLIO_SOCKET);
         SET_EXTRA_API(xlio_socket_connect, xlio_socket_connect, XLIO_EXTRA_API_XLIO_SOCKET);
@@ -306,6 +307,13 @@ extern "C" int xlio_socket_setsockopt(xlio_socket_t sock, int level, int optname
         errno = errno_save;
     }
     return rc;
+}
+
+extern "C" int xlio_socket_getsockname(xlio_socket_t sock, struct sockaddr *addr,
+                                       socklen_t *addrlen)
+{
+    sockinfo_tcp *si = reinterpret_cast<sockinfo_tcp *>(sock);
+    return si->getsockname(addr, addrlen);
 }
 
 extern "C" int xlio_socket_getpeername(xlio_socket_t sock, struct sockaddr *addr,

--- a/src/core/sock/sock-extra.cpp
+++ b/src/core/sock/sock-extra.cpp
@@ -141,6 +141,7 @@ struct xlio_api_t *extra_api()
 
         // XLIO Socket API.
         SET_EXTRA_API(xlio_init_ex, xlio_init_ex, XLIO_EXTRA_API_XLIO_SOCKET);
+        SET_EXTRA_API(xlio_exit, xlio_exit, XLIO_EXTRA_API_XLIO_SOCKET);
         SET_EXTRA_API(xlio_poll_group_create, xlio_poll_group_create, XLIO_EXTRA_API_XLIO_SOCKET);
         SET_EXTRA_API(xlio_poll_group_destroy, xlio_poll_group_destroy, XLIO_EXTRA_API_XLIO_SOCKET);
         SET_EXTRA_API(xlio_poll_group_poll, xlio_poll_group_poll, XLIO_EXTRA_API_XLIO_SOCKET);

--- a/src/core/sock/sock-extra.cpp
+++ b/src/core/sock/sock-extra.cpp
@@ -146,10 +146,17 @@ struct xlio_api_t *extra_api()
         SET_EXTRA_API(xlio_poll_group_poll, xlio_poll_group_poll, XLIO_EXTRA_API_XLIO_SOCKET);
         SET_EXTRA_API(xlio_socket_create, xlio_socket_create, XLIO_EXTRA_API_XLIO_SOCKET);
         SET_EXTRA_API(xlio_socket_destroy, xlio_socket_destroy, XLIO_EXTRA_API_XLIO_SOCKET);
+        SET_EXTRA_API(xlio_socket_update, xlio_socket_update, XLIO_EXTRA_API_XLIO_SOCKET);
         SET_EXTRA_API(xlio_socket_setsockopt, xlio_socket_setsockopt, XLIO_EXTRA_API_XLIO_SOCKET);
+        SET_EXTRA_API(xlio_socket_getpeername, xlio_socket_getpeername, XLIO_EXTRA_API_XLIO_SOCKET);
         SET_EXTRA_API(xlio_socket_bind, xlio_socket_bind, XLIO_EXTRA_API_XLIO_SOCKET);
         SET_EXTRA_API(xlio_socket_connect, xlio_socket_connect, XLIO_EXTRA_API_XLIO_SOCKET);
+        SET_EXTRA_API(xlio_socket_listen, xlio_socket_listen, XLIO_EXTRA_API_XLIO_SOCKET);
         SET_EXTRA_API(xlio_socket_get_pd, xlio_socket_get_pd, XLIO_EXTRA_API_XLIO_SOCKET);
+        SET_EXTRA_API(xlio_socket_detach_group, xlio_socket_detach_group,
+                      XLIO_EXTRA_API_XLIO_SOCKET);
+        SET_EXTRA_API(xlio_socket_attach_group, xlio_socket_attach_group,
+                      XLIO_EXTRA_API_XLIO_SOCKET);
         SET_EXTRA_API(xlio_socket_send, xlio_socket_send, XLIO_EXTRA_API_XLIO_SOCKET);
         SET_EXTRA_API(xlio_socket_sendv, xlio_socket_sendv, XLIO_EXTRA_API_XLIO_SOCKET);
         SET_EXTRA_API(xlio_poll_group_flush, xlio_poll_group_flush, XLIO_EXTRA_API_XLIO_SOCKET);
@@ -282,6 +289,12 @@ extern "C" int xlio_socket_destroy(xlio_socket_t sock)
     return 0;
 }
 
+extern "C" int xlio_socket_update(xlio_socket_t sock, unsigned flags, uintptr_t userdata_sq)
+{
+    sockinfo_tcp *si = reinterpret_cast<sockinfo_tcp *>(sock);
+    return si->update_xlio_socket(flags, userdata_sq);
+}
+
 extern "C" int xlio_socket_setsockopt(xlio_socket_t sock, int level, int optname,
                                       const void *optval, socklen_t optlen)
 {
@@ -293,6 +306,13 @@ extern "C" int xlio_socket_setsockopt(xlio_socket_t sock, int level, int optname
         errno = errno_save;
     }
     return rc;
+}
+
+extern "C" int xlio_socket_getpeername(xlio_socket_t sock, struct sockaddr *addr,
+                                       socklen_t *addrlen)
+{
+    sockinfo_tcp *si = reinterpret_cast<sockinfo_tcp *>(sock);
+    return si->getpeername(addr, addrlen);
 }
 
 extern "C" int xlio_socket_bind(xlio_socket_t sock, const struct sockaddr *addr, socklen_t addrlen)
@@ -321,12 +341,40 @@ extern "C" int xlio_socket_connect(xlio_socket_t sock, const struct sockaddr *to
     return rc;
 }
 
+extern "C" int xlio_socket_listen(xlio_socket_t sock)
+{
+    sockinfo_tcp *si = reinterpret_cast<sockinfo_tcp *>(sock);
+    poll_group *group = si->get_poll_group();
+
+    if (!group->m_socket_accept_cb) {
+        errno = ENOTCONN;
+        return -1;
+    }
+    // TODO handle positive return code from prepareListen() and convert it to errno
+    return si->prepareListen() ?: si->listen(-1);
+}
+
 extern "C" struct ibv_pd *xlio_socket_get_pd(xlio_socket_t sock)
 {
     sockinfo_tcp *si = reinterpret_cast<sockinfo_tcp *>(sock);
     ib_ctx_handler *ctx = si->get_ctx();
 
     return ctx ? ctx->get_ibv_pd() : nullptr;
+}
+
+int xlio_socket_detach_group(xlio_socket_t sock)
+{
+    sockinfo_tcp *si = reinterpret_cast<sockinfo_tcp *>(sock);
+
+    return si->detach_xlio_group();
+}
+
+int xlio_socket_attach_group(xlio_socket_t sock, xlio_poll_group_t group)
+{
+    sockinfo_tcp *si = reinterpret_cast<sockinfo_tcp *>(sock);
+    poll_group *grp = reinterpret_cast<poll_group *>(group);
+
+    return si->attach_xlio_group(grp);
 }
 
 static void xlio_buf_free(struct xlio_buf *buf)

--- a/src/core/sock/sock-extra.cpp
+++ b/src/core/sock/sock-extra.cpp
@@ -351,7 +351,6 @@ extern "C" int xlio_socket_connect(xlio_socket_t sock, const struct sockaddr *to
     int rc = si->connect(to, tolen);
     rc = (rc == -1 && (errno == EINPROGRESS || errno == EAGAIN)) ? 0 : rc;
     if (rc == 0) {
-        si->add_tx_ring_to_group();
         errno = errno_save;
     }
     return rc;

--- a/src/core/sock/sock-extra.cpp
+++ b/src/core/sock/sock-extra.cpp
@@ -281,10 +281,18 @@ extern "C" int xlio_socket_destroy(xlio_socket_t sock)
     sockinfo_tcp *si = reinterpret_cast<sockinfo_tcp *>(sock);
     poll_group *grp = si->get_poll_group();
 
+    if (unlikely(!si->is_xlio_socket())) {
+        errno = EINVAL;
+        return -1;
+    }
+
     if (likely(grp)) {
         grp->mark_socket_to_close(si);
     } else {
-        return XLIO_CALL(close, si->get_fd());
+        // Detached socket flow.
+        g_p_fd_collection->clear_socket(si->get_fd());
+        si->prepare_to_close(true);
+        si->clean_socket_obj();
     }
     return 0;
 }

--- a/src/core/sock/sockinfo.cpp
+++ b/src/core/sock/sockinfo.cpp
@@ -2222,3 +2222,13 @@ bool sockinfo::skip_os_select()
     // os (i.e. TRUE...)
     return (!safe_mce_sys().select_poll_os_ratio);
 }
+
+bool sockinfo::is_xlio_socket() const
+{
+    return m_is_xlio_socket;
+}
+
+poll_group *sockinfo::get_poll_group() const
+{
+    return m_p_group;
+}

--- a/src/core/sock/sockinfo.cpp
+++ b/src/core/sock/sockinfo.cpp
@@ -910,9 +910,7 @@ bool sockinfo::attach_receiver(flow_tuple_with_local_if &flow_key)
     // Registered as receiver successfully
     si_logdbg("Attached %s to ring %p", flow_key.to_str().c_str(), p_nd_resources->p_ring);
 
-    /* Verify 5 tuple over 3 tuple
-     * and replace flow rule with the strongest
-     */
+    // Verify 5 tuple over 3 tuple and replace flow rule with the strongest
     if (flow_key.is_5_tuple()) {
         // Check and remove lesser 3 tuple
         flow_tuple_with_local_if flow_key_3t(

--- a/src/core/sock/sockinfo.cpp
+++ b/src/core/sock/sockinfo.cpp
@@ -926,7 +926,7 @@ bool sockinfo::attach_receiver(flow_tuple_with_local_if &flow_key)
     return true;
 }
 
-bool sockinfo::detach_receiver(flow_tuple_with_local_if &flow_key)
+bool sockinfo::detach_receiver(flow_tuple_with_local_if &flow_key, rfs_rule **rule_extract)
 {
     si_logdbg("Unregistering receiver: %s", flow_key.to_str().c_str());
 
@@ -947,7 +947,7 @@ bool sockinfo::detach_receiver(flow_tuple_with_local_if &flow_key)
 
     // Detach tuple
     unlock_rx_q();
-    p_ring->detach_flow(flow_key, this);
+    p_ring->detach_flow(flow_key, this, rule_extract);
     lock_rx_q();
 
     // Un-map flow from local map
@@ -1154,7 +1154,7 @@ void sockinfo::do_rings_migration_rx(resource_allocation_key &old_key)
             si_logdbg("Detaching %s from ring %p", flow_key.to_str().c_str(), p_old_ring);
             // Detach tuple
             unlock_rx_q();
-            p_old_ring->detach_flow(flow_key, this);
+            p_old_ring->detach_flow(flow_key, this, nullptr);
             lock_rx_q();
             rx_del_ring_cb(p_old_ring);
 

--- a/src/core/sock/sockinfo.cpp
+++ b/src/core/sock/sockinfo.cpp
@@ -148,7 +148,7 @@ sockinfo::~sockinfo()
         sock_stats::instance().return_stats_obj(m_p_socket_stats);
     }
 
-    bool toclose = safe_mce_sys().deferred_close && m_fd >= 0;
+    bool toclose = (safe_mce_sys().deferred_close || is_xlio_socket()) && m_fd >= 0;
 
 #if defined(DEFINED_NGINX)
     if (g_p_app->type == APP_NGINX) {
@@ -158,7 +158,10 @@ sockinfo::~sockinfo()
 #endif
 
     if (toclose) {
-        SYSCALL(close, m_fd);
+        int rc = SYSCALL(close, m_fd);
+        if (rc != 0) {
+            si_logdbg("close(fd=%d) failed with errno=%d", m_fd, errno);
+        }
     }
 }
 

--- a/src/core/sock/sockinfo.h
+++ b/src/core/sock/sockinfo.h
@@ -538,6 +538,8 @@ protected:
      */
     poll_group *m_p_group = nullptr; // Polling group associated with this socket
     bool m_is_xlio_socket = false; // Flag indicating if this is an XLIO socket
+    bool m_is_xlio_socket_terminated =
+        false; // Flag indicating if this is an XLIO socket terminat CB was called
 
 public:
 #if defined(DEFINED_NGINX) || defined(DEFINED_ENVOY)

--- a/src/core/sock/sockinfo.h
+++ b/src/core/sock/sockinfo.h
@@ -394,7 +394,7 @@ protected:
     void save_stats_rx_offload(int nbytes);
     void socket_stats_init();
     bool attach_receiver(flow_tuple_with_local_if &flow_key);
-    bool detach_receiver(flow_tuple_with_local_if &flow_key);
+    bool detach_receiver(flow_tuple_with_local_if &flow_key, rfs_rule **rule_extract = nullptr);
     net_device_resources_t *create_nd_resources(const ip_addr &ip_local);
     bool destroy_nd_resources(const ip_addr &ip_local);
     void do_rings_migration_rx(resource_allocation_key &old_key);

--- a/src/core/sock/sockinfo.h
+++ b/src/core/sock/sockinfo.h
@@ -219,6 +219,7 @@ const uint8_t ip_tos2prio[16] = {0, 0, 0, 0, 2, 2, 2, 2, 6, 6, 6, 6, 4, 4, 4, 4}
 
 class epfd_info;
 
+class poll_group; // Forward declaration
 class sockinfo {
 public:
     enum sockinfo_state : uint16_t {
@@ -344,6 +345,11 @@ public:
     void set_rx_num_buffs_reuse(int val) { m_rx_num_buffs_reuse = val; }
 #endif
 #endif
+
+    // XLIO ZC API
+    bool is_xlio_socket() const;
+    poll_group *get_poll_group() const;
+
 protected:
     static const char *setsockopt_so_opt_to_str(int opt);
 
@@ -525,6 +531,13 @@ protected:
     uint32_t m_pcp = 0U;
     uint32_t m_flow_tag_id = 0U; // Flow Tag for this socket
     uint8_t m_n_uc_ttl_hop_lim;
+    /*
+     * Storage API
+     * Move other StorageApi fields from sockinfo_tcp to sockinfo
+     * TODO Move the fields to proper cold/hot sections in the final version.
+     */
+    poll_group *m_p_group = nullptr; // Polling group associated with this socket
+    bool m_is_xlio_socket = false; // Flag indicating if this is an XLIO socket
 
 public:
 #if defined(DEFINED_NGINX) || defined(DEFINED_ENVOY)

--- a/src/core/sock/sockinfo_tcp.cpp
+++ b/src/core/sock/sockinfo_tcp.cpp
@@ -424,6 +424,17 @@ int sockinfo_tcp::detach_xlio_group()
         errno = EINVAL;
         return -1;
     }
+    // We rely on the flow tag feature to drop RX packets during 2-step migration.
+    if (safe_mce_sys().disable_flow_tag) {
+        static bool already_warned = false;
+        if (!already_warned) {
+            si_tcp_logwarn("Flow tag is disabled in the XLIO configuration. Enable it to use the "
+                           "2-step socket migration.");
+            already_warned = true;
+        }
+        errno = ENOTSUP;
+        return -1;
+    }
     // There are more than 1 RX ring. Not supported and can happen only for listen sockets.
     if (!m_p_rx_ring) {
         errno = ENOTSUP;

--- a/src/core/sock/sockinfo_tcp.cpp
+++ b/src/core/sock/sockinfo_tcp.cpp
@@ -412,6 +412,8 @@ int sockinfo_tcp::update_xlio_socket(unsigned flags, uintptr_t userdata_sq)
 
 int sockinfo_tcp::detach_xlio_group()
 {
+    std::lock_guard<decltype(m_tcp_con_lock)> lock(m_tcp_con_lock);
+
     // Only connected socket can be detached.
     if (!m_p_group || !m_p_connected_dst_entry || m_rx_flow_map.empty() || 
         get_tcp_state(&m_pcb) != ESTABLISHED) {
@@ -454,6 +456,8 @@ int sockinfo_tcp::attach_xlio_group(poll_group *group)
         .group = reinterpret_cast<xlio_poll_group_t>(group),
         .userdata_sq = m_xlio_socket_userdata,
     };
+
+    std::lock_guard<decltype(m_tcp_con_lock)> lock(m_tcp_con_lock);
 
     if (m_p_group) {
         si_tcp_logwarn("Attaching undetached XLIO socket %p, group %p, new-group %p",

--- a/src/core/sock/sockinfo_tcp.cpp
+++ b/src/core/sock/sockinfo_tcp.cpp
@@ -5771,7 +5771,7 @@ void tcp_timers_collection::handle_timer_expired(void *user_data)
             p_sock->unlock_tcp_con();
             if (destroyable) {
                 if (p_sock->is_xlio_socket()) {
-                    p_sock->get_poll_group()->destroy_pending_to_remove_socket(p_sock);
+                    p_sock->get_poll_group()->mark_socket_to_destroy(p_sock);
                 } else {
                     g_p_fd_collection->destroy_sockfd(p_sock);
                 }

--- a/src/core/sock/sockinfo_tcp.cpp
+++ b/src/core/sock/sockinfo_tcp.cpp
@@ -397,7 +397,7 @@ void sockinfo_tcp::set_xlio_socket(const struct xlio_socket_attr *attr)
     tcp_recv(&m_pcb, sockinfo_tcp::rx_lwip_cb_xlio_socket);
     tcp_err(&m_pcb, sockinfo_tcp::err_lwip_cb_xlio_socket);
     set_blocking(false);
-
+    m_is_xlio_socket = true;
     // Allow the queue to grow for non-zerocopy send operations.
     m_pcb.snd_queuelen_max = TCP_SNDQUEUELEN_OVERFLOW;
 }

--- a/src/core/sock/sockinfo_tcp.cpp
+++ b/src/core/sock/sockinfo_tcp.cpp
@@ -984,6 +984,9 @@ bool sockinfo_tcp::prepare_dst_to_send(bool is_accepted_socket /* = false */)
             m_pcb.tso.max_send_sge = ring->get_max_send_sge();
         }
     }
+    if (ret_val && is_xlio_socket()) {
+        add_tx_ring_to_group();
+    }
     return ret_val;
 }
 

--- a/src/core/sock/sockinfo_tcp.cpp
+++ b/src/core/sock/sockinfo_tcp.cpp
@@ -412,8 +412,16 @@ int sockinfo_tcp::update_xlio_socket(unsigned flags, uintptr_t userdata_sq)
 
 int sockinfo_tcp::detach_xlio_group()
 {
-    // TODO check that socket is connected and has all the objects (to attach them unconditionally
-    // later)
+    // Only connected socket can be detached.
+    if (!m_p_group || !m_p_connected_dst_entry || m_rx_flow_map.empty() || 
+        get_tcp_state(&m_pcb) != ESTABLISHED) {
+        si_tcp_logwarn("Unable to detach socket %p, state %s, group %p, dst_entry %p,"
+                       " rx_flow_size %zu. Only connected attached socket can be detached.",
+                       this, tcp_state_str[get_tcp_state(&m_pcb)], m_p_group,
+                       m_p_connected_dst_entry, m_rx_flow_map.size());
+        return -1;
+    }
+
     // TODO replace lwip callbacks with drops
 
     remove_timer();
@@ -447,7 +455,12 @@ int sockinfo_tcp::attach_xlio_group(poll_group *group)
         .userdata_sq = m_xlio_socket_userdata,
     };
 
-    // TODO check that socket is detached
+    if (m_p_group) {
+        si_tcp_logwarn("Attaching undetached XLIO socket %p, group %p, new-group %p",
+                       this, m_p_group, group);
+        return -1;
+    }
+
     // TODO reinitialize lwip callbacks
 
     set_xlio_socket(&attr);

--- a/src/core/sock/sockinfo_tcp.cpp
+++ b/src/core/sock/sockinfo_tcp.cpp
@@ -415,12 +415,18 @@ int sockinfo_tcp::detach_xlio_group()
     std::lock_guard<decltype(m_tcp_con_lock)> lock(m_tcp_con_lock);
 
     // Only connected socket can be detached.
-    if (!m_p_group || !m_p_connected_dst_entry || m_rx_flow_map.empty() || 
+    if (!m_p_group || !m_p_connected_dst_entry || m_rx_flow_map.empty() ||
         get_tcp_state(&m_pcb) != ESTABLISHED) {
         si_tcp_logwarn("Unable to detach socket %p, state %s, group %p, dst_entry %p,"
                        " rx_flow_size %zu. Only connected attached socket can be detached.",
                        this, tcp_state_str[get_tcp_state(&m_pcb)], m_p_group,
                        m_p_connected_dst_entry, m_rx_flow_map.size());
+        errno = EINVAL;
+        return -1;
+    }
+    // There are more than 1 RX ring. Not supported and can happen only for listen sockets.
+    if (!m_p_rx_ring) {
+        errno = ENOTSUP;
         return -1;
     }
 
@@ -432,9 +438,11 @@ int sockinfo_tcp::detach_xlio_group()
     for (auto rx_flow_iter = m_rx_flow_map.begin(); rx_flow_iter != m_rx_flow_map.end();
          rx_flow_iter = m_rx_flow_map.begin()) {
         flow_tuple_with_local_if flow = rx_flow_iter->first;
-        bool result = detach_receiver(flow);
+        m_p_rule_extracted = nullptr;
+        bool result = detach_receiver(flow, &m_p_rule_extracted);
         if (!result) {
             si_tcp_logwarn("Detach receiver failed, migration may be spoiled");
+            break;
         }
     }
     // TODO SO_BINDTODEVICE support
@@ -460,8 +468,8 @@ int sockinfo_tcp::attach_xlio_group(poll_group *group)
     std::lock_guard<decltype(m_tcp_con_lock)> lock(m_tcp_con_lock);
 
     if (m_p_group) {
-        si_tcp_logwarn("Attaching undetached XLIO socket %p, group %p, new-group %p",
-                       this, m_p_group, group);
+        si_tcp_logwarn("Attaching detached XLIO socket %p, group %p, new-group %p", this, m_p_group,
+                       group);
         return -1;
     }
 
@@ -488,6 +496,10 @@ int sockinfo_tcp::attach_xlio_group(poll_group *group)
         si_tcp_logwarn("Couldn't attach RX, migration failed");
         errno = ECONNABORTED;
         return -1;
+    }
+    if (m_p_rule_extracted) {
+        delete m_p_rule_extracted;
+        m_p_rule_extracted = nullptr;
     }
 
     register_timer();
@@ -645,6 +657,11 @@ sockinfo_tcp::~sockinfo_tcp()
         socket_option_t *opt = m_socket_options_list.front();
         m_socket_options_list.pop_front();
         delete (opt);
+    }
+
+    if (m_p_rule_extracted) {
+        delete m_p_rule_extracted;
+        m_p_rule_extracted = nullptr;
     }
 
     unlock_tcp_con();
@@ -3214,8 +3231,7 @@ void sockinfo_tcp::accept_connection_xlio_socket(sockinfo_tcp *new_sock)
 {
     remove_received_syn_socket(new_sock);
     m_p_group->m_socket_accept_cb(reinterpret_cast<xlio_socket_t>(new_sock),
-                                  reinterpret_cast<xlio_socket_t>(this),
-                                  m_xlio_socket_userdata);
+                                  reinterpret_cast<xlio_socket_t>(this), m_xlio_socket_userdata);
 }
 
 void sockinfo_tcp::remove_received_syn_socket(sockinfo_tcp *accepted)

--- a/src/core/sock/sockinfo_tcp.cpp
+++ b/src/core/sock/sockinfo_tcp.cpp
@@ -1578,6 +1578,9 @@ err_t sockinfo_tcp::ip_output_syn_ack(struct pbuf *p, struct tcp_seg *seg, void 
     sockinfo_tcp *p_si_tcp = (sockinfo_tcp *)pcb_container;
     IF_STATS_O(p_si_tcp, p_si_tcp->m_p_socket_stats->tcp_state = new_state);
     if (p_si_tcp->is_xlio_socket()) {
+        if (new_state == CLOSE_WAIT) {
+            p_si_tcp->xlio_socket_event(XLIO_SOCKET_EVENT_CLOSED, 0);
+        }
         if (!p_si_tcp->m_is_xlio_socket_terminated &&
             (new_state == CLOSED || new_state == TIME_WAIT)) {
             p_si_tcp->xlio_socket_event(XLIO_SOCKET_EVENT_TERMINATED, 0);

--- a/src/core/sock/sockinfo_tcp.cpp
+++ b/src/core/sock/sockinfo_tcp.cpp
@@ -692,9 +692,7 @@ bool sockinfo_tcp::prepare_listen_to_close()
     while (!m_accepted_conns.empty()) {
         sockinfo_tcp *new_sock = m_accepted_conns.get_and_pop_front();
         new_sock->m_sock_state = TCP_SOCK_INITED;
-        class flow_tuple key;
-        sockinfo_tcp::create_flow_tuple_key_from_pcb(key, &(new_sock->m_pcb));
-        m_syn_received.erase(key);
+        remove_received_syn_socket(new_sock);
         m_ready_conn_cnt--;
         new_sock->lock_tcp_con();
         new_sock->m_parent = nullptr;
@@ -1908,12 +1906,7 @@ void sockinfo_tcp::handle_incoming_handshake_failure(sockinfo_tcp *child_conn)
         m_ready_pcbs.erase(&child_conn->m_pcb);
     }
 
-    // remove the connection from m_syn_received and close it by caller
-    flow_tuple key;
-    sockinfo_tcp::create_flow_tuple_key_from_pcb(key, &(child_conn->m_pcb));
-    if (!m_syn_received.erase(key)) {
-        si_tcp_logerr("Unable to find the established pcb in syn received list");
-    }
+    remove_received_syn_socket(child_conn);
 
     si_tcp_logfunc("Received-RST/internal-error/timeout in SYN_RCVD state");
     if (m_p_socket_stats) {
@@ -3052,15 +3045,7 @@ int sockinfo_tcp::accept_helper(struct sockaddr *__addr, socklen_t *__addrlen,
     m_ready_conn_cnt--;
     IF_STATS(m_p_socket_stats->listen_counters.n_conn_backlog--);
 
-    class flow_tuple key;
-    sockinfo_tcp::create_flow_tuple_key_from_pcb(key, &(ns->m_pcb));
-
-    // Since the pcb is already contained in connected sockinfo_tcp no need to keep it listen's
-    // socket SYN list
-    if (!m_syn_received.erase(key)) {
-        // Should we worry about that?
-        __log_dbg("Can't find the established pcb in syn received list");
-    }
+    remove_received_syn_socket(ns);
 
     if (safe_mce_sys().tcp_ctl_thread == option_tcp_ctl_thread::CTL_THREAD_WITH_WAKEUP &&
         !m_rx_peer_packets.empty()) {
@@ -3201,6 +3186,25 @@ sockinfo_tcp *sockinfo_tcp::accept_clone()
     return si;
 }
 
+void sockinfo_tcp::accept_connection_xlio_socket(sockinfo_tcp *new_sock)
+{
+    remove_received_syn_socket(new_sock);
+    m_p_group->m_socket_accept_cb(reinterpret_cast<xlio_socket_t>(new_sock),
+                                  reinterpret_cast<xlio_socket_t>(this),
+                                  m_xlio_socket_userdata);
+}
+
+void sockinfo_tcp::remove_received_syn_socket(sockinfo_tcp *accepted)
+{
+    class flow_tuple key;
+    sockinfo_tcp::create_flow_tuple_key_from_pcb(key, &(accepted->m_pcb));
+
+    // The PCB should be removed from the listen socket list of awaiting PCBs.
+    if (!m_syn_received.erase(key)) {
+        si_tcp_logwarn("Unable to find the established pcb in m_syn_received");
+    }
+}
+
 err_t sockinfo_tcp::accept_lwip_cb(void *arg, struct tcp_pcb *child_pcb, err_t err)
 {
     sockinfo_tcp *conn = (sockinfo_tcp *)(arg);
@@ -3309,9 +3313,7 @@ err_t sockinfo_tcp::accept_lwip_cb(void *arg, struct tcp_pcb *child_pcb, err_t e
     conn->m_ready_pcbs.erase(&new_sock->m_pcb);
 
     if (conn->is_xlio_socket()) {
-        conn->m_p_group->m_socket_accept_cb(reinterpret_cast<xlio_socket_t>(new_sock),
-                                            reinterpret_cast<xlio_socket_t>(conn),
-                                            conn->m_xlio_socket_userdata);
+        conn->accept_connection_xlio_socket(new_sock);
     } else {
         conn->m_accepted_conns.push_back(new_sock);
         conn->m_ready_conn_cnt++;

--- a/src/core/sock/sockinfo_tcp.cpp
+++ b/src/core/sock/sockinfo_tcp.cpp
@@ -402,6 +402,82 @@ void sockinfo_tcp::set_xlio_socket(const struct xlio_socket_attr *attr)
     m_pcb.snd_queuelen_max = TCP_SNDQUEUELEN_OVERFLOW;
 }
 
+int sockinfo_tcp::update_xlio_socket(unsigned flags, uintptr_t userdata_sq)
+{
+    NOT_IN_USE(flags); // Currently unused.
+    m_xlio_socket_userdata = userdata_sq;
+
+    return 0;
+}
+
+int sockinfo_tcp::detach_xlio_group()
+{
+    // TODO check that socket is connected and has all the objects (to attach them unconditionally
+    // later)
+    // TODO replace lwip callbacks with drops
+
+    remove_timer();
+
+    // Unregister this receiver from all the rings
+    for (auto rx_flow_iter = m_rx_flow_map.begin(); rx_flow_iter != m_rx_flow_map.end();
+         rx_flow_iter = m_rx_flow_map.begin()) {
+        flow_tuple_with_local_if flow = rx_flow_iter->first;
+        bool result = detach_receiver(flow);
+        if (!result) {
+            si_tcp_logwarn("Detach receiver failed, migration may be spoiled");
+        }
+    }
+    // TODO SO_BINDTODEVICE support
+
+    delete m_p_connected_dst_entry;
+    m_p_connected_dst_entry = nullptr;
+
+    m_p_group->remove_socket(this);
+    m_p_group = nullptr;
+
+    return 0;
+}
+
+int sockinfo_tcp::attach_xlio_group(poll_group *group)
+{
+    struct xlio_socket_attr attr = {
+        .flags = 0, /* unused */
+        .domain = (int)m_family,
+        .group = reinterpret_cast<xlio_poll_group_t>(group),
+        .userdata_sq = m_xlio_socket_userdata,
+    };
+
+    // TODO check that socket is detached
+    // TODO reinitialize lwip callbacks
+
+    set_xlio_socket(&attr);
+    group->add_socket(this);
+
+    create_dst_entry();
+    if (!m_p_connected_dst_entry) {
+        si_tcp_logwarn("Couldn't create dst_enrty, migration failed");
+        errno = ENOMEM;
+        return -1;
+    }
+    bool result = prepare_dst_to_send(is_incoming());
+    if (!result) {
+        si_tcp_logwarn("Couldn't attach TX, migration failed");
+        errno = ENOTCONN;
+        return -1;
+    }
+
+    result = attach_as_uc_receiver(role_t(NULL), true);
+    if (!result) {
+        si_tcp_logwarn("Couldn't attach RX, migration failed");
+        errno = ECONNABORTED;
+        return -1;
+    }
+
+    register_timer();
+
+    return 0;
+}
+
 void sockinfo_tcp::add_tx_ring_to_group()
 {
     ring *rng = get_tx_ring();
@@ -2277,15 +2353,27 @@ ssize_t sockinfo_tcp::rx(const rx_call_t call_type, iovec *p_iov, ssize_t sz_iov
 
 void sockinfo_tcp::register_timer()
 {
-    // A reused time-wait socket wil try to add a timer although it is already registered.
-    // We should avoid calling register_socket_timer_event unnecessarily because it introduces
-    // internal-thread locks contention.
+    /* A reused time-wait socket will try to add a timer although it is already registered.
+     * We should avoid calling register_socket_timer_event unnecessarily because it introduces
+     * internal-thread locks contention.
+     */
     if (!is_timer_registered()) {
-        si_tcp_logdbg("Registering TCP socket timer: socket: %p, thread-col: %p, global-col: %p",
+        si_tcp_logdbg("Registering TCP socket timer: socket: %p, timer-col: %p, global-col: %p",
                       this, get_tcp_timer_collection(), g_tcp_timers_collection);
 
         set_timer_registered(true);
         get_event_mgr()->register_socket_timer_event(this);
+    }
+}
+
+void sockinfo_tcp::remove_timer()
+{
+    if (is_timer_registered()) {
+        si_tcp_logdbg("Removing TCP socket timer: socket: %p, timer-col: %p, global-col: %p", this,
+                      get_tcp_timer_collection(), g_tcp_timers_collection);
+
+        set_timer_registered(false);
+        get_event_mgr()->unregister_socket_timer_event(this);
     }
 }
 
@@ -2542,7 +2630,7 @@ int sockinfo_tcp::connect(const sockaddr *__to, socklen_t __tolen)
     int rc = wait_for_conn_ready_blocking();
     // Handle ret from blocking connect
     if (rc < 0) {
-        // Interuppted wait for blocking socket currently considered as failure.
+        // Interrupted wait for blocking socket currently considered as failure.
         if (errno == EINTR || errno == EAGAIN) {
             m_conn_state = TCP_CONN_FAILED;
         }
@@ -3055,19 +3143,35 @@ sockinfo_tcp *sockinfo_tcp::accept_clone()
     // Clone is always called first when a SYN packet received by a listen socket.
     IF_STATS(m_p_socket_stats->listen_counters.n_rx_syn++);
 
-    // Create the socket object. We skip shadow sockets for incoming connections.
-    fd = socket_internal(m_family, SOCK_STREAM, 0, false, false);
-    if (fd < 0) {
-        IF_STATS(m_p_socket_stats->listen_counters.n_conn_dropped++);
-        return nullptr;
-    }
+    if (is_xlio_socket()) {
+        struct xlio_socket_attr attr = {
+            .flags = 0, /* unused */
+            .domain = (int)m_family,
+            .group = reinterpret_cast<xlio_poll_group_t>(m_p_group),
+            .userdata_sq = 0,
+        };
+        xlio_socket_t sock;
+        int rc = xlio_socket_create(&attr, &sock);
+        if (rc != 0) {
+            si_tcp_logdbg("Couldn't create XLIO socket (errno=%d)", errno);
+            IF_STATS(m_p_socket_stats->listen_counters.n_conn_dropped++);
+            return nullptr;
+        }
+        si = reinterpret_cast<sockinfo_tcp *>(sock);
+    } else {
+        // Create the socket object. We skip shadow sockets for incoming connections.
+        fd = socket_internal(m_family, SOCK_STREAM, 0, false, false);
+        if (fd < 0) {
+            IF_STATS(m_p_socket_stats->listen_counters.n_conn_dropped++);
+            return nullptr;
+        }
 
-    si = dynamic_cast<sockinfo_tcp *>(fd_collection_get_sockfd(fd));
-
-    if (!si) {
-        si_tcp_logwarn("can not get accept socket from FD collection");
-        XLIO_CALL(close, fd);
-        return nullptr;
+        si = dynamic_cast<sockinfo_tcp *>(fd_collection_get_sockfd(fd));
+        if (!si) {
+            si_tcp_logwarn("Can not get accept socket from FD collection");
+            XLIO_CALL(close, fd);
+            return nullptr;
+        }
     }
 
     // This method is called from a flow which assumes that the socket is locked
@@ -3126,10 +3230,20 @@ err_t sockinfo_tcp::accept_lwip_cb(void *arg, struct tcp_pcb *child_pcb, err_t e
         return ERR_RST;
     }
 
-    tcp_ip_output(&(new_sock->m_pcb), sockinfo_tcp::ip_output);
-    tcp_arg(&(new_sock->m_pcb), new_sock);
-    tcp_recv(&new_sock->m_pcb, sockinfo_tcp::rx_lwip_cb);
-    tcp_err(&(new_sock->m_pcb), sockinfo_tcp::err_lwip_cb);
+    tcp_ip_output(&new_sock->m_pcb, sockinfo_tcp::ip_output);
+    tcp_arg(&new_sock->m_pcb, new_sock);
+
+    if (new_sock->is_xlio_socket()) {
+        tcp_recv(&new_sock->m_pcb, sockinfo_tcp::rx_lwip_cb_xlio_socket);
+    } else {
+        tcp_recv(&new_sock->m_pcb, sockinfo_tcp::rx_lwip_cb);
+    }
+
+    if (new_sock->is_xlio_socket()) {
+        tcp_err(&new_sock->m_pcb, sockinfo_tcp::err_lwip_cb_xlio_socket);
+    } else {
+        tcp_err(&new_sock->m_pcb, sockinfo_tcp::err_lwip_cb);
+    }
 
     ASSERT_LOCKED(new_sock->m_tcp_con_lock);
 
@@ -3193,10 +3307,17 @@ err_t sockinfo_tcp::accept_lwip_cb(void *arg, struct tcp_pcb *child_pcb, err_t e
 
     // todo check that listen socket was not closed by now ? (is_server())
     conn->m_ready_pcbs.erase(&new_sock->m_pcb);
-    conn->m_accepted_conns.push_back(new_sock);
-    conn->m_ready_conn_cnt++;
 
-    NOTIFY_ON_EVENTS(conn, EPOLLIN);
+    if (conn->is_xlio_socket()) {
+        conn->m_p_group->m_socket_accept_cb(reinterpret_cast<xlio_socket_t>(new_sock),
+                                            reinterpret_cast<xlio_socket_t>(conn),
+                                            conn->m_xlio_socket_userdata);
+    } else {
+        conn->m_accepted_conns.push_back(new_sock);
+        conn->m_ready_conn_cnt++;
+
+        NOTIFY_ON_EVENTS(conn, EPOLLIN);
+    }
 
     if (conn->m_p_socket_stats) {
         conn->m_p_socket_stats->listen_counters.n_conn_established++;
@@ -3389,34 +3510,32 @@ err_t sockinfo_tcp::syn_received_lwip_cb(void *arg, struct tcp_pcb *newpcb)
 
     ASSERT_LOCKED(listen_sock->m_tcp_con_lock);
 
-    /* Inherite properties from the parent */
+    // Inherit properties from the parent.
     new_sock->set_conn_properties_from_pcb();
 
     new_sock->m_rcvbuff_max = std::max(listen_sock->m_rcvbuff_max, 2 * new_sock->m_pcb.mss);
     new_sock->fit_rcv_wnd(true);
 
-    // Socket socket options
     listen_sock->set_sock_options(new_sock);
 
     listen_sock->m_tcp_con_lock.unlock();
 
     new_sock->create_dst_entry();
-    bool is_new_offloaded = new_sock->m_p_connected_dst_entry &&
-        new_sock->prepare_dst_to_send(
-            true); // pass true for passive socket to skip the transport rules checking
+    // Pass true for passive socket to skip the transport rules checking.
+    bool is_new_offloaded =
+        new_sock->m_p_connected_dst_entry && new_sock->prepare_dst_to_send(true);
 
-    /* this can happen if there is no route back to the syn sender.
-     * so we just need to ignore it.
-     * we set the state to close so we won't try to send fin when we don't
-     * have route. */
+    /* This can happen if there is no route back to the syn sender. So we just need to ignore it.
+     * We set the state to close so we won't try to send fin when we don't have route.
+     */
     if (!is_new_offloaded) {
         new_sock->setPassthrough();
         set_tcp_state(&new_sock->m_pcb, CLOSED);
 
-        // This method is called from a flow (tcp_listen_input, L3_level_tcp_input) which
-        // priorly called clone_conn_cb which creates a locked new socket. Before we call to
-        // close() we need to unlock the socket, so close() can perform as a regular close()
-        // call.
+        /* This method is called from a flow (tcp_listen_input, L3_level_tcp_input) which priorly
+         * called clone_conn_cb which creates a locked new socket. Before we call to close() we
+         * need to unlock the socket, so close() can perform as a regular close() call.
+         */
         new_sock->unlock_tcp_con();
 
         close(new_sock->get_fd());

--- a/src/core/sock/sockinfo_tcp.h
+++ b/src/core/sock/sockinfo_tcp.h
@@ -646,6 +646,7 @@ private:
      */
     bool m_b_xlio_socket_dirty = false;
     uintptr_t m_xlio_socket_userdata = 0;
+    rfs_rule *m_p_rule_extracted = nullptr;
 };
 
 #endif

--- a/src/core/sock/sockinfo_tcp.h
+++ b/src/core/sock/sockinfo_tcp.h
@@ -403,6 +403,8 @@ private:
     bool poll_and_progress_rx(uint64_t &poll_sn);
     bool check_last_rx_poll_progress(unsigned int prev_sndbuf, bool all_drained);
     bool prepare_listen_to_close();
+    void remove_received_syn_socket(sockinfo_tcp *accepted);
+    void accept_connection_xlio_socket(sockinfo_tcp *new_sock);
 
     // Builds rfs key
     static void create_flow_tuple_key_from_pcb(flow_tuple &key, struct tcp_pcb *pcb);

--- a/src/core/sock/sockinfo_tcp.h
+++ b/src/core/sock/sockinfo_tcp.h
@@ -291,9 +291,6 @@ public:
     }
 
     bool is_incoming() override { return m_b_incoming; }
-    bool is_timer_registered() const { return m_timer_registered; }
-    void set_timer_registered(bool v) { m_timer_registered = v; }
-
     bool is_connected() { return m_sock_state == TCP_SOCK_CONNECTED_RDWR; }
 
     inline bool is_rtr()
@@ -318,6 +315,8 @@ public:
     inline fd_type_t get_type() override { return FD_TYPE_SOCKET; }
 
     void handle_timer_expired();
+    bool is_timer_registered() const { return m_timer_registered; }
+    void set_timer_registered(bool v) { m_timer_registered = v; }
 
     inline ib_ctx_handler *get_ctx()
     {
@@ -375,9 +374,12 @@ public:
     void flush();
 
     void set_xlio_socket(const struct xlio_socket_attr *attr);
+    int update_xlio_socket(unsigned flags, uintptr_t userdata_sq);
+    bool is_xlio_socket() const { return m_p_group != nullptr; }
     void add_tx_ring_to_group();
-    bool is_xlio_socket() { return m_p_group != nullptr; }
-    poll_group *get_poll_group() { return m_p_group; }
+    poll_group *get_poll_group() const { return m_p_group; }
+    int detach_xlio_group();
+    int attach_xlio_group(poll_group *group);
     void xlio_socket_event(int event, int value);
     static err_t rx_lwip_cb_xlio_socket(void *arg, struct tcp_pcb *tpcb, struct pbuf *p, err_t err);
     static void err_lwip_cb_xlio_socket(void *pcb_container, err_t err);
@@ -456,8 +458,9 @@ private:
     void set_conn_properties_from_pcb();
     void set_sock_options(sockinfo_tcp *new_sock);
     void passthrough_unlock(const char *dbg);
-    // Register to timer
+
     void register_timer();
+    void remove_timer();
 
     void handle_socket_linger();
 

--- a/src/core/sock/sockinfo_tcp.h
+++ b/src/core/sock/sockinfo_tcp.h
@@ -375,9 +375,7 @@ public:
 
     void set_xlio_socket(const struct xlio_socket_attr *attr);
     int update_xlio_socket(unsigned flags, uintptr_t userdata_sq);
-    bool is_xlio_socket() const { return m_p_group != nullptr; }
     void add_tx_ring_to_group();
-    poll_group *get_poll_group() const { return m_p_group; }
     int detach_xlio_group();
     int attach_xlio_group(poll_group *group);
     void xlio_socket_event(int event, int value);
@@ -648,7 +646,6 @@ private:
      */
     bool m_b_xlio_socket_dirty = false;
     uintptr_t m_xlio_socket_userdata = 0;
-    poll_group *m_p_group = nullptr;
 };
 
 #endif

--- a/src/core/util/xlio_stats.h
+++ b/src/core/util/xlio_stats.h
@@ -359,6 +359,7 @@ typedef struct {
             uint32_t n_tx_dev_mem_allocated;
             uint32_t n_tx_num_bufs;
             uint32_t n_zc_num_bufs;
+            uint32_t n_rx_zc_migiration_drop;
         } simple;
         struct {
             char s_tap_name[IFNAMSIZ];

--- a/src/core/xlio.h
+++ b/src/core/xlio.h
@@ -241,11 +241,20 @@ struct ibv_pd;
 
 int xlio_socket_create(const struct xlio_socket_attr *attr, xlio_socket_t *sock_out);
 int xlio_socket_destroy(xlio_socket_t sock);
+int xlio_socket_update(xlio_socket_t sock, unsigned flags, uintptr_t userdata_sq);
+
 int xlio_socket_setsockopt(xlio_socket_t sock, int level, int optname, const void *optval,
                            socklen_t optlen);
+int xlio_socket_getpeername(xlio_socket_t sock, struct sockaddr *addr, socklen_t *addrlen);
+
 int xlio_socket_bind(xlio_socket_t sock, const struct sockaddr *addr, socklen_t addrlen);
 int xlio_socket_connect(xlio_socket_t sock, const struct sockaddr *to, socklen_t tolen);
+int xlio_socket_listen(xlio_socket_t sock);
 struct ibv_pd *xlio_socket_get_pd(xlio_socket_t sock);
+
+/* Socket migration */
+int xlio_socket_detach_group(xlio_socket_t sock);
+int xlio_socket_attach_group(xlio_socket_t sock, xlio_poll_group_t group);
 
 /*
  * TX flow.

--- a/src/core/xlio.h
+++ b/src/core/xlio.h
@@ -245,6 +245,7 @@ int xlio_socket_update(xlio_socket_t sock, unsigned flags, uintptr_t userdata_sq
 
 int xlio_socket_setsockopt(xlio_socket_t sock, int level, int optname, const void *optval,
                            socklen_t optlen);
+int xlio_socket_getsockname(xlio_socket_t sock, struct sockaddr *addr, socklen_t *addrlen);
 int xlio_socket_getpeername(xlio_socket_t sock, struct sockaddr *addr, socklen_t *addrlen);
 
 int xlio_socket_bind(xlio_socket_t sock, const struct sockaddr *addr, socklen_t addrlen);

--- a/src/core/xlio_extra.h
+++ b/src/core/xlio_extra.h
@@ -113,11 +113,16 @@ struct __attribute__((packed)) xlio_api_t {
     void (*xlio_poll_group_poll)(xlio_poll_group_t group);
     int (*xlio_socket_create)(const struct xlio_socket_attr *attr, xlio_socket_t *sock_out);
     int (*xlio_socket_destroy)(xlio_socket_t sock);
+    int (*xlio_socket_update)(xlio_socket_t sock, unsigned flags, uintptr_t userdata_sq);
     int (*xlio_socket_setsockopt)(xlio_socket_t sock, int level, int optname, const void *optval,
                                   socklen_t optlen);
+    int (*xlio_socket_getpeername)(xlio_socket_t sock, struct sockaddr *addr, socklen_t *addrlen);
     int (*xlio_socket_bind)(xlio_socket_t sock, const struct sockaddr *addr, socklen_t addrlen);
     int (*xlio_socket_connect)(xlio_socket_t sock, const struct sockaddr *to, socklen_t tolen);
+    int (*xlio_socket_listen)(xlio_socket_t sock);
     struct ibv_pd *(*xlio_socket_get_pd)(xlio_socket_t sock);
+    int (*xlio_socket_detach_group)(xlio_socket_t sock);
+    int (*xlio_socket_attach_group)(xlio_socket_t sock, xlio_poll_group_t group);
     int (*xlio_socket_send)(xlio_socket_t sock, const void *data, size_t len,
                             const struct xlio_socket_send_attr *attr);
     int (*xlio_socket_sendv)(xlio_socket_t sock, const struct iovec *iov, unsigned iovcnt,

--- a/src/core/xlio_extra.h
+++ b/src/core/xlio_extra.h
@@ -107,6 +107,7 @@ struct __attribute__((packed)) xlio_api_t {
      * XLIO Socket API.
      */
     int (*xlio_init_ex)(const struct xlio_init_attr *attr);
+    int (*xlio_exit)(void);
     int (*xlio_poll_group_create)(const struct xlio_poll_group_attr *attr,
                                   xlio_poll_group_t *group_out);
     int (*xlio_poll_group_destroy)(xlio_poll_group_t group);

--- a/src/core/xlio_extra.h
+++ b/src/core/xlio_extra.h
@@ -116,6 +116,7 @@ struct __attribute__((packed)) xlio_api_t {
     int (*xlio_socket_update)(xlio_socket_t sock, unsigned flags, uintptr_t userdata_sq);
     int (*xlio_socket_setsockopt)(xlio_socket_t sock, int level, int optname, const void *optval,
                                   socklen_t optlen);
+    int (*xlio_socket_getsockname)(xlio_socket_t sock, struct sockaddr *addr, socklen_t *addrlen);
     int (*xlio_socket_getpeername)(xlio_socket_t sock, struct sockaddr *addr, socklen_t *addrlen);
     int (*xlio_socket_bind)(xlio_socket_t sock, const struct sockaddr *addr, socklen_t addrlen);
     int (*xlio_socket_connect)(xlio_socket_t sock, const struct sockaddr *to, socklen_t tolen);

--- a/src/core/xlio_types.h
+++ b/src/core/xlio_types.h
@@ -303,6 +303,9 @@ typedef void (*xlio_socket_comp_cb_t)(xlio_socket_t, uintptr_t userdata_sq, uint
 typedef void (*xlio_socket_rx_cb_t)(xlio_socket_t, uintptr_t userdata_sq, void *data, size_t len,
                                     struct xlio_buf *buf);
 
+typedef void (*xlio_socket_accept_cb_t)(xlio_socket_t sock, xlio_socket_t parent,
+                                        uintptr_t parent_userdata_sq);
+
 /*
  * XLIO Socket API attribute structures
  */
@@ -327,6 +330,7 @@ struct xlio_poll_group_attr {
     xlio_socket_event_cb_t socket_event_cb;
     xlio_socket_comp_cb_t socket_comp_cb;
     xlio_socket_rx_cb_t socket_rx_cb;
+    xlio_socket_accept_cb_t socket_accept_cb;
 };
 
 struct xlio_socket_attr {

--- a/src/stats/stats_reader.cpp
+++ b/src/stats/stats_reader.cpp
@@ -331,6 +331,10 @@ void update_delta_ring_stat(ring_stats_t *p_curr_ring_stats, ring_stats_t *p_pre
             (p_curr_ring_stats->simple.n_tx_dropped_wqes -
              p_prev_ring_stats->simple.n_tx_dropped_wqes) /
             delay;
+        p_prev_ring_stats->simple.n_rx_zc_migiration_drop =
+            (p_curr_ring_stats->simple.n_rx_zc_migiration_drop -
+             p_prev_ring_stats->simple.n_rx_zc_migiration_drop) /
+            delay;
         p_prev_ring_stats->simple.n_tx_num_bufs =
             (p_curr_ring_stats->simple.n_tx_num_bufs - p_prev_ring_stats->simple.n_tx_num_bufs) /
             delay;
@@ -496,6 +500,10 @@ void print_ring_stats(ring_instance_block_t *p_ring_inst_arr)
             if (p_ring_stats->simple.n_tx_dropped_wqes) {
                 printf(FORMAT_STATS_64bit,
                        "TX Dropped Send Reqs:", p_ring_stats->simple.n_tx_dropped_wqes, post_fix);
+            }
+            if (p_ring_stats->simple.n_rx_zc_migiration_drop) {
+                printf(FORMAT_STATS_32bit,
+                       "RX ZC Migration Drop:", p_ring_stats->simple.n_rx_zc_migiration_drop);
             }
 
 #ifdef DEFINED_UTLS
@@ -1804,6 +1812,7 @@ void zero_ring_stats(ring_stats_t *p_ring_stats)
         p_ring_stats->simple.n_tx_dev_mem_oob = 0;
         p_ring_stats->simple.n_tx_num_bufs = 0;
         p_ring_stats->simple.n_zc_num_bufs = 0;
+        p_ring_stats->simple.n_rx_zc_migiration_drop = 0;
     }
 }
 

--- a/tests/extra_api/xlio_socket_api_listen.c
+++ b/tests/extra_api/xlio_socket_api_listen.c
@@ -1,0 +1,299 @@
+/*
+ * Copyright © 2019-2024 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/* g++ -I./install/include -L./install/lib -L../dpcp/install/lib -o test xlio_socket_api_listen.c -lxlio -lm -lnl-3 -ldpcp -libverbs -lmlx5 -lrdmacm -lnl-route-3 -g3 */
+/* LD_LIBRARY_PATH=./install/lib:../dpcp/install/lib ./test */
+/* Use `nc <IP> <PORT>` on the remote side */
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+#include <mellanox/xlio.h>
+#include <infiniband/verbs.h>
+
+#define LISTEN_MAGIC 0xdeadc0de
+
+static bool quit = false;
+static bool terminated = false;
+static int g_comp_events = 0;
+static char sndbuf[256];
+
+static struct ibv_pd *pd = NULL;
+static struct ibv_mr *mr_buf;
+
+static unsigned sock_nr = 0;
+static unsigned destroyed_sock_nr = 0;
+static xlio_socket_t sock_arr[32];
+
+static unsigned short listen_port = 8080;
+static const char *listen_ip = "";
+
+static void memory_cb(void *data, size_t size, size_t page_size)
+{
+    printf("Memory area allocated data=%p size=%zu page_size=%zu\n", data, size, page_size);
+}
+
+static void send_single_msg(xlio_socket_t sock, const void *data, size_t len, uintptr_t userdata_op,
+                            unsigned flags)
+{
+    struct xlio_socket_send_attr attr = {
+        .flags = flags,
+        .mkey = mr_buf->lkey,
+        .userdata_op = userdata_op,
+    };
+    memcpy(sndbuf, data, len);
+    int ret = xlio_socket_send(sock, sndbuf, len, &attr);
+    assert(ret == 0);
+    xlio_socket_flush(sock);
+}
+
+static void send_inline_msg(xlio_socket_t sock, const void *data, size_t len, uintptr_t userdata_op,
+                            unsigned flags)
+{
+    struct xlio_socket_send_attr attr = {
+        .flags = flags | XLIO_SOCKET_SEND_FLAG_INLINE,
+        .mkey = 0,
+        .userdata_op = userdata_op,
+    };
+    int ret = xlio_socket_send(sock, data, len, &attr);
+    assert(ret == 0);
+    xlio_socket_flush(sock);
+}
+
+static void socket_event_cb(xlio_socket_t sock, uintptr_t userdata_sq, int event, int value)
+{
+    if (event == XLIO_SOCKET_EVENT_ESTABLISHED) {
+        printf("Connection established (sock=%lx).\n", userdata_sq);
+    } else if (event == XLIO_SOCKET_EVENT_CLOSED) {
+        printf("Connection closed passively (sock=%lx).\n", userdata_sq);
+    } else if (event == XLIO_SOCKET_EVENT_TERMINATED) {
+        printf("Connection terminated (sock=%lx).\n", userdata_sq);
+        if (userdata_sq == LISTEN_MAGIC) {
+            terminated = true;
+        } else {
+            ++destroyed_sock_nr;
+        }
+    } else {
+        printf("Event callback: event=%d value=%d (sock=%lx).\n", event, value, userdata_sq);
+        if (event == XLIO_SOCKET_EVENT_ERROR) {
+            quit = true;
+        }
+    }
+}
+
+static void socket_comp_cb(xlio_socket_t sock, uintptr_t userdata_sq, uintptr_t userdata_op)
+{
+    const char *reply_msg = "completed\n";
+
+    printf("Completed zcopy buffer userdata_sq=%lx userdata_op=%lx.\n", userdata_sq, userdata_op);
+    assert(userdata_sq != 0);
+    assert(userdata_op != 0);
+
+    ++g_comp_events;
+    if (!quit) {
+        /*
+         * Don't send data after socket destroy, completions are still possible until
+         * XLIO_SOCKET_EVENT_TERMINATED event arrives.
+         */
+        send_single_msg(sock, reply_msg, strlen(reply_msg), 0, 0);
+    }
+}
+
+static void socket_rx_cb(xlio_socket_t sock, uintptr_t userdata_sq, void *data, size_t len,
+                         struct xlio_buf *buf)
+{
+    char *msg = (char *)malloc(len + 1);
+    memcpy(msg, data, len);
+    msg[len] = '\0';
+    if (len > 0 && msg[len - 1] == '\n') {
+        msg[len - 1] = '\0';
+    }
+    printf("RECV: %s\n", msg);
+    if (strncmp(msg, "quit", 4) == 0 || strncmp(msg, "exit", 4) == 0) {
+        quit = true;
+    }
+    free(msg);
+
+    send_single_msg(sock, data, len, 0xdeadbeef, 0);
+    xlio_socket_buf_free(sock, buf);
+}
+
+static void socket_accept_cb(xlio_socket_t sock, xlio_socket_t parent_sock,
+                             uintptr_t parent_userdata)
+{
+    struct sockaddr_in6 sa = {};
+    socklen_t len = sizeof(sa);
+    int rc;
+    unsigned short port = 0;
+    char buf[64] = "";
+
+    rc = xlio_socket_getpeername(sock, (struct sockaddr *)&sa, &len);
+    if (rc != 0) {
+        printf("Failed to get peername of an incoming socket.\n");
+        // XXX Cannot close the socket in this callback in the current implementation.
+        return;
+    }
+
+    switch (sa.sin6_family) {
+    case AF_INET:
+        inet_ntop(AF_INET, &((struct sockaddr_in *)&sa)->sin_addr, buf, sizeof(buf));
+        port = ntohs(((struct sockaddr_in *)&sa)->sin_port);
+        break;
+    case AF_INET6:
+        inet_ntop(AF_INET6, &sa.sin6_addr, buf, sizeof(buf));
+        port = ntohs(sa.sin6_port);
+        break;
+    default:
+        printf("Unknown AF: %u.\n", sa.sin6_family);
+    }
+
+    if (!pd) {
+        pd = xlio_socket_get_pd(sock);
+        assert(pd != NULL);
+        mr_buf = ibv_reg_mr(pd, sndbuf, sizeof(sndbuf), IBV_ACCESS_LOCAL_WRITE);
+        assert(mr_buf != NULL);
+    }
+
+    sock_arr[sock_nr++] = sock;
+
+    uintptr_t userdata_sq = (uintptr_t)sock_nr;
+    rc = xlio_socket_update(sock, 0, userdata_sq);
+    if (rc != 0) {
+        printf("Failed to update context of an incoming socket.\n");
+    }
+    printf("Accepted incoming connection from %s:%u userdata_sq=%lx.\n", buf, port, userdata_sq);
+}
+
+int main(int argc, char **argv)
+{
+    xlio_poll_group_t group;
+    xlio_socket_t sock;
+    int rc;
+
+    struct xlio_init_attr iattr = {
+        .flags = 0,
+        .memory_cb = &memory_cb,
+    };
+    struct xlio_poll_group_attr gattr = {
+        .socket_event_cb = &socket_event_cb,
+        .socket_comp_cb = &socket_comp_cb,
+        .socket_rx_cb = &socket_rx_cb,
+        .socket_accept_cb = &socket_accept_cb,
+    };
+
+    if (argc > 1 && (strcmp(argv[1], "--help") == 0 || strcmp(argv[1], "-h") == 0)) {
+        printf("Usage: %s [IP [PORT]]\n", argv[0]);
+        printf("Run 'nc <IP> <PORT>' on the client side.\n");
+        printf("Type messages on the nc side.\n");
+        printf("Message 'quit' or 'exit' will terminate the server.\n");
+        return 0;
+    }
+
+    rc = xlio_init_ex(&iattr);
+    assert(rc == 0);
+
+    rc = xlio_poll_group_create(&gattr, &group);
+    assert(rc == 0);
+
+    printf("Group created.\n");
+
+    struct xlio_socket_attr sattr = {
+        .domain = AF_INET,
+        .group = group,
+        .userdata_sq = LISTEN_MAGIC,
+    };
+
+    rc = xlio_socket_create(&sattr, &sock);
+    assert(rc == 0);
+
+    printf("Listen socket created.\n");
+
+    if (argc > 1) {
+        listen_ip = argv[1];
+    }
+    if (argc > 2) {
+        listen_port = atoi(argv[2]);
+    }
+    struct sockaddr_in addr = {};
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(listen_port);
+    if (listen_ip[0] != '\0') {
+        rc = inet_aton(argv[1], &addr.sin_addr);
+        assert(rc != 0);
+    }
+    rc = xlio_socket_bind(sock, (struct sockaddr *)&addr, sizeof(addr));
+    assert(rc == 0);
+
+    printf("Listen socket bound to %s:%u.\n", listen_ip, listen_port);
+
+    rc = xlio_socket_listen(sock);
+    assert(rc == 0);
+
+    printf("Listen.\n");
+    printf("Starting polling loop.\n");
+
+    while (!quit) {
+        xlio_poll_group_poll(group);
+    }
+
+    printf("Quiting...\n");
+
+    rc = xlio_socket_destroy(sock);
+    assert(rc == 0);
+    for (unsigned i = 0; i < sock_nr; ++i) {
+        rc = xlio_socket_destroy(sock_arr[i]);
+        assert(rc == 0);
+    }
+    while (!terminated || destroyed_sock_nr < sock_nr) {
+        xlio_poll_group_poll(group);
+    }
+
+    printf("All the sockets are destroyed.\n");
+
+    rc = xlio_poll_group_destroy(group);
+    assert(rc == 0);
+
+    printf("Zerocopy completion events: %d\n", g_comp_events);
+
+    if (mr_buf) {
+        ibv_dereg_mr(mr_buf);
+    }
+    xlio_exit();
+
+    return 0;
+}

--- a/tests/extra_api/xlio_socket_api_listen.c
+++ b/tests/extra_api/xlio_socket_api_listen.c
@@ -1,33 +1,7 @@
 /*
- * Copyright © 2019-2024 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
- *
- * This software is available to you under a choice of one of two
- * licenses.  You may choose to be licensed under the terms of the GNU
- * General Public License (GPL) Version 2, available from the file
- * COPYING in the main directory of this source tree, or the
- * BSD license below:
- *
- *     Redistribution and use in source and binary forms, with or
- *     without modification, are permitted provided that the following
- *     conditions are met:
- *
- *      - Redistributions of source code must retain the above
- *        copyright notice, this list of conditions and the following
- *        disclaimer.
- *
- *      - Redistributions in binary form must reproduce the above
- *        copyright notice, this list of conditions and the following
- *        disclaimer in the documentation and/or other materials
- *        provided with the distribution.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
- * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
- * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
- * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+ * Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: GPL-2.0-only or BSD-2-Clause
  */
 
 /* g++ -I./install/include -L./install/lib -L../dpcp/install/lib -o test xlio_socket_api_listen.c -lxlio -lm -lnl-3 -ldpcp -libverbs -lmlx5 -lrdmacm -lnl-route-3 -g3 */

--- a/tests/extra_api/xlio_socket_listen_migrate.c
+++ b/tests/extra_api/xlio_socket_listen_migrate.c
@@ -1,0 +1,475 @@
+/*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+ * Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: GPL-2.0-only or BSD-2-Clause
+ */
+
+/* g++ -I./install/include -L./install/lib -L../dpcp/install/lib -o test xlio_socket_api_listen.c -lxlio -lm -lnl-3 -ldpcp -libverbs -lmlx5 -lrdmacm -lnl-route-3 -g3 */
+/* LD_LIBRARY_PATH=./install/lib:../dpcp/install/lib ./test */
+/* Use `nc <IP> <PORT>` on the remote side */
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <pthread.h>
+#include <unistd.h>
+#include <stdarg.h>
+#include <time.h>
+
+#include <mellanox/xlio.h>
+#include <infiniband/verbs.h>
+
+#define LISTEN_MAGIC 0xdeadc0de
+#define MIGRATE_GROUP_CMD "mg"
+
+static bool quit = false;
+static bool terminated = false;
+static int g_comp_events = 0;
+static int g1_comp_events = 0;
+static int g2_comp_events = 0;
+static size_t g1_rx_bytes = 0;
+static size_t g2_rx_bytes = 0;
+static char     sndbuf[256];
+
+static struct ibv_pd *pd = NULL;
+static struct ibv_mr *mr_buf;
+
+static unsigned sock_nr = 0;
+static unsigned destroyed_sock_nr = 0;
+
+typedef enum {
+    NORMAL = 1,
+    WANT_TO_MIGRATE,
+    MOVE_TO_GROUP2,
+    MOVE_TO_GROUP1
+} socket_phase_t;
+
+typedef struct {
+    xlio_socket_t sock;
+    socket_phase_t phase;
+    xlio_poll_group_t current_group;
+    time_t detach_time;  // Timestamp when socket was detached
+} socket_info_t;
+
+static socket_info_t sock_arr[32] = {0};
+static pthread_mutex_t sock_arr_mutex = PTHREAD_MUTEX_INITIALIZER;
+
+
+static unsigned short listen_port = 8080;
+static const char *listen_ip = "";
+static int jitter_seconds = 0;  // New global variable for jitter control
+
+static xlio_poll_group_t group_1;
+static xlio_poll_group_t group_2;
+static pthread_t thread_2;
+
+static void log_print(const char *format, ...)
+{
+    va_list args;
+    va_start(args, format);
+    vprintf(format, args);
+    va_end(args);
+    fflush(stdout);
+    fflush(stderr);
+}
+
+static void memory_cb(void *data, size_t size, size_t page_size)
+{
+    log_print("Memory area allocated data=%p size=%zu page_size=%zu\n", data, size, page_size);
+}
+
+static void send_single_msg(xlio_socket_t sock, const void *data, size_t len, uintptr_t userdata_op,
+                            unsigned flags)
+{
+    struct xlio_socket_send_attr attr = {
+        .flags = flags,
+        .mkey = mr_buf->lkey,
+        .userdata_op = userdata_op,
+    };
+    memcpy(sndbuf, data, len);
+    int ret = xlio_socket_send(sock, sndbuf, len, &attr);
+    assert(ret == 0);
+    xlio_socket_flush(sock);
+}
+
+static void send_inline_msg(xlio_socket_t sock, const void *data, size_t len, uintptr_t userdata_op,
+                            unsigned flags)
+{
+    struct xlio_socket_send_attr attr = {
+        .flags = flags | XLIO_SOCKET_SEND_FLAG_INLINE,
+        .mkey = 0,
+        .userdata_op = userdata_op,
+    };
+    int ret = xlio_socket_send(sock, data, len, &attr);
+    assert(ret == 0);
+    xlio_socket_flush(sock);
+}
+
+static void send_single_msg_with_prefix(xlio_socket_t sock, const char *msg, size_t len, uintptr_t userdata_op, unsigned flags)
+{
+    char prefixed_msg[256];
+    prefixed_msg[0] = '>';
+    prefixed_msg[1] = ' ';
+    memcpy(prefixed_msg + 2, msg, len);
+    send_single_msg(sock, prefixed_msg, len + 2, userdata_op, flags);
+}
+
+static void socket_event_cb(xlio_socket_t sock, uintptr_t userdata_sq, int event, int value)
+{
+    if (event == XLIO_SOCKET_EVENT_ESTABLISHED) {
+        log_print("Connection established (sock=%lx).\n", sock);
+    } else if (event == XLIO_SOCKET_EVENT_CLOSED) {
+        log_print("Connection closed passively (sock=%lx).\n", sock);
+    } else if (event == XLIO_SOCKET_EVENT_TERMINATED) {
+        log_print("Connection terminated (sock=%lx).\n", sock);
+        if (userdata_sq == LISTEN_MAGIC) {
+            terminated = true;
+        } else {
+            ++destroyed_sock_nr;
+        }
+    } else {
+        log_print("Event callback: event=%d value=%d (sock=%lx).\n", event, value, userdata_sq);
+        if (event == XLIO_SOCKET_EVENT_ERROR) {
+            quit = true;
+        }
+    }
+}
+
+static inline int find_socket_index(xlio_socket_t sock)
+{
+    for (unsigned i = 0; i < sock_nr; i++) {
+        if (sock_arr[i].sock == sock) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+static void socket_comp_cb(xlio_socket_t sock, uintptr_t userdata_sq, uintptr_t userdata_op)
+{
+    const char *reply_msg = "> comp_cb\n";
+
+    log_print("Completed zcopy buffer userdata_sq=%lx userdata_op=%lx.\n", userdata_sq, userdata_op);
+    assert(userdata_sq != 0);
+    assert(userdata_op != 0);
+
+    ++g_comp_events;
+    int idx = find_socket_index(sock);
+    if (idx >= 0) {
+        if (sock_arr[idx].current_group == group_1) {
+            ++g1_comp_events;
+        } else if (sock_arr[idx].current_group == group_2) {
+            ++g2_comp_events;
+        }
+    }
+}
+
+static void handle_quit_exit_and_migrategroup(xlio_socket_t sock, const char *msg, uintptr_t userdata_sq)
+{
+    if (strstr(msg, "quit") || strstr(msg, "exit")) {
+        quit = true;
+        return;
+    }
+    
+    if (strstr(msg, MIGRATE_GROUP_CMD)) {
+        int idx = find_socket_index(sock);
+        if (idx >= 0) {
+            sock_arr[idx].phase = WANT_TO_MIGRATE;
+            log_print("Socket %d marked for migration\n",idx);
+        }
+    }
+}
+
+static inline void mem_copy_and_add_nl(const void *data, size_t len, char *msg)
+{
+    memcpy(msg, data, len);
+    msg[len] = '\0';
+    if (len > 0 && msg[len - 1] == '\n') {
+        msg[len - 1] = '\0';
+    }
+}
+
+static void socket_rx_cb(xlio_socket_t sock, uintptr_t userdata_sq, void *data, size_t len,
+                         struct xlio_buf *buf)
+{
+    int idx = find_socket_index(sock);
+    if (idx >= 0) {
+        if (sock_arr[idx].current_group == group_1) {
+            g1_rx_bytes += len;
+        } else if (sock_arr[idx].current_group == group_2) {
+            g2_rx_bytes += len;
+        }
+    }
+    
+    char *msg = (char *)malloc(len + 1);
+    mem_copy_and_add_nl(data, len, msg);
+
+    handle_quit_exit_and_migrategroup(sock, msg, userdata_sq);
+    free(msg);
+    xlio_socket_buf_free(sock, buf);
+}
+
+static void socket_accept_cb(xlio_socket_t sock, xlio_socket_t parent_sock,
+                             uintptr_t parent_userdata)
+{
+    struct sockaddr_in6 sa = {};
+    socklen_t len = sizeof(sa);
+    int rc;
+    unsigned short port = 0;
+    char buf[64] = "";
+
+    rc = xlio_socket_getpeername(sock, (struct sockaddr *)&sa, &len);
+    if (rc != 0) {
+        log_print("Failed to get peername of an incoming socket.\n");
+        // XXX Cannot close the socket in this callback in the current implementation.
+        return;
+    }
+
+    switch (sa.sin6_family) {
+    case AF_INET:
+        inet_ntop(AF_INET, &((struct sockaddr_in *)&sa)->sin_addr, buf, sizeof(buf));
+        port = ntohs(((struct sockaddr_in *)&sa)->sin_port);
+        break;
+    case AF_INET6:
+        inet_ntop(AF_INET6, &sa.sin6_addr, buf, sizeof(buf));
+        port = ntohs(sa.sin6_port);
+        break;
+    default:
+        log_print("Unknown AF: %u.\n", sa.sin6_family);
+    }
+
+    sock_arr[sock_nr].sock = sock;
+    sock_arr[sock_nr].phase = NORMAL;
+    sock_arr[sock_nr].current_group = group_1;
+    sock_nr++;
+
+    uintptr_t userdata_sq = (uintptr_t)sock_nr;
+    rc = xlio_socket_update(sock, 0, userdata_sq);
+    if (rc != 0) {
+        log_print("Failed to update context of an incoming socket.\n");
+    }
+
+    if (!pd) {
+        pd = xlio_socket_get_pd(sock);
+        assert(pd != NULL);
+        mr_buf = ibv_reg_mr(pd, sndbuf, sizeof(sndbuf), IBV_ACCESS_LOCAL_WRITE);
+        assert(mr_buf != NULL);
+    }
+
+    log_print("Accepted incoming connection from %s:%u userdata_sq=%lx.\n", buf, port, userdata_sq);
+
+    const char* reply_msg = "Connected to group1\n";
+}
+
+static inline void handle_socket_want_to_migrate(xlio_poll_group_t group, unsigned i)
+{
+    log_print("Detaching socket %d from group%d\n", i, (group == group_1) ? 1 : 2);
+    int rc = xlio_socket_detach_group(sock_arr[i].sock);
+    assert(rc == 0);
+    sock_arr[i].phase = (group == group_1) ? MOVE_TO_GROUP2 : MOVE_TO_GROUP1;
+    sock_arr[i].current_group = 0;
+    sock_arr[i].detach_time = time(NULL);  // Set detach_time when we actually detach
+}
+
+static void check_if_socket_want_to_migrate(xlio_poll_group_t group)
+{
+    for (unsigned i = 0; i < sock_nr; i++) {
+        if (sock_arr[i].current_group == group && sock_arr[i].phase == WANT_TO_MIGRATE) {
+            handle_socket_want_to_migrate(group, i);
+        }
+    }
+}
+
+static inline void update_pd_and_mr(xlio_socket_t sock)
+{
+    struct ibv_pd *new_pd = xlio_socket_get_pd(sock);
+    if (new_pd->handle != pd->handle) {
+        ibv_dereg_mr(mr_buf);
+        pd = new_pd;
+        mr_buf = ibv_reg_mr(pd, sndbuf, sizeof(sndbuf), IBV_ACCESS_LOCAL_WRITE);
+        assert(mr_buf != NULL);
+    }
+}
+
+static void handle_socket_migration_to_us(xlio_poll_group_t group, unsigned i)
+{
+    time_t current_time = time(NULL);
+    time_t elapsed = current_time - sock_arr[i].detach_time;
+    
+    if (jitter_seconds > 0 && elapsed < jitter_seconds) {
+        // Not enough time has passed, skip this socket for now
+        return;
+    }
+
+    log_print("Socket %d: Attaching to group%d after %ld seconds delay (detached at: %ld, attaching at: %ld)\n", 
+             i, (group == group_1) ? 1 : 2, elapsed, sock_arr[i].detach_time, current_time);
+    int rc = xlio_socket_attach_group(sock_arr[i].sock, group);
+    assert(rc == 0);
+    sock_arr[i].phase = NORMAL;
+    sock_arr[i].current_group = group;
+    
+    update_pd_and_mr(sock_arr[i].sock);
+    
+    const char* msg = (group == group_1) ? "Migrated to group1\n" : "Migrated to group2\n";
+
+}
+
+static void check_if_some_socket_want_to_migrate_to_us(xlio_poll_group_t group)
+{
+    for (unsigned i = 0; i < sock_nr; i++) {
+        if ((group == group_1 && sock_arr[i].phase == MOVE_TO_GROUP1) ||
+            (group == group_2 && sock_arr[i].phase == MOVE_TO_GROUP2)) {
+            handle_socket_migration_to_us(group, i);
+        }
+    }
+}
+
+static void *thread_group2_func(void *arg)
+{
+    while (!quit) {
+        xlio_poll_group_poll(group_2);
+        check_if_socket_want_to_migrate(group_2);
+        check_if_some_socket_want_to_migrate_to_us(group_2);
+    }
+    return NULL;
+}
+
+int main(int argc, char **argv)
+{
+    xlio_socket_t sock;
+    int rc;
+
+    struct xlio_init_attr iattr = {
+        .flags = 0,
+        .memory_cb = &memory_cb,
+    };
+    struct xlio_poll_group_attr gattr = {
+        .flags = 0,
+        .socket_event_cb = &socket_event_cb,
+        .socket_comp_cb = &socket_comp_cb,
+        .socket_rx_cb = &socket_rx_cb,
+        .socket_accept_cb = &socket_accept_cb,
+    };
+
+    if (argc > 1 && (strcmp(argv[1], "--help") == 0 || strcmp(argv[1], "-h") == 0)) {
+        log_print("Usage: %s [--jitter SECONDS] [IP [PORT]]\n", argv[0]);
+        log_print("Run 'nc <IP> <PORT>' on the client side.\n");
+        log_print("Type messages on the nc side.\n");
+        log_print("Message 'quit' or 'exit' will terminate the server.\n");
+        log_print("Message 'mg' will migrate the socket between groups.\n");
+        log_print("--jitter SECONDS: Add delay between detach and attach operations\n");
+        return 0;
+    }
+
+    // Check for jitter
+    int arg_offset = 1;
+    if (argc > arg_offset && strcmp(argv[arg_offset], "--jitter") == 0) {
+        if (argc <= arg_offset + 1) {
+            log_print("Error: --jitter requires a value in seconds\n");
+            return 1;
+        }
+        jitter_seconds = atoi(argv[arg_offset + 1]);
+        if (jitter_seconds < 0) {
+            log_print("Error: jitter value must be non-negative\n");
+            return 1;
+        }
+        arg_offset += 2;
+    }
+
+    rc = xlio_init_ex(&iattr);
+    assert(rc == 0);
+
+    rc = xlio_poll_group_create(&gattr, &group_1);
+    assert(rc == 0);
+    log_print("Group_1 created.\n");
+    rc = xlio_poll_group_create(&gattr, &group_2);
+    assert(rc == 0);
+    log_print("Group_2 created.\n");
+
+    struct xlio_socket_attr sattr = {
+        .domain = AF_INET,
+        .group = group_1,
+        .userdata_sq = LISTEN_MAGIC,
+    };
+
+    rc = xlio_socket_create(&sattr, &sock);
+    assert(rc == 0);
+
+    log_print("Listen socket created.\n");
+
+    if (argc > arg_offset) {
+        listen_ip = argv[arg_offset];
+    }
+    if (argc > arg_offset + 1) {
+        listen_port = atoi(argv[arg_offset + 1]);
+    }
+    struct sockaddr_in addr = {};
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(listen_port);
+    if (listen_ip[0] != '\0') {
+        rc = inet_aton(argv[arg_offset], &addr.sin_addr);
+        assert(rc != 0);
+    }
+    rc = xlio_socket_bind(sock, (struct sockaddr *)&addr, sizeof(addr));
+    assert(rc == 0);
+
+    log_print("Listen socket bound to %s:%u.\n", listen_ip, listen_port);
+    rc = xlio_socket_listen(sock);
+    assert(rc == 0);
+
+    log_print("Listen.\n");
+    log_print("Starting polling loop.\n");
+
+    // Create only thread2 for group2
+    pthread_create(&thread_2, NULL, thread_group2_func, NULL);
+
+    // Main thread handles group1 polling
+    while (!quit) {
+        xlio_poll_group_poll(group_1);
+        check_if_socket_want_to_migrate(group_1);
+        check_if_some_socket_want_to_migrate_to_us(group_1);
+    }
+
+    log_print("Quiting...\n");
+
+    // Wait for thread2 to finish
+    pthread_join(thread_2, NULL);
+
+    rc = xlio_socket_destroy(sock);
+    assert(rc == 0);
+    for (unsigned i = 0; i < sock_nr; ++i) {
+        rc = xlio_socket_destroy(sock_arr[i].sock);
+        assert(rc == 0);
+    }
+    while (!terminated || destroyed_sock_nr < sock_nr) {
+        xlio_poll_group_poll(group_1);
+        xlio_poll_group_poll(group_2);
+    }
+
+    log_print("All the sockets are destroyed.\n");
+
+    rc = xlio_poll_group_destroy(group_1);
+    assert(rc == 0);
+    rc = xlio_poll_group_destroy(group_2);
+    assert(rc == 0);
+
+    log_print("Total zerocopy completion events: %d\n", g_comp_events);
+    log_print("Group1 zerocopy completion events: %d\n", g1_comp_events);
+    log_print("Group2 zerocopy completion events: %d\n", g2_comp_events);
+    log_print("Group1 received bytes: %zu\n", g1_rx_bytes);
+    log_print("Group2 received bytes: %zu\n", g2_rx_bytes);
+    log_print("Total received bytes: %zu\n", g1_rx_bytes + g2_rx_bytes);
+
+    if (mr_buf) {
+        ibv_dereg_mr(mr_buf);
+    }
+    pthread_mutex_destroy(&sock_arr_mutex);
+    xlio_exit();
+
+    return 0;
+}

--- a/tests/gtest/Makefile.am
+++ b/tests/gtest/Makefile.am
@@ -129,7 +129,14 @@ gtest_SOURCES = \
 	xliod/xliod_hash.cc \
 	xliod/xliod_init.cc \
 	xliod/xliod_state.cc \
-	xliod/xliod_flow.cc
+	xliod/xliod_flow.cc \
+	\
+	xlio_zc_api/xlio_socket.cc \
+	xlio_zc_api/xlio_socket_listen_connect.cc \
+	xlio_zc_api/xlio_socket_migrate.cc \
+	xlio_zc_api/xlio_socket_migrate_2.cc \
+	xlio_zc_api/xlio_socket_send_receive.cc \
+	xlio_zc_api/xlio_socket_send_receive_2.cc
 
 noinst_HEADERS = \
 	common/tap.h \

--- a/tests/gtest/core/xlio_base.cc
+++ b/tests/gtest/core/xlio_base.cc
@@ -12,6 +12,10 @@
 
 #include "xlio_base.h"
 
+#if defined(EXTRA_API_ENABLED) && (EXTRA_API_ENABLED == 1)
+struct xlio_api_t *xlio_base::xlio_api = nullptr;
+#endif /* EXTRA_API_ENABLED */
+
 void xlio_base::SetUp()
 {
     errno = EOK;

--- a/tests/gtest/core/xlio_base.h
+++ b/tests/gtest/core/xlio_base.h
@@ -8,7 +8,7 @@
 #define TESTS_GTEST_XLIO_BASE_H_
 
 #include <xlio_extra.h>
-
+#include <xlio_types.h>
 /**
  * To enable xlio tests you need to set below EXTRA_API_ENABLED to 1
  * or you can add the following CPPFLAG during compilation 'make CPPFLAGS="-DEXTRA_API_ENABLED=1"'
@@ -27,8 +27,64 @@ protected:
 
 protected:
 #if defined(EXTRA_API_ENABLED) && (EXTRA_API_ENABLED == 1)
-    struct xlio_api_t *xlio_api;
+    static struct xlio_api_t *xlio_api;
 #endif /* EXTRA_API_ENABLED */
 };
+
+#if defined(EXTRA_API_ENABLED) && (EXTRA_API_ENABLED == 1)
+class xlio_zc_api_base : public xlio_base {
+public:
+    virtual void SetUp()
+    {
+        xlio_base::SetUp();
+        errno = EOK;
+        base_init_xlio_zc_api();
+    };
+    void base_create_poll_group(xlio_poll_group_attr *attr, xlio_poll_group_t *group)
+    {
+        int rc;
+        rc = xlio_api->xlio_poll_group_create(attr, group);
+        ASSERT_TRUE(rc == 0);
+    }
+    void base_destroy_poll_group(xlio_poll_group_t group)
+    {
+        int rc;
+        rc = xlio_api->xlio_poll_group_destroy(group);
+        ASSERT_TRUE(rc == 0);
+    }
+    void base_create_socket(xlio_socket_attr *attr, xlio_socket_t *sock)
+    {
+
+        int rc;
+        rc = xlio_api->xlio_socket_create(attr, sock);
+        ASSERT_TRUE(rc == 0);
+    }
+    void base_destroy_socket(xlio_socket_t sock)
+    {
+        int rc;
+        rc = xlio_api->xlio_socket_destroy(sock);
+        ASSERT_TRUE(rc == 0);
+    }
+    void base_init_xlio_zc_api()
+    {
+        int rc;
+        struct xlio_init_attr iattr = {
+            .flags = 0,
+            .memory_cb = nullptr,
+            .memory_alloc = nullptr,
+            .memory_free = nullptr,
+        };
+
+        rc = xlio_api->xlio_init_ex(&iattr);
+        ASSERT_TRUE(rc == 0);
+    };
+    void base_cleanup_xlio_zc_api()
+    {
+        int rc;
+        rc = xlio_api->xlio_exit();
+        ASSERT_TRUE(rc == 0);
+    };
+};
+#endif /* EXTRA_API_ENABLED */
 
 #endif /* TESTS_GTEST_XLIO_BASE_H_ */

--- a/tests/gtest/xlio_zc_api/xlio_socket.cc
+++ b/tests/gtest/xlio_zc_api/xlio_socket.cc
@@ -1,0 +1,88 @@
+/*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+ * Copyright (c) 2021-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: GPL-2.0-only or BSD-2-Clause
+ */
+
+#include "common/def.h"
+#include "common/log.h"
+#include "common/sys.h"
+#include "common/base.h"
+#include "core/xlio_base.h"
+
+#if defined(EXTRA_API_ENABLED) && (EXTRA_API_ENABLED == 1)
+
+class zc_api_xlio_socket : public xlio_zc_api_base {
+public:
+    void create_poll_group(xlio_poll_group_t *group)
+    {
+        xlio_poll_group_attr gattr = {
+            .flags = 0,
+            .socket_event_cb = &socket_event_cb,
+            .socket_comp_cb = &socket_comp_cb,
+            .socket_rx_cb = &socket_rx_cb,
+            .socket_accept_cb = &socket_accept_cb,
+        };
+        base_create_poll_group(&gattr, group);
+    }
+    void destroy_poll_group(xlio_poll_group_t group) { base_destroy_poll_group(group); }
+    static void socket_event_cb(xlio_socket_t sock, uintptr_t userdata_sq, int event, int value)
+    {
+        UNREFERENCED_PARAMETER(sock);
+        UNREFERENCED_PARAMETER(userdata_sq);
+        UNREFERENCED_PARAMETER(event);
+        UNREFERENCED_PARAMETER(value);
+    }
+    static void socket_comp_cb(xlio_socket_t sock, uintptr_t userdata_sq, uintptr_t userdata_op)
+    {
+        UNREFERENCED_PARAMETER(sock);
+        UNREFERENCED_PARAMETER(userdata_sq);
+        UNREFERENCED_PARAMETER(userdata_op);
+    }
+
+    static void socket_rx_cb(xlio_socket_t sock, uintptr_t userdata_sq, void *data, size_t len,
+                             struct xlio_buf *buf)
+    {
+        UNREFERENCED_PARAMETER(sock);
+        UNREFERENCED_PARAMETER(userdata_sq);
+        UNREFERENCED_PARAMETER(data);
+        UNREFERENCED_PARAMETER(len);
+        UNREFERENCED_PARAMETER(buf);
+    }
+
+    static void socket_accept_cb(xlio_socket_t sock, xlio_socket_t parent_sock,
+                                 uintptr_t parent_userdata)
+    {
+        UNREFERENCED_PARAMETER(sock);
+        UNREFERENCED_PARAMETER(parent_sock);
+        UNREFERENCED_PARAMETER(parent_userdata);
+    }
+};
+
+/**
+ * @test zc_api_xlio_socket.ti_1
+ * @brief
+ *    Create TCP socket
+ * @details
+ */
+TEST_F(zc_api_xlio_socket, ti_1)
+{
+    xlio_zc_api_base::SetUp();
+    xlio_poll_group_t group;
+    xlio_socket_t sock;
+
+    create_poll_group(&group);
+    xlio_socket_attr sattr = {
+        .flags = 0,
+        .domain = AF_INET,
+        .group = group,
+        .userdata_sq = 0,
+    };
+    base_create_socket(&sattr, &sock);
+
+    base_destroy_socket(sock);
+
+    destroy_poll_group(group);
+}
+
+#endif /* EXTRA_API_ENABLED */

--- a/tests/gtest/xlio_zc_api/xlio_socket_listen_connect.cc
+++ b/tests/gtest/xlio_zc_api/xlio_socket_listen_connect.cc
@@ -1,0 +1,165 @@
+/*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+ * Copyright (c) 2021-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: GPL-2.0-only or BSD-2-Clause
+ */
+
+#include "common/def.h"
+#include "common/log.h"
+#include "common/sys.h"
+#include "common/base.h"
+#include "core/xlio_base.h"
+
+#if defined(EXTRA_API_ENABLED) && (EXTRA_API_ENABLED == 1)
+
+static int connected_counter = 0;
+static int terminated_counter = 0;
+static std::vector<xlio_socket_t> accepted_sockets;
+
+class zc_api_xlio_socket_listen_connect : public xlio_zc_api_base {
+public:
+    virtual void SetUp() { errno = EOK; };
+    virtual void TearDown() {};
+    void create_poll_group(xlio_poll_group_t *group)
+    {
+        xlio_poll_group_attr gattr = {
+            .flags = 0,
+            .socket_event_cb = &socket_event_cb,
+            .socket_comp_cb = &socket_comp_cb,
+            .socket_rx_cb = &socket_rx_cb,
+            .socket_accept_cb = &socket_accept_cb,
+        };
+        base_create_poll_group(&gattr, group);
+    }
+    void destroy_poll_group(xlio_poll_group_t group) { base_destroy_poll_group(group); }
+
+    void wait_for_delayed_acks(xlio_poll_group_t group)
+    {
+        struct timespec start_time;
+        clock_gettime(CLOCK_MONOTONIC, &start_time);
+        struct timespec current_time = {0, 0};
+        while (current_time.tv_sec - start_time.tv_sec < 1) {
+            xlio_api->xlio_poll_group_poll(group);
+            clock_gettime(CLOCK_MONOTONIC, &current_time);
+        }
+    }
+
+    static void socket_event_cb(xlio_socket_t sock, uintptr_t userdata_sq, int event, int value)
+    {
+        UNREFERENCED_PARAMETER(sock);
+        UNREFERENCED_PARAMETER(userdata_sq);
+        UNREFERENCED_PARAMETER(value);
+        if (event == XLIO_SOCKET_EVENT_ESTABLISHED) {
+            connected_counter++;
+        } else if (event == XLIO_SOCKET_EVENT_CLOSED) {
+            terminated_counter++;
+        } else if (event == XLIO_SOCKET_EVENT_TERMINATED) {
+            terminated_counter++;
+        }
+    }
+    static void socket_comp_cb(xlio_socket_t sock, uintptr_t userdata_sq, uintptr_t userdata_op)
+    {
+        UNREFERENCED_PARAMETER(sock);
+        UNREFERENCED_PARAMETER(userdata_sq);
+        UNREFERENCED_PARAMETER(userdata_op);
+    }
+
+    static void socket_rx_cb(xlio_socket_t sock, uintptr_t userdata_sq, void *data, size_t len,
+                             struct xlio_buf *buf)
+    {
+        UNREFERENCED_PARAMETER(sock);
+        UNREFERENCED_PARAMETER(userdata_sq);
+        UNREFERENCED_PARAMETER(data);
+        UNREFERENCED_PARAMETER(len);
+        UNREFERENCED_PARAMETER(buf);
+    }
+
+    static void socket_accept_cb(xlio_socket_t sock, xlio_socket_t parent_sock,
+                                 uintptr_t parent_userdata)
+    {
+        UNREFERENCED_PARAMETER(sock);
+        UNREFERENCED_PARAMETER(parent_sock);
+        UNREFERENCED_PARAMETER(parent_userdata);
+        accepted_sockets.push_back(sock);
+        connected_counter++;
+    }
+};
+
+/**
+ * @test socket_connect.ti_1
+ * @brief
+ *    Create TCP socket/listen(target)/connect(initiator)
+ * @details
+ */
+TEST_F(zc_api_xlio_socket_listen_connect, ti_1)
+{
+    int rc;
+    int pid = fork();
+    xlio_zc_api_base::SetUp();
+    xlio_poll_group_t group;
+    xlio_socket_t sock;
+
+    create_poll_group(&group);
+    xlio_socket_attr sattr = {
+        .flags = 0,
+        .domain = server_addr.addr.sa_family,
+        .group = group,
+        .userdata_sq = 0,
+    };
+
+    if (pid == 0) {
+        // Child process - server side
+        base_create_socket(&sattr, &sock);
+        rc = xlio_api->xlio_socket_bind(sock, (struct sockaddr *)&server_addr, sizeof(server_addr));
+        ASSERT_EQ(0, rc);
+        rc = xlio_api->xlio_socket_listen(sock);
+        ASSERT_EQ(0, rc);
+        barrier_fork(pid, true); // Tell parent that we are listening
+        while (connected_counter < 1) {
+            xlio_api->xlio_poll_group_poll(group);
+        }
+        wait_for_delayed_acks(group);
+        barrier_fork(pid, true); // Tell parent that we got last ack
+        base_destroy_socket(sock);
+        while (!accepted_sockets.empty()) {
+            base_destroy_socket(accepted_sockets.back());
+            accepted_sockets.pop_back();
+        }
+        while (terminated_counter < 1) {
+            xlio_api->xlio_poll_group_poll(group);
+        }
+        destroy_poll_group(group);
+        exit(testing::Test::HasFailure());
+    } else {
+        // Parent process - client side
+        base_create_socket(&sattr, &sock);
+
+        rc = xlio_api->xlio_socket_bind(sock, (struct sockaddr *)&client_addr, sizeof(client_addr));
+        ASSERT_EQ(0, rc);
+
+        barrier_fork(pid, true); // Wait for child to listen
+
+        rc = xlio_api->xlio_socket_connect(sock, (struct sockaddr *)&server_addr,
+                                           sizeof(server_addr));
+        ASSERT_EQ(0, rc);
+
+        while (connected_counter < 1) {
+            xlio_api->xlio_poll_group_poll(group);
+        }
+
+        wait_for_delayed_acks(group);
+
+        barrier_fork(pid, true); // Wait for child to get last ack
+
+        base_destroy_socket(sock);
+        while (terminated_counter < 1) {
+            xlio_api->xlio_poll_group_poll(group);
+        }
+
+        destroy_poll_group(group);
+
+        wait_fork(pid);
+    }
+}
+
+#endif /* EXTRA_API_ENABLED */

--- a/tests/gtest/xlio_zc_api/xlio_socket_migrate.cc
+++ b/tests/gtest/xlio_zc_api/xlio_socket_migrate.cc
@@ -1,0 +1,220 @@
+/*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+ * Copyright (c) 2021-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: GPL-2.0-only or BSD-2-Clause
+ */
+
+#include "common/def.h"
+#include "common/log.h"
+#include "common/sys.h"
+#include "common/base.h"
+#include <infiniband/verbs.h>
+#include <pthread.h>
+#include <unistd.h>
+#include "core/xlio_base.h"
+
+#if defined(EXTRA_API_ENABLED) && (EXTRA_API_ENABLED == 1)
+
+static int connected_counter = 0;
+static int terminated_counter = 0;
+static int rx_cb_counter = 0;
+static int comp_cb_counter = 0;
+static const char *data_to_send = "I Love XLIO!";
+static int data_bytes_to_be_sent = strlen(data_to_send) * 1000;
+static int data_sent_completed = 0;
+static int data_received = 0;
+static struct ibv_pd *pd = NULL;
+static struct ibv_mr *mr_buf;
+static char sndbuf[256];
+static bool do_migrate = false;
+static std::vector<xlio_socket_t> accepted_sockets;
+
+class zc_api_xlio_socket_migrate : public xlio_zc_api_base {
+public:
+    virtual void SetUp() { errno = EOK; };
+    virtual void TearDown() {};
+    void create_poll_group(xlio_poll_group_t *group)
+    {
+        xlio_poll_group_attr gattr = {
+            .flags = 0,
+            .socket_event_cb = &socket_event_cb,
+            .socket_comp_cb = &socket_comp_cb,
+            .socket_rx_cb = &socket_rx_cb,
+            .socket_accept_cb = &socket_accept_cb,
+        };
+        base_create_poll_group(&gattr, group);
+    }
+    void destroy_poll_group(xlio_poll_group_t group) { base_destroy_poll_group(group); }
+    void wait_for_delayed_acks(xlio_poll_group_t group)
+    {
+        struct timespec start_time;
+        clock_gettime(CLOCK_MONOTONIC, &start_time);
+        struct timespec current_time = {0, 0};
+        while (current_time.tv_sec - start_time.tv_sec < 3) {
+            xlio_api->xlio_poll_group_poll(group);
+            clock_gettime(CLOCK_MONOTONIC, &current_time);
+        }
+    }
+    static void send_single_msg(xlio_socket_t sock, const void *data, size_t len,
+                                uintptr_t userdata_op, unsigned flags)
+    {
+        struct xlio_socket_send_attr attr = {
+            .flags = flags,
+            .mkey = mr_buf->lkey,
+            .userdata_op = userdata_op,
+        };
+        memcpy(sndbuf, data, len);
+        int ret = xlio_api->xlio_socket_send(sock, sndbuf, len, &attr);
+        ASSERT_EQ(ret, 0);
+        xlio_api->xlio_socket_flush(sock);
+    }
+    static void socket_event_cb(xlio_socket_t sock, uintptr_t userdata_sq, int event, int value)
+    {
+        UNREFERENCED_PARAMETER(userdata_sq);
+        UNREFERENCED_PARAMETER(value);
+        if (event == XLIO_SOCKET_EVENT_ESTABLISHED) {
+            pd = xlio_api->xlio_socket_get_pd(sock);
+            ASSERT_TRUE(pd != NULL);
+            mr_buf = ibv_reg_mr(pd, sndbuf, sizeof(sndbuf), IBV_ACCESS_LOCAL_WRITE);
+            ASSERT_TRUE(mr_buf != NULL);
+            connected_counter++;
+        } else if (event == XLIO_SOCKET_EVENT_CLOSED) {
+            terminated_counter++;
+        } else if (event == XLIO_SOCKET_EVENT_TERMINATED) {
+            terminated_counter++;
+        }
+    }
+    static void socket_comp_cb(xlio_socket_t sock, uintptr_t userdata_sq, uintptr_t userdata_op)
+    {
+        UNREFERENCED_PARAMETER(sock);
+        UNREFERENCED_PARAMETER(userdata_sq);
+        comp_cb_counter++;
+        data_sent_completed += userdata_op;
+    }
+
+    static void socket_rx_cb(xlio_socket_t sock, uintptr_t userdata_sq, void *data, size_t len,
+                             struct xlio_buf *buf)
+    {
+        UNREFERENCED_PARAMETER(userdata_sq);
+        UNREFERENCED_PARAMETER(data);
+        if (rx_cb_counter == 0) {
+            do_migrate = true;
+        }
+        rx_cb_counter++;
+        data_received += len;
+        xlio_api->xlio_socket_buf_free(sock, buf);
+    }
+
+    static void socket_accept_cb(xlio_socket_t sock, xlio_socket_t parent_sock,
+                                 uintptr_t parent_userdata)
+    {
+        UNREFERENCED_PARAMETER(parent_sock);
+        UNREFERENCED_PARAMETER(parent_userdata);
+        int rc = xlio_api->xlio_socket_update(sock, 0, 0x1);
+        ASSERT_EQ(rc, 0);
+        accepted_sockets.push_back(sock);
+        connected_counter++;
+    }
+};
+
+/**
+ * @test zc_api_xlio_socket_migrate.ti_1
+ * @brief
+ *    Create TCP socket/connect/send(initiator)/receive(target)
+ * @details
+ */
+TEST_F(zc_api_xlio_socket_migrate, ti_1)
+{
+    int rc;
+    int pid = fork();
+    xlio_zc_api_base::SetUp();
+    xlio_poll_group_t group;
+    xlio_socket_t sock;
+
+    create_poll_group(&group);
+    xlio_socket_attr sattr = {
+        .flags = 0,
+        .domain = server_addr.addr.sa_family,
+        .group = group,
+        .userdata_sq = 0,
+    };
+    if (pid == 0) {
+        xlio_poll_group_t group_2;
+        create_poll_group(&group_2);
+
+        base_create_socket(&sattr, &sock);
+
+        rc = xlio_api->xlio_socket_bind(sock, (struct sockaddr *)&server_addr, sizeof(server_addr));
+        ASSERT_EQ(0, rc);
+
+        rc = xlio_api->xlio_socket_listen(sock);
+        ASSERT_EQ(0, rc);
+
+        barrier_fork(pid, true);
+
+        while (data_received < data_bytes_to_be_sent) {
+            xlio_api->xlio_poll_group_poll(group);
+            xlio_api->xlio_poll_group_poll(group_2);
+            if (do_migrate) {
+                xlio_api->xlio_socket_detach_group(accepted_sockets.back());
+                xlio_api->xlio_socket_attach_group(accepted_sockets.back(), group_2);
+                do_migrate = false;
+            }
+        }
+
+        wait_for_delayed_acks(group);
+
+        ASSERT_EQ(data_received, data_bytes_to_be_sent);
+
+        barrier_fork(pid, true);
+
+        base_destroy_socket(sock);
+        while (!accepted_sockets.empty()) {
+            base_destroy_socket(accepted_sockets.back());
+            accepted_sockets.pop_back();
+        }
+        while (terminated_counter < 1) {
+            xlio_api->xlio_poll_group_poll(group);
+        }
+
+        destroy_poll_group(group);
+        exit(testing::Test::HasFailure());
+    } else {
+        base_create_socket(&sattr, &sock);
+
+        rc = xlio_api->xlio_socket_bind(sock, (struct sockaddr *)&client_addr, sizeof(client_addr));
+        ASSERT_EQ(0, rc);
+
+        barrier_fork(pid, true); // wait for child to bind and listen
+
+        rc = xlio_api->xlio_socket_connect(sock, (struct sockaddr *)&server_addr,
+                                           sizeof(server_addr));
+        ASSERT_EQ(0, rc);
+
+        int sent_bytes = 0;
+        while (data_sent_completed < data_bytes_to_be_sent) {
+            xlio_api->xlio_poll_group_poll(group);
+            if (connected_counter > 0 && sent_bytes < data_bytes_to_be_sent) {
+                send_single_msg(sock, data_to_send, strlen(data_to_send), strlen(data_to_send), 0);
+                sent_bytes += strlen(data_to_send);
+            }
+        }
+
+        wait_for_delayed_acks(group);
+
+        ASSERT_EQ(data_sent_completed, data_bytes_to_be_sent);
+
+        barrier_fork(pid, true); // wait for child to accept + receive last ack
+
+        base_destroy_socket(sock);
+        while (terminated_counter < 1) {
+            xlio_api->xlio_poll_group_poll(group);
+        }
+
+        destroy_poll_group(group);
+
+        wait_fork(pid);
+    }
+}
+
+#endif /* EXTRA_API_ENABLED */

--- a/tests/gtest/xlio_zc_api/xlio_socket_migrate_2.cc
+++ b/tests/gtest/xlio_zc_api/xlio_socket_migrate_2.cc
@@ -1,0 +1,234 @@
+/*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+ * Copyright (c) 2021-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: GPL-2.0-only or BSD-2-Clause
+ */
+
+#include "common/def.h"
+#include "common/log.h"
+#include "common/sys.h"
+#include "common/base.h"
+#include <infiniband/verbs.h>
+#include <pthread.h>
+#include <unistd.h>
+#include "core/xlio_base.h"
+
+#if defined(EXTRA_API_ENABLED) && (EXTRA_API_ENABLED == 1)
+
+static int connected_counter = 0;
+static int terminated_counter = 0;
+static int rx_cb_counter = 0;
+static int comp_cb_counter = 0;
+static const char *data_to_send = "I Love XLIO!";
+#define NUMBER_OF_MESSAGES    1000
+#define MIGRATE_AFTER_SECONDS 10
+static int data_bytes_to_be_sent = strlen(data_to_send) * NUMBER_OF_MESSAGES;
+static int data_sent_completed = 0;
+static int data_received = 0;
+static struct ibv_pd *pd = NULL;
+static struct ibv_mr *mr_buf;
+static char sndbuf[256];
+static bool do_migrate = false;
+static std::vector<xlio_socket_t> accepted_sockets;
+
+class zc_api_xlio_socket_migrate_2 : public xlio_zc_api_base {
+public:
+    virtual void SetUp() { errno = EOK; };
+    virtual void TearDown() {};
+    void create_poll_group(xlio_poll_group_t *group)
+    {
+        xlio_poll_group_attr gattr = {
+            .flags = 0,
+            .socket_event_cb = &socket_event_cb,
+            .socket_comp_cb = &socket_comp_cb,
+            .socket_rx_cb = &socket_rx_cb,
+            .socket_accept_cb = &socket_accept_cb,
+        };
+        base_create_poll_group(&gattr, group);
+    }
+    void destroy_poll_group(xlio_poll_group_t group) { base_destroy_poll_group(group); }
+    void wait_for_delayed_acks(xlio_poll_group_t group)
+    {
+        struct timespec start_time;
+        clock_gettime(CLOCK_MONOTONIC, &start_time);
+        struct timespec current_time = {0, 0};
+        while (current_time.tv_sec - start_time.tv_sec < 3) {
+            xlio_api->xlio_poll_group_poll(group);
+            clock_gettime(CLOCK_MONOTONIC, &current_time);
+        }
+    }
+    static void send_single_msg(xlio_socket_t sock, const void *data, size_t len,
+                                uintptr_t userdata_op, unsigned flags)
+    {
+        struct xlio_socket_send_attr attr = {
+            .flags = flags,
+            .mkey = mr_buf->lkey,
+            .userdata_op = userdata_op,
+        };
+        memcpy(sndbuf, data, len);
+        int ret = xlio_api->xlio_socket_send(sock, sndbuf, len, &attr);
+        ASSERT_EQ(ret, 0);
+        xlio_api->xlio_socket_flush(sock);
+    }
+    static void socket_event_cb(xlio_socket_t sock, uintptr_t userdata_sq, int event, int value)
+    {
+        UNREFERENCED_PARAMETER(userdata_sq);
+        UNREFERENCED_PARAMETER(value);
+        if (event == XLIO_SOCKET_EVENT_ESTABLISHED) {
+            pd = xlio_api->xlio_socket_get_pd(sock);
+            ASSERT_TRUE(pd != NULL);
+            mr_buf = ibv_reg_mr(pd, sndbuf, sizeof(sndbuf), IBV_ACCESS_LOCAL_WRITE);
+            ASSERT_TRUE(mr_buf != NULL);
+            connected_counter++;
+        } else if (event == XLIO_SOCKET_EVENT_CLOSED) {
+            terminated_counter++;
+        } else if (event == XLIO_SOCKET_EVENT_TERMINATED) {
+            terminated_counter++;
+        }
+    }
+    static void socket_comp_cb(xlio_socket_t sock, uintptr_t userdata_sq, uintptr_t userdata_op)
+    {
+        UNREFERENCED_PARAMETER(sock);
+        UNREFERENCED_PARAMETER(userdata_sq);
+        comp_cb_counter++;
+        data_sent_completed += userdata_op;
+    }
+
+    static void socket_rx_cb(xlio_socket_t sock, uintptr_t userdata_sq, void *data, size_t len,
+                             struct xlio_buf *buf)
+    {
+        UNREFERENCED_PARAMETER(userdata_sq);
+        UNREFERENCED_PARAMETER(data);
+        if (rx_cb_counter == 0) {
+            do_migrate = true;
+        }
+        rx_cb_counter++;
+        data_received += len;
+        xlio_api->xlio_socket_buf_free(sock, buf);
+    }
+
+    static void socket_accept_cb(xlio_socket_t sock, xlio_socket_t parent_sock,
+                                 uintptr_t parent_userdata)
+    {
+        UNREFERENCED_PARAMETER(parent_sock);
+        UNREFERENCED_PARAMETER(parent_userdata);
+        int rc = xlio_api->xlio_socket_update(sock, 0, 0x1);
+        ASSERT_EQ(rc, 0);
+        accepted_sockets.push_back(sock);
+        connected_counter++;
+    }
+};
+
+/**
+ * @test zc_api_xlio_socket_migrate_2.ti_1
+ * @brief
+ *    Create TCP socket/connect/send(initiator)/receive(target)
+ * @details
+ */
+TEST_F(zc_api_xlio_socket_migrate_2, ti_1)
+{
+    int rc;
+    int pid = fork();
+    xlio_zc_api_base::SetUp();
+    xlio_poll_group_t group;
+    xlio_socket_t sock;
+
+    create_poll_group(&group);
+    xlio_socket_attr sattr = {
+        .flags = 0,
+        .domain = server_addr.addr.sa_family,
+        .group = group,
+        .userdata_sq = 0,
+    };
+    if (pid == 0) {
+        xlio_poll_group_t group_2;
+        create_poll_group(&group_2);
+
+        base_create_socket(&sattr, &sock);
+
+        rc = xlio_api->xlio_socket_bind(sock, (struct sockaddr *)&server_addr, sizeof(server_addr));
+        ASSERT_EQ(0, rc);
+
+        rc = xlio_api->xlio_socket_listen(sock);
+        ASSERT_EQ(0, rc);
+
+        barrier_fork(pid, true);
+
+        bool is_detached = false;
+        struct timespec start_time_detach;
+        struct timespec start_time_now;
+        while (data_received < data_bytes_to_be_sent) {
+            xlio_api->xlio_poll_group_poll(group);
+            xlio_api->xlio_poll_group_poll(group_2);
+            // add timer to attach after 10 seconds of detach
+            if (do_migrate) {
+                if (!is_detached) {
+                    clock_gettime(CLOCK_MONOTONIC, &start_time_detach);
+                    xlio_api->xlio_socket_detach_group(accepted_sockets.back());
+                    is_detached = true;
+                }
+                clock_gettime(CLOCK_MONOTONIC, &start_time_now);
+                if (start_time_now.tv_sec - start_time_detach.tv_sec > MIGRATE_AFTER_SECONDS) {
+                    xlio_api->xlio_socket_attach_group(accepted_sockets.back(), group_2);
+                    do_migrate = false;
+                }
+            }
+        }
+
+        wait_for_delayed_acks(group);
+
+        ASSERT_EQ(data_received, data_bytes_to_be_sent);
+
+        barrier_fork(pid, true);
+
+        base_destroy_socket(sock);
+        while (!accepted_sockets.empty()) {
+            base_destroy_socket(accepted_sockets.back());
+            accepted_sockets.pop_back();
+        }
+        while (terminated_counter < 1) {
+            xlio_api->xlio_poll_group_poll(group);
+        }
+
+        destroy_poll_group(group);
+        exit(testing::Test::HasFailure());
+    } else {
+        base_create_socket(&sattr, &sock);
+
+        rc = xlio_api->xlio_socket_bind(sock, (struct sockaddr *)&client_addr, sizeof(client_addr));
+        ASSERT_EQ(0, rc);
+
+        barrier_fork(pid, true); // wait for child to bind and listen
+
+        rc = xlio_api->xlio_socket_connect(sock, (struct sockaddr *)&server_addr,
+                                           sizeof(server_addr));
+        ASSERT_EQ(0, rc);
+
+        int sent_bytes = 0;
+        while (data_sent_completed < data_bytes_to_be_sent) {
+            xlio_api->xlio_poll_group_poll(group);
+            if (connected_counter > 0 && sent_bytes < data_bytes_to_be_sent) {
+                send_single_msg(sock, data_to_send, strlen(data_to_send), strlen(data_to_send), 0);
+                sent_bytes += strlen(data_to_send);
+                usleep(MIGRATE_AFTER_SECONDS * 1000000 / NUMBER_OF_MESSAGES);
+            }
+        }
+
+        wait_for_delayed_acks(group);
+
+        ASSERT_EQ(data_sent_completed, data_bytes_to_be_sent);
+
+        barrier_fork(pid, true); // wait for child to accept + receive last ack
+
+        base_destroy_socket(sock);
+        while (terminated_counter < 1) {
+            xlio_api->xlio_poll_group_poll(group);
+        }
+
+        destroy_poll_group(group);
+
+        wait_fork(pid);
+    }
+}
+
+#endif /* EXTRA_API_ENABLED */

--- a/tests/gtest/xlio_zc_api/xlio_socket_send_receive.cc
+++ b/tests/gtest/xlio_zc_api/xlio_socket_send_receive.cc
@@ -1,0 +1,200 @@
+/*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+ * Copyright (c) 2021-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: GPL-2.0-only or BSD-2-Clause
+ */
+
+#include "common/def.h"
+#include "common/log.h"
+#include "common/sys.h"
+#include "common/base.h"
+#include <infiniband/verbs.h>
+#include <pthread.h>
+#include <unistd.h>
+#include "core/xlio_base.h"
+
+#if defined(EXTRA_API_ENABLED) && (EXTRA_API_ENABLED == 1)
+
+static int connected_counter = 0;
+static int terminated_counter = 0;
+static int rx_cb_counter = 0;
+static int comp_cb_counter = 0;
+static const char *data_to_send = "I Love XLIO!";
+static struct ibv_pd *pd = NULL;
+static struct ibv_mr *mr_buf;
+static char sndbuf[256];
+static std::vector<xlio_socket_t> accepted_sockets;
+
+class zc_api_xlio_socket_send_receive : public xlio_zc_api_base {
+public:
+    virtual void SetUp() { errno = EOK; };
+    virtual void TearDown() {};
+    void create_poll_group(xlio_poll_group_t *group)
+    {
+        xlio_poll_group_attr gattr = {
+            .flags = 0,
+            .socket_event_cb = &socket_event_cb,
+            .socket_comp_cb = &socket_comp_cb,
+            .socket_rx_cb = &socket_rx_cb,
+            .socket_accept_cb = &socket_accept_cb,
+        };
+        base_create_poll_group(&gattr, group);
+    }
+    void destroy_poll_group(xlio_poll_group_t group) { base_destroy_poll_group(group); }
+    void wait_for_delayed_acks(xlio_poll_group_t group)
+    {
+        struct timespec start_time;
+        clock_gettime(CLOCK_MONOTONIC, &start_time);
+        struct timespec current_time = {0, 0};
+        while (current_time.tv_sec - start_time.tv_sec < 1) {
+            xlio_api->xlio_poll_group_poll(group);
+            clock_gettime(CLOCK_MONOTONIC, &current_time);
+        }
+    }
+    static void send_single_msg(xlio_socket_t sock, const void *data, size_t len,
+                                uintptr_t userdata_op, unsigned flags)
+    {
+        struct xlio_socket_send_attr attr = {
+            .flags = flags,
+            .mkey = mr_buf->lkey,
+            .userdata_op = userdata_op,
+        };
+        memcpy(sndbuf, data, len);
+        int ret = xlio_api->xlio_socket_send(sock, sndbuf, len, &attr);
+        ASSERT_EQ(ret, 0);
+        xlio_api->xlio_socket_flush(sock);
+    }
+    static void socket_event_cb(xlio_socket_t sock, uintptr_t userdata_sq, int event, int value)
+    {
+        UNREFERENCED_PARAMETER(userdata_sq);
+        UNREFERENCED_PARAMETER(value);
+        if (event == XLIO_SOCKET_EVENT_ESTABLISHED) {
+            pd = xlio_api->xlio_socket_get_pd(sock);
+            ASSERT_TRUE(pd != NULL);
+            mr_buf = ibv_reg_mr(pd, sndbuf, sizeof(sndbuf), IBV_ACCESS_LOCAL_WRITE);
+            ASSERT_TRUE(mr_buf != NULL);
+            send_single_msg(sock, data_to_send, strlen(data_to_send), 0x1, 0);
+            connected_counter++;
+        } else if (event == XLIO_SOCKET_EVENT_CLOSED) {
+            terminated_counter++;
+        } else if (event == XLIO_SOCKET_EVENT_TERMINATED) {
+            terminated_counter++;
+        }
+    }
+    static void socket_comp_cb(xlio_socket_t sock, uintptr_t userdata_sq, uintptr_t userdata_op)
+    {
+        UNREFERENCED_PARAMETER(sock);
+        UNREFERENCED_PARAMETER(userdata_sq);
+        UNREFERENCED_PARAMETER(userdata_op);
+        comp_cb_counter++;
+    }
+
+    static void socket_rx_cb(xlio_socket_t sock, uintptr_t userdata_sq, void *data, size_t len,
+                             struct xlio_buf *buf)
+    {
+        UNREFERENCED_PARAMETER(sock);
+        UNREFERENCED_PARAMETER(userdata_sq);
+        rx_cb_counter++;
+        // Assume that the data_to_send is received in one packet
+        if (memcmp(data, data_to_send, len) != 0) {
+            GTEST_FAIL();
+        }
+        xlio_api->xlio_socket_buf_free(sock, buf);
+    }
+
+    static void socket_accept_cb(xlio_socket_t sock, xlio_socket_t parent_sock,
+                                 uintptr_t parent_userdata)
+    {
+        UNREFERENCED_PARAMETER(sock);
+        UNREFERENCED_PARAMETER(parent_sock);
+        UNREFERENCED_PARAMETER(parent_userdata);
+        int rc = xlio_api->xlio_socket_update(sock, 0, 0x1);
+        ASSERT_EQ(rc, 0);
+        accepted_sockets.push_back(sock);
+        connected_counter++;
+    }
+};
+
+/**
+ * @test zc_api_xlio_socket_send_receive.ti_1
+ * @brief
+ *    Create TCP socket/connect/send(initiator)/receive(target)
+ * @details
+ */
+TEST_F(zc_api_xlio_socket_send_receive, ti_1)
+{
+    int rc;
+    int pid = fork();
+    xlio_zc_api_base::SetUp();
+    xlio_poll_group_t group;
+    xlio_socket_t sock;
+
+    create_poll_group(&group);
+    xlio_socket_attr sattr = {
+        .flags = 0,
+        .domain = server_addr.addr.sa_family,
+        .group = group,
+        .userdata_sq = 0,
+    };
+    if (pid == 0) {
+        base_create_socket(&sattr, &sock);
+
+        rc = xlio_api->xlio_socket_bind(sock, (struct sockaddr *)&server_addr, sizeof(server_addr));
+        ASSERT_EQ(0, rc);
+
+        rc = xlio_api->xlio_socket_listen(sock);
+        ASSERT_EQ(0, rc);
+
+        barrier_fork(pid, true);
+
+        while (connected_counter < 1 || rx_cb_counter < 1) {
+            xlio_api->xlio_poll_group_poll(group);
+        }
+
+        wait_for_delayed_acks(group);
+
+        barrier_fork(pid, false); // Wait for parent to receive last ack
+
+        base_destroy_socket(sock);
+        while (!accepted_sockets.empty()) {
+            base_destroy_socket(accepted_sockets.back());
+            accepted_sockets.pop_back();
+        }
+        while (terminated_counter < 1) {
+            xlio_api->xlio_poll_group_poll(group);
+        }
+
+        destroy_poll_group(group);
+        exit(testing::Test::HasFailure());
+    } else {
+        base_create_socket(&sattr, &sock);
+
+        rc = xlio_api->xlio_socket_bind(sock, (struct sockaddr *)&client_addr, sizeof(client_addr));
+        ASSERT_EQ(0, rc);
+
+        barrier_fork(pid, true); // Wait for child to bind and listen
+
+        rc = xlio_api->xlio_socket_connect(sock, (struct sockaddr *)&server_addr,
+                                           sizeof(server_addr));
+        ASSERT_EQ(0, rc);
+
+        while (connected_counter < 1 || comp_cb_counter < 1) {
+            xlio_api->xlio_poll_group_poll(group);
+        }
+
+        wait_for_delayed_acks(group);
+
+        barrier_fork(pid, false);
+
+        base_destroy_socket(sock);
+        while (terminated_counter < 1) {
+            xlio_api->xlio_poll_group_poll(group);
+        }
+
+        destroy_poll_group(group);
+
+        wait_fork(pid);
+    }
+}
+
+#endif /* EXTRA_API_ENABLED */

--- a/tests/gtest/xlio_zc_api/xlio_socket_send_receive_2.cc
+++ b/tests/gtest/xlio_zc_api/xlio_socket_send_receive_2.cc
@@ -1,0 +1,201 @@
+/*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+ * Copyright (c) 2021-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: GPL-2.0-only or BSD-2-Clause
+ */
+
+#include "common/def.h"
+#include "common/log.h"
+#include "common/sys.h"
+#include "common/base.h"
+#include <infiniband/verbs.h>
+#include <pthread.h>
+#include <unistd.h>
+#include "core/xlio_base.h"
+
+#if defined(EXTRA_API_ENABLED) && (EXTRA_API_ENABLED == 1)
+
+static int connected_counter = 0;
+static int terminated_counter = 0;
+static int rx_cb_counter = 0;
+static int comp_cb_counter = 0;
+static const char *data_to_send = "I Love XLIO!";
+static struct ibv_pd *pd = NULL;
+static struct ibv_mr *mr_buf;
+static char sndbuf[256];
+static std::vector<xlio_socket_t> accepted_sockets;
+
+class zc_api_xlio_socket_send_receive_2 : public xlio_zc_api_base {
+public:
+    virtual void SetUp() { errno = EOK; };
+    virtual void TearDown() {};
+    void create_poll_group(xlio_poll_group_t *group)
+    {
+        xlio_poll_group_attr gattr = {
+            .flags = 0,
+            .socket_event_cb = &socket_event_cb,
+            .socket_comp_cb = &socket_comp_cb,
+            .socket_rx_cb = &socket_rx_cb,
+            .socket_accept_cb = &socket_accept_cb,
+        };
+        base_create_poll_group(&gattr, group);
+    }
+    void destroy_poll_group(xlio_poll_group_t group) { base_destroy_poll_group(group); }
+    void wait_for_delayed_acks(xlio_poll_group_t group)
+    {
+        struct timespec start_time;
+        clock_gettime(CLOCK_MONOTONIC, &start_time);
+        struct timespec current_time = {0, 0};
+        while (current_time.tv_sec - start_time.tv_sec < 1) {
+            xlio_api->xlio_poll_group_poll(group);
+            clock_gettime(CLOCK_MONOTONIC, &current_time);
+        }
+    }
+    static void send_single_msg(xlio_socket_t sock, const void *data, size_t len,
+                                uintptr_t userdata_op, unsigned flags)
+    {
+        struct xlio_socket_send_attr attr = {
+            .flags = flags,
+            .mkey = mr_buf->lkey,
+            .userdata_op = userdata_op,
+        };
+        memcpy(sndbuf, data, len);
+        int ret = xlio_api->xlio_socket_send(sock, sndbuf, len, &attr);
+        ASSERT_EQ(ret, 0);
+        xlio_api->xlio_socket_flush(sock);
+    }
+    static void socket_event_cb(xlio_socket_t sock, uintptr_t userdata_sq, int event, int value)
+    {
+        UNREFERENCED_PARAMETER(sock);
+        UNREFERENCED_PARAMETER(userdata_sq);
+        UNREFERENCED_PARAMETER(value);
+        if (event == XLIO_SOCKET_EVENT_ESTABLISHED) {
+            connected_counter++;
+        } else if (event == XLIO_SOCKET_EVENT_CLOSED) {
+            terminated_counter++;
+        } else if (event == XLIO_SOCKET_EVENT_TERMINATED) {
+            terminated_counter++;
+        }
+    }
+    static void socket_comp_cb(xlio_socket_t sock, uintptr_t userdata_sq, uintptr_t userdata_op)
+    {
+        UNREFERENCED_PARAMETER(sock);
+        UNREFERENCED_PARAMETER(userdata_sq);
+        UNREFERENCED_PARAMETER(userdata_op);
+        comp_cb_counter++;
+    }
+
+    static void socket_rx_cb(xlio_socket_t sock, uintptr_t userdata_sq, void *data, size_t len,
+                             struct xlio_buf *buf)
+    {
+        UNREFERENCED_PARAMETER(sock);
+        UNREFERENCED_PARAMETER(userdata_sq);
+        rx_cb_counter++;
+
+        // Assume that the data_to_send is received in one packet
+        if (memcmp(data, data_to_send, len) != 0) {
+            GTEST_FAIL();
+        }
+        xlio_api->xlio_socket_buf_free(sock, buf);
+    }
+
+    static void socket_accept_cb(xlio_socket_t sock, xlio_socket_t parent_sock,
+                                 uintptr_t parent_userdata)
+    {
+        UNREFERENCED_PARAMETER(sock);
+        UNREFERENCED_PARAMETER(parent_sock);
+        UNREFERENCED_PARAMETER(parent_userdata);
+        int rc = xlio_api->xlio_socket_update(sock, 0, 0x1);
+        ASSERT_EQ(rc, 0);
+        accepted_sockets.push_back(sock);
+        connected_counter++;
+        pd = xlio_api->xlio_socket_get_pd(sock);
+        ASSERT_TRUE(pd != NULL);
+        mr_buf = ibv_reg_mr(pd, sndbuf, sizeof(sndbuf), IBV_ACCESS_LOCAL_WRITE);
+        ASSERT_TRUE(mr_buf != NULL);
+        send_single_msg(sock, data_to_send, strlen(data_to_send), 0x1, 0);
+    }
+};
+
+/**
+ * @test zc_api_xlio_socket_send_receive_2.ti_1
+ * @brief
+ *    Create TCP socket/connect/send(target)/receive(initiator)
+ * @details
+ */
+TEST_F(zc_api_xlio_socket_send_receive_2, ti_1)
+{
+    int rc;
+    int pid = fork();
+    xlio_zc_api_base::SetUp();
+    xlio_poll_group_t group;
+    xlio_socket_t sock;
+
+    create_poll_group(&group);
+    xlio_socket_attr sattr = {
+        .flags = 0,
+        .domain = server_addr.addr.sa_family,
+        .group = group,
+        .userdata_sq = 0,
+    };
+    base_create_socket(&sattr, &sock);
+    if (pid == 0) {
+        // Child process - server side
+        rc = xlio_api->xlio_socket_bind(sock, (struct sockaddr *)&server_addr, sizeof(server_addr));
+        ASSERT_EQ(0, rc);
+
+        rc = xlio_api->xlio_socket_listen(sock);
+        ASSERT_EQ(0, rc);
+
+        barrier_fork(pid, true);
+
+        while (connected_counter < 1 || comp_cb_counter < 1) {
+            xlio_api->xlio_poll_group_poll(group);
+        }
+
+        wait_for_delayed_acks(group);
+
+        barrier_fork(pid, true);
+
+        base_destroy_socket(sock);
+        while (!accepted_sockets.empty()) {
+            base_destroy_socket(accepted_sockets.back());
+            accepted_sockets.pop_back();
+        }
+        while (terminated_counter < 1) {
+            xlio_api->xlio_poll_group_poll(group);
+        }
+
+        destroy_poll_group(group);
+        exit(testing::Test::HasFailure());
+    } else {
+        // Parent process - client side
+        rc = xlio_api->xlio_socket_bind(sock, (struct sockaddr *)&client_addr, sizeof(client_addr));
+        ASSERT_EQ(0, rc);
+
+        barrier_fork(pid, true); // Wait for child to bind and listen
+
+        rc = xlio_api->xlio_socket_connect(sock, (struct sockaddr *)&server_addr,
+                                           sizeof(server_addr));
+        ASSERT_EQ(0, rc);
+
+        while (connected_counter < 1 || rx_cb_counter < 1) {
+            xlio_api->xlio_poll_group_poll(group);
+        }
+
+        wait_for_delayed_acks(group);
+
+        barrier_fork(pid, true); // Wait for child to accept + receive last ack
+
+        base_destroy_socket(sock);
+        while (terminated_counter < 1) {
+            xlio_api->xlio_poll_group_poll(group);
+        }
+
+        destroy_poll_group(group);
+
+        wait_fork(pid);
+    }
+}
+
+#endif /* EXTRA_API_ENABLED */


### PR DESCRIPTION
### **User description**
## Description
Server side support for the XLIO Socket API.

Includes:
 * Listen and incoming sockets support
 * 2-step migration of the incoming sockets between XLIO polling groups
 * Additionally, improves xlio_socket_destroy() flow

##### What
Server side support for the XLIO Socket API.

##### Why ?
Cover server-side applications, not only client-side.

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Introduced XLIO Zero-Copy (ZC) API enhancements for socket migration and event handling.

- Added new test cases for socket migration, send/receive, and listen/connect functionalities.

- Enhanced core socket and poll group logic to support socket migration and group management.

- Updated XLIO API to include new methods for socket operations and event handling.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>13 files</summary><table>
<tr>
  <td><strong>sockinfo_tcp.cpp</strong><dd><code>Added XLIO socket migration and event handling logic.</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Mellanox/libxlio/pull/363/files#diff-91b36ba48ffbc4892f8ead2b9d0ca1fe4686b9340ee6382f48c2249be7479566">+233/-69</a></td>

</tr>

<tr>
  <td><strong>sock-extra.cpp</strong><dd><code>Extended XLIO API with new socket operations.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Mellanox/libxlio/pull/363/files#diff-83926b69f94960c3072837d38967f801cb1a549f5e88e6579ff26c4534f84de8">+67/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>poll_group.cpp</strong><dd><code>Enhanced poll group logic for socket migration.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Mellanox/libxlio/pull/363/files#diff-2bfd390f1426afac21033a064bf0d86652c6c8a5f6ffc508f7ee5edd0d463fd8">+64/-14</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>ring_slave.cpp</strong><dd><code>Updated flow detachment logic for socket migration.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Mellanox/libxlio/pull/363/files#diff-7f937511d122ef12190e1171880b46a2a707f44f7c34c7753bff5415896d9ff4">+15/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>sockinfo.cpp</strong><dd><code>Added support for XLIO socket identification and group handling.</code></dd></td>
  <td><a href="https://github.com/Mellanox/libxlio/pull/363/files#diff-559b9c9fc681ff416327d9f5b85273784a49753b9b194c78504c48be35a29a77">+19/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>dst_entry_tcp.cpp</strong><dd><code>Enhanced buffer handling for XLIO socket operations.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Mellanox/libxlio/pull/363/files#diff-a1801ff70830b49c55ec4086eb9a7306243411d81b562b9480d7ab0e7fa4918e">+7/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>rfs.cpp</strong><dd><code>Modified flow destruction logic for XLIO socket migration.</code></dd></td>
  <td><a href="https://github.com/Mellanox/libxlio/pull/363/files#diff-536025d389f04661d5ed61a12c3dbc9a36d50c789a64e83be6a5b28342f5ab87">+12/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>event_handler_manager.cpp</strong><dd><code>Added unregister logic for socket timers.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Mellanox/libxlio/pull/363/files#diff-dd4391f205e4ef0df7b843089a4eab5c4d27a7a99e012c38a5f5720e78ae5f2f">+17/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>stats_reader.cpp</strong><dd><code>Added stats for RX ZC migration drops.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Mellanox/libxlio/pull/363/files#diff-245ea68206817135704f74499430feb8cc2313a46d38ece10e55899779b04042">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ring_tap.cpp</strong><dd><code>Updated detach flow logic for XLIO sockets.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Mellanox/libxlio/pull/363/files#diff-fb3944601b6d0daa79589f6d4fee7d592989a9e5f60d71d24846f6e99fdab467">+6/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ring_bond.cpp</strong><dd><code>Enhanced ring bond logic for socket migration.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Mellanox/libxlio/pull/363/files#diff-1c48fa336d75fc145ac448ddb248ce693c904f50b39c008ea405607240bf21d2">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ring_simple.cpp</strong><dd><code>Added TX skip poll logic for XLIO sockets.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Mellanox/libxlio/pull/363/files#diff-8ebafd403300bfdebe2f535833b5f2ebec2262f3683d0e9a4c8f74a5499cb323">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ring.cpp</strong><dd><code>Added poll group association for rings.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Mellanox/libxlio/pull/363/files#diff-9b0ddc6ea647014ee14bfc3d5cbfb0740eddb5145896ad4051c290fc2a2b0860">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>xlio_socket_migrate_2.cc</strong><dd><code>Added test for XLIO socket migration with delay.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Mellanox/libxlio/pull/363/files#diff-343c943ba628c017b49286f825fa29697ffeb0f2ef58a5b00d744495d18f1a4b">+240/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>xlio_socket_migrate.cc</strong><dd><code>Added test for basic XLIO socket migration.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Mellanox/libxlio/pull/363/files#diff-12912e5e1ec3f31ddc091d30a8be449fb2b718619d9c5081d7b802eba045b3e0">+226/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>xlio_socket_send_receive_2.cc</strong><dd><code>Added test for XLIO socket send/receive with callbacks.</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Mellanox/libxlio/pull/363/files#diff-0af47dedbff204a2824364523b2dc1c668004bf5bbe40f191ad69e23ad945596">+207/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>xlio_socket_send_receive.cc</strong><dd><code>Added test for basic XLIO socket send/receive.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Mellanox/libxlio/pull/363/files#diff-84c8866256b9fe7b040643204c1900bfa574f1bd0b2c92225e685b9222544ca1">+206/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>xlio_socket_listen_connect.cc</strong><dd><code>Added test for XLIO socket listen and connect.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Mellanox/libxlio/pull/363/files#diff-7cf7677375490c3a1611d1572e88ba4dd89fc4e3f71c30896a8274e3f18dd311">+179/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>xlio_socket.cc</strong><dd><code>Added basic test for XLIO socket creation and destruction.</code></dd></td>
  <td><a href="https://github.com/Mellanox/libxlio/pull/363/files#diff-82818dc807b5fd3f468a26ab325a6f9374beba6e019754cbe89d25a1fa1b66bf">+102/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>xlio_base.cc</strong><dd><code>Initialized XLIO API for tests.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Mellanox/libxlio/pull/363/files#diff-dd32161517387032ecba2dcc2d8ccaae9a1e818233b7f493eee20ea31c692273">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>21 files</summary><table>
<tr>
  <td><strong>gtest.sh</strong></td>
  <td><a href="https://github.com/Mellanox/libxlio/pull/363/files#diff-b931e7706b29d88b78a0b11e0d38b62df436610ef93b4a894f3e73a8cf1ceb89">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>rfs.h</strong></td>
  <td><a href="https://github.com/Mellanox/libxlio/pull/363/files#diff-c6a3ee2465190c17c39d18e872140903ba931a720d581fccd67c3d8fef39782b">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ring.h</strong></td>
  <td><a href="https://github.com/Mellanox/libxlio/pull/363/files#diff-e72ecbf5add70e461e14786d9fcc6d524824a09983abf5dab9bc19b68278b8b8">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ring_bond.h</strong></td>
  <td><a href="https://github.com/Mellanox/libxlio/pull/363/files#diff-c6663127246c1e57d16ab7fa40ac04ec94aaed2dfc83cc9b702051eef252016b">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ring_simple.h</strong></td>
  <td><a href="https://github.com/Mellanox/libxlio/pull/363/files#diff-e3f0945e34bb23583e690445bf8a62d62da8272981438e7e51c03fa1b22a067b">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ring_slave.h</strong></td>
  <td><a href="https://github.com/Mellanox/libxlio/pull/363/files#diff-f18fbfbc832f8455cae67984a6976b4b3b8bcf6fff41a4e48c163765bf6ba06b">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ring_tap.h</strong></td>
  <td><a href="https://github.com/Mellanox/libxlio/pull/363/files#diff-c27510c91d17889151f8bd156a5c9492ed5eaf76c95d7c85b2b2a3f1bbb24e72">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>event_handler_manager.h</strong></td>
  <td><a href="https://github.com/Mellanox/libxlio/pull/363/files#diff-83b080a8549e82226111be87b43cc4bc570259ef190ba37421ad33d140650a13">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>poll_group.h</strong></td>
  <td><a href="https://github.com/Mellanox/libxlio/pull/363/files#diff-0bdafc2ff6e8896d35ae9fdbf703a5e4d01e508af0f41323988f803433ba3025">+20/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>dst_entry_tcp.h</strong></td>
  <td><a href="https://github.com/Mellanox/libxlio/pull/363/files#diff-004d7d78a37b56dafe1473b475c7c9931c6c77dbadda00c26de607cf56edac5e">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>fd_collection.h</strong></td>
  <td><a href="https://github.com/Mellanox/libxlio/pull/363/files#diff-ff7f200feda467b2baf52b9bea3bf1a2a462d6ac7b3ae0d1ec550e6a71a95518">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>sockinfo.h</strong></td>
  <td><a href="https://github.com/Mellanox/libxlio/pull/363/files#diff-39ddf75fa30ced200d8d53b6c873ea41f1d86058a7f40a27bb229883e5b7cd9a">+16/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>sockinfo_tcp.h</strong></td>
  <td><a href="https://github.com/Mellanox/libxlio/pull/363/files#diff-256869e853a9148a9296c08b24b13493513d0c3b5f1c13dfd53930ab9419c6d2">+10/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>xlio_stats.h</strong></td>
  <td><a href="https://github.com/Mellanox/libxlio/pull/363/files#diff-b7b193a2cb6b13fdd460f43c4dbe9cafc52278691051699a1d28b22a5b75848e">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>xlio.h</strong></td>
  <td><a href="https://github.com/Mellanox/libxlio/pull/363/files#diff-9886f75de7857ff30327d957ed507218f09cbdc2e164deafec4cbd0dc8a60f77">+10/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>xlio_extra.h</strong></td>
  <td><a href="https://github.com/Mellanox/libxlio/pull/363/files#diff-5afa699e8d336247eaf7de70dd3dd3f81b8b3c0093b098ac3467dfded85a9733">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>xlio_types.h</strong></td>
  <td><a href="https://github.com/Mellanox/libxlio/pull/363/files#diff-13fc9f6447af4d14ceed7ba756e47b3cbbdd9cc75dda32bfd1cee259ff766175">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>xlio_socket_api_listen.c</strong></td>
  <td><a href="https://github.com/Mellanox/libxlio/pull/363/files#diff-566dbdcc59a80e69cb500745259dda554cd35451b7adeef5f896f0f9acb5a0e5">+273/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>xlio_socket_listen_migrate.c</strong></td>
  <td><a href="https://github.com/Mellanox/libxlio/pull/363/files#diff-94421caef98b4fef30c2853019a61385b2f73930b6e65873dde0ff2813286391">+475/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>Makefile.am</strong></td>
  <td><a href="https://github.com/Mellanox/libxlio/pull/363/files#diff-5c0611c256790ab1a351a7e610521aa7f1ab929f90d06f04d930b88ec873dc8b">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>xlio_base.h</strong></td>
  <td><a href="https://github.com/Mellanox/libxlio/pull/363/files#diff-14f45210387746f263922442bc8b2558af4c749024a3224aa7b662bdd3d9abf8">+51/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>