### PR TITLE
issue: 4315534 Improve TX buffer management in the Threads mode

### DIFF
--- a/src/core/event/entity_context.h
+++ b/src/core/event/entity_context.h
@@ -41,8 +41,6 @@
 class sockinfo;
 class mem_buf_desc_t;
 
-#define JOB_SOCK_TX_IOV_MAX 32
-
 class entity_context : public poll_group {
 public:
     enum job_type {
@@ -53,11 +51,17 @@ public:
         JOB_TYPE_SOCK_CLOSE
     };
 
+    enum job_flag {
+        JOB_FLAG_TX_LAST_CHUNK = 0x0001,
+    };
+
     struct job_desc {
         job_type job_id;
+        int flags;
         sockinfo *sock;
         mem_buf_desc_t *buf;
-        size_t tot_size;
+        uint32_t offset;
+        uint32_t tot_size;
     };
 
     entity_context(size_t index);

--- a/src/core/event/entity_context_manager.cpp
+++ b/src/core/event/entity_context_manager.cpp
@@ -88,7 +88,8 @@ entity_context_manager::~entity_context_manager()
 void entity_context_manager::distribute_socket(sockinfo *si, entity_context::job_type jobtype)
 {
     uint16_t next_idx = m_next_distribute.fetch_add(1U) % safe_mce_sys().worker_threads;
-    m_entity_contexts[next_idx]->add_job(entity_context::job_desc {jobtype, si, nullptr, 0U});
+    m_entity_contexts[next_idx]->add_job(
+        entity_context::job_desc {jobtype, 0, si, nullptr, 0U, 0U});
 }
 
 void entity_context_manager::distribute_listen_socket(sockinfo_tcp *si)
@@ -99,7 +100,7 @@ void entity_context_manager::distribute_listen_socket(sockinfo_tcp *si)
         sockinfo_tcp *listen_rss_child = si->get_listen_context()->get_listen_rss_child(i);
         listen_rss_child->get_listen_context()->set_steering_index(i);
         m_entity_contexts[i]->add_job(entity_context::job_desc {
-            entity_context::JOB_TYPE_SOCK_ADD_AND_LISTEN, listen_rss_child, nullptr, 0U});
+            entity_context::JOB_TYPE_SOCK_ADD_AND_LISTEN, 0, listen_rss_child, nullptr, 0U, 0U});
     }
 }
 

--- a/src/core/sock/fd_collection.cpp
+++ b/src/core/sock/fd_collection.cpp
@@ -497,7 +497,7 @@ void fd_collection::handle_socket_close_job_worker_threads_mode(sockinfo_tcp *si
     // Send close job to socket's entity context
     assert(si->get_entity_context());
     si->get_entity_context()->add_job(
-        entity_context::job_desc {entity_context::JOB_TYPE_SOCK_CLOSE, si, nullptr, 0U});
+        entity_context::job_desc {entity_context::JOB_TYPE_SOCK_CLOSE, 0, si, nullptr, 0U, 0U});
 }
 
 int fd_collection::del_epfd(int fd, bool b_cleanup /*=false*/)

--- a/src/core/sock/sockinfo.h
+++ b/src/core/sock/sockinfo.h
@@ -253,9 +253,10 @@ public:
     virtual bool rx_input_cb(mem_buf_desc_t *p_rx_pkt_mem_buf_desc_info,
                              void *pv_fd_ready_array) = 0;
 
-    virtual void rx_data_recvd(size_t tot_size) = 0;
+    virtual void rx_data_recvd(uint32_t tot_size) = 0;
     virtual ssize_t tx(xlio_tx_call_attr_t &tx_arg) = 0;
-    virtual void tx_thread_commit(mem_buf_desc_t *buf_list) { NOT_IN_USE(buf_list); };
+    virtual void tx_thread_commit(mem_buf_desc_t *buf_list, uint32_t offset, uint32_t size,
+                                  int flags) = 0;
     virtual bool is_readable(uint64_t *p_poll_sn, fd_array_t *p_fd_array = nullptr) = 0;
     virtual bool is_writeable() = 0;
     virtual bool is_errorable(int *errors) = 0;

--- a/src/core/sock/sockinfo_tcp.h
+++ b/src/core/sock/sockinfo_tcp.h
@@ -187,7 +187,7 @@ public:
     void create_dst_entry();
     void destructor_helper_tcp();
     bool prepare_dst_to_send(bool is_accepted_socket = false);
