### PR TITLE
issue: 4555854 fix bad any_cast error - striding_rq

### DIFF
--- a/src/core/util/sys_vars.cpp
+++ b/src/core/util/sys_vars.cpp
@@ -2094,8 +2094,11 @@ void mce_sys_var::read_hypervisor_info()
 
 void mce_sys_var::configure_striding_rq(const config_registry &registry)
 {
-    set_value_from_registry_if_exists(enable_strq_env, "hardware_features.striding_rq.enable",
-                                      registry);
+    if (registry.value_exists("hardware_features.striding_rq.enable")) {
+        enable_strq_env = registry.get_value<bool>("hardware_features.striding_rq.enable")
+            ? option_3::ON
+            : option_3::OFF;
+    }
 
     enable_striding_rq = (enable_strq_env == option_3::ON || enable_strq_env == option_3::AUTO);
 


### PR DESCRIPTION
## Description
The set_value_from_registry_if_exists() function was causing a bad any_cast error when loading the hardware_features.striding_rq.enable configuration value.
This occurred because the generic template function couldn't properly handle the boolean to enum conversion.

Replace the generic set_value_from_registry_if_exists() call with explicit type-safe operations using registry.get_value<bool>() and converting the boolean result to option_3::ON/OFF enum values.

This fixes configuration loading failures when setting: XLIO_USE_NEW_CONFIG=1 \
XLIO_INLINE_CONFIG="hardware_features.striding_rq.enable=false"

##### What
Replace set_value_from_registry_if_exists() with explicit registry.get_value<bool>() and boolean-to-enum conversion to fix bad any_cast error for hardware_features.striding_rq.enable.

##### Why ?
fixes 4555854.

##### How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc._

## Change type
What kind of change does this PR introduce?
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

