### PR TITLE
Thread skeleton listen Socket

### DIFF
--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -154,6 +154,7 @@ libxlio_la_SOURCES := \
 	sock/sockinfo_udp.cpp \
 	sock/sockinfo_ulp.cpp \
 	sock/sockinfo_tcp.cpp \
+	sock/sockinfo_tcp_listen_context.cpp \
 	sock/fd_collection.cpp \
 	sock/sock-redirect.cpp \
 	sock/sock-app.cpp \
@@ -308,6 +309,7 @@ libxlio_la_SOURCES := \
 	sock/sock_stats.h \
 	sock/sockinfo.h \
 	sock/sockinfo_tcp.h \
+	sock/sockinfo_tcp_listen_context.h \
 	sock/sockinfo_udp.h \
 	sock/sockinfo_ulp.h \
 	sock/sock-redirect.h \

--- a/src/core/dev/rfs.cpp
+++ b/src/core/dev/rfs.cpp
@@ -355,6 +355,8 @@ bool rfs::create_flow()
     }
 
     m_b_tmp_is_attached = true;
+    m_p_ring_simple->m_p_ring_stat->n_rx_steering_rules++;
+
     rfs_logdbg("Create RFS flow succeeded, Tag: %" PRIu32 ", Flow: %s", m_flow_tag_id,
                m_flow_tuple.to_str().c_str());
 
@@ -363,6 +365,7 @@ bool rfs::create_flow()
 
 bool rfs::destroy_flow(rfs_rule **rule_extract)
 {
+    int n_rx_steering_rules = 0;
     if (unlikely(!m_rfs_flow)) {
         rfs_logdbg("Destroy RFS flow failed, RFS flow was not created. "
                    "This is OK for MC same ip diff port scenario. Tag: %" PRIu32
@@ -377,15 +380,19 @@ bool rfs::destroy_flow(rfs_rule **rule_extract)
             delete m_rfs_flow;
         }
         m_rfs_flow = nullptr;
+        n_rx_steering_rules++;
     }
     if (m_rfs_rule_secondary) {
         delete m_rfs_rule_secondary;
         m_rfs_rule_secondary = nullptr;
+        n_rx_steering_rules++;
     }
 
     m_b_tmp_is_attached = false;
     rfs_logdbg("Destroy RFS flow succeeded, Tag: %" PRIu32 ", Flow: %s", m_flow_tag_id,
                m_flow_tuple.to_str().c_str());
+
+    m_p_ring_simple->m_p_ring_stat->n_rx_steering_rules -= n_rx_steering_rules;
 
     return true;
 }

--- a/src/core/dev/rfs_mc.h
+++ b/src/core/dev/rfs_mc.h
@@ -24,6 +24,9 @@ public:
 
     virtual bool rx_dispatch_packet(mem_buf_desc_t *p_rx_wc_buf_desc,
                                     void *pv_fd_ready_array) override;
+    virtual void prepare_flow_spec_worker_thread_mode() override {}
+    virtual void prepare_flow_spec_secondary_rule() override {}
+    virtual bool if_secondary_rule_needed() override { return false; }
 
 protected:
     void prepare_flow_spec() override;

--- a/src/core/dev/rfs_uc.h
+++ b/src/core/dev/rfs_uc.h
@@ -20,13 +20,19 @@
 class rfs_uc : public rfs {
 public:
     rfs_uc(flow_tuple *flow_spec_5t, ring_slave *p_ring, rfs_rule_filter *rule_filter = nullptr,
-           uint32_t flow_tag_id = 0);
+           uint32_t flow_tag_id = 0, int steering_index = -1);
 
     virtual bool rx_dispatch_packet(mem_buf_desc_t *p_rx_wc_buf_desc,
                                     void *pv_fd_ready_array) override;
+    virtual void prepare_flow_spec_worker_thread_mode() override;
+    virtual void prepare_flow_spec_secondary_rule() override;
+    virtual bool if_secondary_rule_needed() override;
 
 protected:
     virtual void prepare_flow_spec() override;
+
+    // RSS child listen socket - Threads mode parameter
+    int m_steering_index = -1; // -1 means not a rss_child listen socket
 };
 
 #endif /* RFS_UC_H */