-    void rx_data_recvd(size_t tot_size) override;
+    void rx_data_recvd(uint32_t tot_size) override;
     void clear_rx_ready_buffers();
 
     int fcntl(int __cmd, unsigned long int __arg) override;
@@ -243,7 +243,8 @@ public:
     ssize_t tx(xlio_tx_call_attr_t &tx_arg) override;
     ssize_t tcp_tx(xlio_tx_call_attr_t &tx_arg);
     ssize_t tcp_tx_thread(xlio_tx_call_attr_t &tx_arg);
-    void tx_thread_commit(mem_buf_desc_t *buf_list) override;
+    void tx_thread_commit(mem_buf_desc_t *buf_list, uint32_t offset, uint32_t size,
+                          int flags) override;
     ssize_t rx(const rx_call_t call_type, iovec *p_iov, ssize_t sz_iov, int *p_flags,
                sockaddr *__from = nullptr, socklen_t *__fromlen = nullptr,
                struct msghdr *__msg = nullptr) override;
@@ -640,7 +641,6 @@ private:
     uint32_t m_ready_conn_cnt;
     int m_backlog;
 
-private:
     multilock m_tcp_con_lock;
 
     // used for reporting 'connected' on second non-blocking call to connect or
@@ -668,6 +668,9 @@ private:
     bool m_b_xlio_socket_dirty = false;
     uintptr_t m_xlio_socket_userdata = 0;
     rfs_rule *m_p_rule_extracted = nullptr;
+
+    mem_buf_desc_t *m_store = nullptr;
+    uint32_t m_store_offset = 0;
 
     // Listen context - allocated only for listen sockets
     sockinfo_tcp_listen_context *m_listen_ctx = nullptr;

--- a/src/core/sock/sockinfo_udp.cpp
+++ b/src/core/sock/sockinfo_udp.cpp
@@ -2194,6 +2194,15 @@ tx_packet_to_os_stats:
     return ret;
 }
 
+void sockinfo_udp::tx_thread_commit(mem_buf_desc_t *buf_list, uint32_t offset, uint32_t size,
+                                    int flags)
+{
+    NOT_IN_USE(buf_list);
+    NOT_IN_USE(offset);
+    NOT_IN_USE(size);
+    NOT_IN_USE(flags);
+}
+
 ssize_t sockinfo_udp::check_payload_size(const iovec *p_iov, ssize_t sz_iov)
 {
     // Calc user data payload size

--- a/src/core/sock/sockinfo_udp.h
+++ b/src/core/sock/sockinfo_udp.h
@@ -68,7 +68,7 @@ public:
     bool isPassthrough() override { return !m_sock_offload; }
 
     int prepare_to_connect(const sockaddr *__to, socklen_t __tolen);
-    void rx_data_recvd(size_t) override {}
+    void rx_data_recvd(uint32_t) override {}
     int bind_no_os();
     int bind(const struct sockaddr *__addr, socklen_t __addrlen) override;
     int connect(const struct sockaddr *__to, socklen_t __tolen) override;
@@ -135,6 +135,8 @@ public:
      * true)
      */
     ssize_t tx(xlio_tx_call_attr_t &tx_arg) override;
+    void tx_thread_commit(mem_buf_desc_t *buf_list, uint32_t offset, uint32_t size,
+                          int flags) override;
     /**
      * Check that a call to this sockinof rx() will not block
      * -> meaning, we got a ready rx packet


### PR DESCRIPTION
## Description

Previous buffer management was simple: allocate TX buffers and copy user data there. Once the TX operation is completed, free the buffers to the ring. To work efficiently, the default TX buffer size needs to be increased. This approach has 2 main issues:
 1. Maximum hardcoded limit for buffer size is 64KB which is less than TSO.
 2. A small message wastes entire buffer.

Current commit doesn't handle (1).

New buffer management improves (2) and expects the TX buffer to be large: Every socket keeps a buffer as a storage and distributes it across multiple send operations. Once the storage buffer is full, socket allocates new one.

Every operation keeps its own reference to the storage buffer and releases it in the Ultra API TX completion callback. This is needed, because TX operations can be completed out of order in corner cases.

Further work:
 - Set default TX buffer size to 256KB in the Threads mode
 - Improve memory usage for big number of connections
 - Reduce memory usage by the neighboring ring

##### What
Improve TX buffer management in the Threads mode.

##### Why ?
Performance improvement.

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

