### PR TITLE
issue: 4551255 fix any_cast error - exception mode

### DIFF
--- a/src/core/util/sys_vars.cpp
+++ b/src/core/util/sys_vars.cpp
@@ -2710,7 +2710,10 @@ void mce_sys_var::configure_memory_limits(const config_registry &registry)
 
     // TODO: this should be replaced by calling "exception_handling.init()" that
     // will be called from init()
-    set_value_from_registry_if_exists(exception_handling, "core.exception_handling.mode", registry);
+    if (registry.value_exists("core.exception_handling.mode")) {
+        exception_handling = static_cast<xlio_exception_handling>(
+            registry.get_value<int64_t>("core.exception_handling.mode"));
+    }
 
     set_value_from_registry_if_exists(avoid_sys_calls_on_tcp_fd, "core.syscall.avoid_ctl_syscalls",
                                       registry);


### PR DESCRIPTION
## Description
The set_value_from_registry_if_exists() function was causing a bad any_cast error when loading the core.exception_handling.mode configuration value.
This occurred because the generic template function couldn't properly handle the int64_t to enum conversion.

Replace the generic set_value_from_registry_if_exists() call with explicit type-safe operations using registry.get_value<int64_t>() and converting the int64_t result to xlio_exception_handling::mode values.

This fixes configuration loading failures when setting: XLIO_USE_NEW_CONFIG=1 \
XLIO_INLINE_CONFIG="core.exception_handling.mode=-2"

##### What
Replace set_value_from_registry_if_exists() with explicit registry.get_value<int64_t>() and static_cast to fix bad any_cast error for core.exception_handling.mode.

##### Why ?
fixes 4551255.

##### How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc._

## Change type
What kind of change does this PR introduce?
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

