### PR TITLE
issue: 4610737 Skip Ultra API rings in CQ moderation

### DIFF
--- a/src/core/dev/net_device_val.cpp
+++ b/src/core/dev/net_device_val.cpp
@@ -1118,7 +1118,7 @@ int net_device_val::ring_drain_and_proccess()
     std::lock_guard<decltype(m_lock)> lock(m_lock);
     rings_hash_map_t::iterator ring_iter;
     for (ring_iter = m_h_ring_map.begin(); ring_iter != m_h_ring_map.end(); ring_iter++) {
-        if (THE_RING->get_poll_group() != nullptr) {
+        if (THE_RING->is_ultra_ring()) {
             continue;
         }
         int ret = THE_RING->drain_and_proccess();
@@ -1140,6 +1140,9 @@ void net_device_val::ring_adapt_cq_moderation()
     std::lock_guard<decltype(m_lock)> lock(m_lock);
     rings_hash_map_t::iterator ring_iter;
     for (ring_iter = m_h_ring_map.begin(); ring_iter != m_h_ring_map.end(); ring_iter++) {
+        if (THE_RING->is_ultra_ring()) {
+            continue;
+        }
         THE_RING->adapt_cq_moderation();
     }
 }

--- a/src/core/dev/ring.h
+++ b/src/core/dev/ring.h
@@ -206,6 +206,7 @@ public:
     // XLIO Ultra API
     void set_poll_group(poll_group *p_group) { m_p_group = p_group; }
     poll_group *get_poll_group() const { return m_p_group; }
+    bool is_ultra_ring() const { return m_p_group != nullptr; }
 
 protected:
     inline void set_parent(ring *parent) { m_parent = (parent ? parent : this); }


### PR DESCRIPTION
## Description
CQ moderation is implemented as a global timer running in the internal thread. Access to Ultra API rings must be serialized by user with the concept of polling groups. Access from the internal thread can introduce a race.

Skip such rings during CQ moderation logic. Once Ultra API interrupt mode is implemented, CQ moderation will be done per group.

##### What
Skip Ultra API rings in CQ moderation logic.

##### Why ?
Avoid potential race.

## Change type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

