### PR TITLE
issue: 4490689 move schema generation to configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -388,6 +388,34 @@ dnl=== SECTION 9: Configure makefiles
 dnl===
 dnl===-----------------------------------------------------------------------===
 show_section_title "Configure makefiles"
+
+# Generate XLIO config schema header file
+#
+AC_MSG_CHECKING([for generating XLIO config schema header])
+CONFIG_SCHEMA_JSON="${srcdir}/src/core/config/descriptor_providers/xlio_config_schema.json"
+CONFIG_SCHEMA_HEADER="src/core/config/descriptor_providers/xlio_config_schema.h"
+
+if test -f "${CONFIG_SCHEMA_JSON}"; then
+    # Create output directory if it doesn't exist
+    mkdir -p "$(dirname "${CONFIG_SCHEMA_HEADER}")"
+    
+    # Generate the header file
+    cat > "${CONFIG_SCHEMA_HEADER}" << EOF
+#pragma once
+unsigned char config_descriptor_providers_xlio_config_schema_json[[]] = {
+EOF
+    hexdump -v -e '16/1 "0x%02x, " "\n"' "${CONFIG_SCHEMA_JSON}" | \
+    sed 's/0x  ,//g; s/, $/,/' >> "${CONFIG_SCHEMA_HEADER}"
+    
+    cat >> "${CONFIG_SCHEMA_HEADER}" << EOF
+};
+unsigned int config_descriptor_providers_xlio_config_schema_json_len = $(wc -c < "${CONFIG_SCHEMA_JSON}");
+EOF
+    AC_MSG_RESULT([yes - generated ${CONFIG_SCHEMA_HEADER}])
+else
+    AC_MSG_ERROR([${CONFIG_SCHEMA_JSON} not found])
+fi
+
 AC_CONFIG_FILES([
 		Makefile
 		src/Makefile

--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -14,18 +14,14 @@ LEX_OUTPUT_ROOT=lex.libxlio_yy
 #libconfig_parser_la_SOURCES += util/config_scanner.l util/config_parser.y
 libconfig_parser_la_SOURCES = $(top_builddir)/third_party/legacy_config_parser/config_scanner.c $(top_builddir)/third_party/legacy_config_parser/config_parser.c
 
-BUILT_SOURCES = config/descriptor_providers/xlio_config_schema.h
-
-dist-hook:
-	cd $(distdir); rm -f $(BUILT_SOURCES)
 
 SUBDIRS = infra netlink
 
 EXTRA_DIST = \
-	$(srcdir)/config/descriptor_providers/xlio_config_schema.json \
-	$(srcdir)/config/descriptor_providers/libxlio_config.json
+	config/descriptor_providers/xlio_config_schema.json \
+	config/descriptor_providers/libxlio_config.json
 
-sysconf_DATA = $(srcdir)/config/descriptor_providers/xlio_config_schema.json $(srcdir)/config/descriptor_providers/libxlio_config.json
+sysconf_DATA = config/descriptor_providers/xlio_config_schema.json config/descriptor_providers/libxlio_config.json
 otherincludedir = $(includedir)/mellanox
 otherinclude_HEADERS = \
 	xlio.h \
@@ -45,7 +41,10 @@ uninstall-hook:
 lib_LTLIBRARIES = libxlio.la
 
 AM_CPPFLAGS := \
-	-I$(top_srcdir)/src ${LIBNL_CFLAGS} ${LIBJSON_CFLAGS}
+	-I$(top_srcdir)/src -I$(top_builddir)/src/core/config/descriptor_providers ${LIBNL_CFLAGS} ${LIBJSON_CFLAGS}
+
+# Files generated during configure should be cleaned during distclean
+DISTCLEANFILES = config/descriptor_providers/xlio_config_schema.h
 
 libxlio_la_CFLAGS = $(XLIO_STATIC_BUILD) $(XLIO_LTO) $(XLIO_PROFILE)
 libxlio_la_CXXFLAGS = $(XLIO_STATIC_BUILD) $(XLIO_LTO) $(XLIO_PROFILE)
@@ -63,17 +62,8 @@ libxlio_la_LIBADD = \
 	$(top_builddir)/src/core/infra/libinfra.la \
 	libconfig_parser.la
 
-dist_noinst_DATA = $(srcdir)/config/descriptor_providers/xlio_config_schema.json
+dist_noinst_DATA = config/descriptor_providers/xlio_config_schema.json
 
-$(srcdir)/config/descriptor_providers/xlio_config_schema.h:
-	(echo "#pragma once"; \
-	echo "unsigned char config_descriptor_providers_xlio_config_schema_json[] = {"; \
-	hexdump -v -e '16/1 "0x%02x, " "\n"' $(srcdir)/config/descriptor_providers/xlio_config_schema.json | \
-	sed 's/0x  ,//g; s/, $$/,/'; \
-	echo "};"; \
-	echo "unsigned int config_descriptor_providers_xlio_config_schema_json_len = $$(wc -c < $(srcdir)/config/descriptor_providers/xlio_config_schema.json);") > $@
-
-CLEANFILES = $(BUILT_SOURCES)
 
 libxlio_la_SOURCES := \
 	dev/allocator.cpp \
@@ -197,7 +187,7 @@ libxlio_la_SOURCES := \
 	config/config_strings.cpp \
 	config/json_object_handle.cpp \
 	\
-	config/descriptor_providers/xlio_config_schema.h \
+	$(top_builddir)/src/core/config/descriptor_providers/xlio_config_schema.h \
 	\
 	libxlio.c \
 	main.cpp \


### PR DESCRIPTION
## Description
Move the auto-generation of xlio_config_schema.h from the build stage (Makefile.am) to the configure stage (configure.ac). This change provides several benefits:

- The generated header is available immediately after configure runs
- The header file is included in source distributions via EXTRA_DIST
- Separates code generation from compilation, following best practices
- Eliminates the need for BUILT_SOURCES and associated cleanup rules

The generation logic converts the JSON schema file into a C header containing a byte array representation of the schema, which is used by the configuration system at runtime.

Remove the corresponding build-time generation rules from src/core/Makefile.am and add the generated header to EXTRA_DIST. This ensures it's included in distribution tarballs.

##### What
Solves https://redmine.mellanox.com/issues/4490689

##### Why ?
- Separates code generation from compilation, following best practices
- Eliminates the need for BUILT_SOURCES and associated cleanup rules

## Change type
What kind of change does this PR introduce?
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

