### PR TITLE
issue: 4367367 Handle socket passthrough in XLIO Ultra API

### DIFF
--- a/src/core/xlio.h
+++ b/src/core/xlio.h
@@ -493,6 +493,10 @@ int xlio_socket_getpeername(xlio_socket_t sock, struct sockaddr *addr, socklen_t
  * @param addrlen Length of the address
  * @return 0 on success, -1 on error (errno is set)
  *
+ * @par Error Codes:
+ * - ENODEV: Trying to bind to a non-NVIDIA NIC
+ * - Inherits bind(2) error codes
+ *
  * @see bind(2)
  */
 int xlio_socket_bind(xlio_socket_t sock, const struct sockaddr *addr, socklen_t addrlen);
@@ -508,8 +512,15 @@ int xlio_socket_bind(xlio_socket_t sock, const struct sockaddr *addr, socklen_t 
  * @param tolen Length of the remote address
  * @return 0 on success, -1 on error (errno is set)
  *
+ * @par Error Codes:
+ * - EISCONN: The socket is already connected
+ * - EALREADY: Previous connect attempt hasn't been completed yet
+ * - ECONNABORTED: Previous connect attempt has failed
+ * - ENODEV: Cannot establish connection with XLIO Ultra API or NVIDIA NIC
+ *
  * @note This function returns immediately. Connection establishment is
- * indicated by the XLIO_SOCKET_EVENT_ESTABLISHED event.
+ * indicated by the XLIO_SOCKET_EVENT_ESTABLISHED event. If a connection
+ * failure occurs an XLIO_SOCKET_EVENT_ERROR event will be delivered.
  *
  * @see connect(2)
  */


### PR DESCRIPTION
## Description
Some operations in XLIO can disable socket offload and enable "passthrough" mode. With POSIX API, this socket is passed to kernel with subsequent operations. However, XLIO Ultra API doesn't have an option to handle sockets with kernel. Therefore, we have to fail such operations if we cannot continue offloading the socket with XLIO.

This commit handles xlio_socket_bind() and xlio_socket_connect() calls.

##### What
Fail XLIO Ultra API bind() and connect() operations if socket cannot be offloaded by XLIO.

##### Why ?
"Passthrough" sockets cannot work with XLIO Ultra API.

## Change type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