--- a/src/core/dev/rfs_uc_tcp_gro.cpp
+++ b/src/core/dev/rfs_uc_tcp_gro.cpp
@@ -36,8 +36,9 @@ inline bool ipv6_check(const struct ip6_hdr &p_ip6_h)
 }
 
 rfs_uc_tcp_gro::rfs_uc_tcp_gro(flow_tuple *flow_spec_5t, ring_slave *p_ring,
-                               rfs_rule_filter *rule_filter, uint32_t flow_tag_id)
-    : rfs_uc(flow_spec_5t, p_ring, rule_filter, flow_tag_id)
+                               rfs_rule_filter *rule_filter, uint32_t flow_tag_id,
+                               int steering_index)
+    : rfs_uc(flow_spec_5t, p_ring, rule_filter, flow_tag_id, steering_index)
     , m_b_active(false)
     , m_b_reserved(false)
     , m_pcb(nullptr)

--- a/src/core/dev/rfs_uc_tcp_gro.h
+++ b/src/core/dev/rfs_uc_tcp_gro.h
@@ -42,7 +42,8 @@ class gro_mgr;
 class rfs_uc_tcp_gro : public rfs_uc {
 public:
     rfs_uc_tcp_gro(flow_tuple *flow_spec_5t, ring_slave *p_ring,
-                   rfs_rule_filter *rule_filter = nullptr, uint32_t flow_tag_id = 0);
+                   rfs_rule_filter *rule_filter = nullptr, uint32_t flow_tag_id = 0,
+                   int steering_index = -1);
 
     virtual bool rx_dispatch_packet(mem_buf_desc_t *p_rx_wc_buf_desc, void *pv_fd_ready_array);
 

--- a/src/core/event/entity_context.cpp
+++ b/src/core/event/entity_context.cpp
@@ -66,6 +66,9 @@ void entity_context::process()
         case JOB_TYPE_SOCK_ADD_AND_CONNECT:
             connect_socket_job(job);
             break;
+        case JOB_TYPE_SOCK_ADD_AND_LISTEN:
+            listen_socket_job(job.sock);
+            break;
         case JOB_TYPE_SOCK_TX:
             // Handle socket transmit job
             // TODO: implement transmit logic
@@ -115,5 +118,17 @@ void entity_context::rx_data_recvd_job(const job_desc &job)
 
     if (job.sock) {
         job.sock->rx_data_recvd(job.tot_size);
+    }
+}
+
+void entity_context::listen_socket_job(sockinfo *sock)
+{
+    if (sock->get_protocol() == PROTO_TCP) {
+        sock->set_entity_context(this);
+        add_socket(reinterpret_cast<sockinfo_tcp *>(sock));
+        reinterpret_cast<sockinfo_tcp *>(sock)->listen_entity_context();
+        ctx_logdbg("New TCP Listen rss_child socket added (sock: %p)", sock);
+    } else {
+        ctx_logdbg("Unsupported socket protocol %hd for Threads mode", sock->get_protocol());
     }
 }

