### PR TITLE
Fix PCB last_unacked in SYN_SENT state

### DIFF
--- a/src/core/lwip/tcp_in.c
+++ b/src/core/lwip/tcp_in.c
@@ -597,6 +597,7 @@ static err_t tcp_process(struct tcp_pcb *pcb, tcp_in_data *in_data)
             /* If there's nothing left to acknowledge, stop the retransmit
                timer, otherwise reset it to start again */
             if (pcb->unacked == NULL) {
+                pcb->last_unacked = NULL;
                 pcb->rtime = -1;
                 pcb->ticks_since_data_sent = -1;
             } else {


### PR DESCRIPTION
When processing SYN+ACK in SYN_SENT state, the unacked queue is cleared but last_unacked is not updated, leaving inconsistent PCB state.

Ensure both pointers are kept in sync to maintain correct state.

## Description
Please provide a summary of the change.

##### What
_Subject: what this PR is doing in one line._ 

##### Why ?
_Justification for the PR. If there is existing issue/bug please reference._

##### How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc._

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

