### PR TITLE
[CI] issue: HPCINFRA-3561  Change git pull policy in CI job

### DIFF
--- a/.ci/opensource_jjb.yaml
+++ b/.ci/opensource_jjb.yaml
@@ -136,7 +136,7 @@
                 credentials-id: 'swx-jenkins_ssh_key'
                 branches: ['$sha1']
                 shallow-clone: true
-                depth: 2
+                depth: 100
                 refspec: "+refs/pull/*:refs/remotes/origin/pr/*"
                 browser: githubweb
                 browser-url: "{jjb_git}"


### PR DESCRIPTION
##### Why ?
Current depth sometime is not sufficient

##### How ?
Increase depth to 100  
It limits clone depth to some value thus speeding up the process  
The number is big enough for any reasonable action

Issue: HPCINFRA-3561

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