--- a/src/core/event/entity_context.h
+++ b/src/core/event/entity_context.h
@@ -43,7 +43,12 @@ class mem_buf_desc_t;
 
 class entity_context : public poll_group {
 public:
-    enum job_type { JOB_TYPE_SOCK_ADD_AND_CONNECT, JOB_TYPE_SOCK_TX, JOB_TYPE_SOCK_RX_DATA_RECVD };
+    enum job_type {
+        JOB_TYPE_SOCK_ADD_AND_CONNECT,
+        JOB_TYPE_SOCK_TX,
+        JOB_TYPE_SOCK_RX_DATA_RECVD,
+        JOB_TYPE_SOCK_ADD_AND_LISTEN
+    };
 
     struct job_desc {
         job_type job_id;
@@ -61,6 +66,7 @@ public:
 private:
     void connect_socket_job(const job_desc &sock);
     void rx_data_recvd_job(const job_desc &sock);
+    void listen_socket_job(sockinfo *sock);
 
     job_queue<job_desc> m_job_queue;
     size_t m_max_jobs = 0U;

--- a/src/core/event/entity_context_manager.h
+++ b/src/core/event/entity_context_manager.h
@@ -40,6 +40,7 @@
 #include "entity_context.h"
 
 class sockinfo;
+class sockinfo_tcp;
 
 class entity_context_manager {
 public:
@@ -52,8 +53,11 @@ public:
     static void fork_nullify();
 
     void distribute_socket(sockinfo *si, entity_context::job_type jobtype);
+    void distribute_listen_socket(sockinfo_tcp *si);
 
     const std::vector<entity_context *> &get_all_contexts() const { return m_entity_contexts; }
+
+    static int calculate_entity_context_pow2();
 
 private:
     static entity_context_manager *s_p_entity_context_manager;

--- a/src/core/sock/sock-redirect.cpp
+++ b/src/core/sock/sock-redirect.cpp
@@ -2042,7 +2042,6 @@ EXPORT_SYMBOL int XLIO_SYMBOL(epoll_ctl)(int __epfd, int __op, int __fd,
                                          struct epoll_event *__event)
 {
     PROFILE_FUNC
-
     const static char *op_names[] = {"<null>", "ADD", "DEL", "MOD"};
     NOT_IN_USE(op_names); /* to suppress warning in case MAX_DEFINED_LOG_LEVEL */
     if (__event) {

--- a/src/core/sock/sockinfo_tcp_listen_context.cpp
+++ b/src/core/sock/sockinfo_tcp_listen_context.cpp
@@ -1,0 +1,51 @@
+/*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+ * Copyright (c) 2021-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: GPL-2.0-only or BSD-2-Clause
+ */
+
+#include "sockinfo_tcp_listen_context.h"
+#include "util/sys_vars.h"
+
+sockinfo_tcp_listen_context::sockinfo_tcp_listen_context()
+{
+    m_listen_rss_children.reserve(safe_mce_sys().worker_threads);
+}
+
+void sockinfo_tcp_listen_context::increment_finish_counter()
+{
+    {
+        // C++ standard requires: shared variables used in condition_variable predicates must be
+        // modified while holding the same mutex used by wait(), even if atomic
+        std::lock_guard<std::mutex> lock(m_ready_mutex);
+        m_sockinfo_tcp_listen_finish_counter.fetch_add(1);
+    }
+    // Wake up parent to check if all children are ready
+    m_ready_condition.notify_one();
+}
+
+void sockinfo_tcp_listen_context::increment_error_counter()
+{
+    {
+        // C++ standard requires: shared variables used in condition_variable predicates must be
+        // modified while holding the same mutex used by wait(), even if atomic
+        std::lock_guard<std::mutex> lock(m_ready_mutex);
+        m_sockinfo_tcp_listen_error_counter.fetch_add(1);
+    }
+    // Wake up parent immediately on any error
+    m_ready_condition.notify_one();
+}
+
+bool sockinfo_tcp_listen_context::wait_for_rss_children_ready()
+{
+    // std::condition_variable works only with std::unique_lock<std::mutex>
+    std::unique_lock<std::mutex> lock(m_ready_mutex);
+    // Wait until either:
+    // 1. ALL children are ready (finish_counter == rss_children_size), OR
+    // 2. At least 1 error occurred (error_counter > 0)
+    // Each child wakes up parent, parent checks condition, goes back to wait if not met
+    m_ready_condition.wait(lock, [this] {
+        return get_finish_counter() == get_listen_rss_children_size() || get_error_counter() > 0;
+    });
+    return true; // Condition was met
+}

--- a/src/core/sock/sockinfo_tcp_listen_context.h
+++ b/src/core/sock/sockinfo_tcp_listen_context.h
@@ -1,0 +1,60 @@
+/*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+ * Copyright (c) 2021-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: GPL-2.0-only or BSD-2-Clause
+ */
+
+#ifndef SOCKINFO_TCP_LISTEN_CONTEXT_H
+#define SOCKINFO_TCP_LISTEN_CONTEXT_H
+
+#include <vector>
+#include <atomic>
+#include <cstddef>
+#include <mutex>
+#include <condition_variable>
+
+class sockinfo_tcp;
+
+class sockinfo_tcp_listen_context {
+public:
+    sockinfo_tcp_listen_context();
+    ~sockinfo_tcp_listen_context() = default;
+
+    size_t get_listen_rss_children_size() const { return m_listen_rss_children.size(); }
+    sockinfo_tcp *get_listen_rss_child(size_t index) { return m_listen_rss_children[index]; }
+    void add_listen_rss_child(sockinfo_tcp *rss_child)
+    {
+        m_listen_rss_children.push_back(rss_child);
+    }
+    bool listen_rss_children_empty() const { return m_listen_rss_children.empty(); }
+
+    int get_steering_index() const { return m_socketinfo_tcp_listen_steering_index; }
+    void set_steering_index(int index) { m_socketinfo_tcp_listen_steering_index = index; }
+
+    bool is_rss_child_listen_socket() const { return m_parent_listen_socket != nullptr; }
+
+    sockinfo_tcp *get_parent_listen_socket() const { return m_parent_listen_socket; }
+    void set_parent_listen_socket(sockinfo_tcp *parent) { m_parent_listen_socket = parent; }
+
+    size_t get_round_robin_index() const { return m_round_robin_index; }
+    size_t increment_round_robin_index() { return m_round_robin_index++; }
+
+    void increment_finish_counter();
+    void increment_error_counter();
+    uint16_t get_finish_counter() const { return m_sockinfo_tcp_listen_finish_counter.load(); }
+    uint16_t get_error_counter() const { return m_sockinfo_tcp_listen_error_counter.load(); }
+
+    bool wait_for_rss_children_ready();
+
+private:
+    sockinfo_tcp *m_parent_listen_socket = nullptr;
+    size_t m_round_robin_index = 0;
+    std::vector<sockinfo_tcp *> m_listen_rss_children;
+    std::atomic_uint16_t m_sockinfo_tcp_listen_finish_counter {0};
+    std::atomic_uint16_t m_sockinfo_tcp_listen_error_counter {0};
+    int m_socketinfo_tcp_listen_steering_index = -1;
+    std::mutex m_ready_mutex;
+    std::condition_variable m_ready_condition;
+};
+
+#endif /* SOCKINFO_TCP_LISTEN_CONTEXT_H */

--- a/src/core/util/xlio_stats.h
+++ b/src/core/util/xlio_stats.h
@@ -372,6 +372,7 @@ typedef struct {
     uint64_t n_tx_dev_mem_byte_count;
     uint64_t n_tx_dev_mem_oob;
     uint32_t n_tx_dev_mem_allocated;
+    uint32_t n_rx_steering_rules;
 } ring_stats_t;
 
 typedef struct {

--- a/src/stats/stats_reader.cpp
+++ b/src/stats/stats_reader.cpp
@@ -384,6 +384,9 @@ void update_delta_ring_stat(ring_stats_t *p_curr_ring_stats, ring_stats_t *p_pre
             delay;
         p_prev_ring_stats->n_tx_dev_mem_oob =
             (p_curr_ring_stats->n_tx_dev_mem_oob - p_prev_ring_stats->n_tx_dev_mem_oob) / delay;
+        p_prev_ring_stats->n_rx_steering_rules =
+            (p_curr_ring_stats->n_rx_steering_rules - p_prev_ring_stats->n_rx_steering_rules) /
+            delay;
     }
 }
 
@@ -531,6 +534,9 @@ void print_ring_stats(ring_instance_block_t *p_ring_inst_arr)
                        "Dev Mem Stats:", p_ring_stats->n_tx_dev_mem_byte_count / BYTES_TRAFFIC_UNIT,
                        p_ring_stats->n_tx_dev_mem_pkt_count, p_ring_stats->n_tx_dev_mem_oob,
                        post_fix);
+            }
+            if (p_ring_stats->n_rx_steering_rules) {
+                printf(FORMAT_STATS_32bit, "RX steering rules:", p_ring_stats->n_rx_steering_rules);
             }
 
             printf(FORMAT_STATS_32bit, "TX buffers inflight:", p_ring_stats->n_tx_num_bufs);


### PR DESCRIPTION

    issue: 4315534 Add TCP listen socket/accept() support for Threads mode
    
    Supporting TCP listen socket/accept() in Threads mode.
    Socket Listen procedure is split into two phases:
    
    ** Phase1 - Called from the application context **
    - prepareListen()
    -- Validates socket state.
    -- Auto-bind if the socket wasn't bound.
    -- Transport decision (XLIO offload or OS fallback).
    - Listen()
    -- Backlog calculation.
    -- Create listen socket clone object for every entity context.
    -- Call entity context manager to distribute clones via JOB_TYPE_SOCK_ADD_AND_LISTEN.
    -- Wait for listen clones to become ready.
    
    ** Phase2 - Called from Worker Thread execution context via entity_context **
    - listen_socket_job()
    -- Set the entity_context of the clone listen socket.
    -- Update the allocation logics.
    -- Add the socket to the socket list of the entity_context.
    - listen_entity_context
    -- attach_as_uc_receiver()
    --- Attach clone listen socket to Receive ring/s
    --- Create Masked flow steering rule/s using rule-based RSS
    ---- The source port range is partitioned across multiple listening sockets
    ---- Each socket installs a rule with a masked source port to handle a specific portion of the range.
    - Notify Master listen socket that clone is ready.
    
    ** Accept procedure **
    - Clone listen sockets:
    -- Receive new incoming connections.
    -- NOTIFY_ON_EVENTS(new conn, EPOLLIN) to notify epoll IOMUX.
    - Main listen socket will:
    -- Receive epoll event
    -- invoke accept()

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

