### PR TITLE
issue: 4567877 fix multicast L2 rules config path

### DIFF
--- a/src/core/util/sys_vars.h
+++ b/src/core/util/sys_vars.h
@@ -744,7 +744,7 @@ extern mce_sys_var &safe_mce_sys();
 #define NEW_CONFIG_VAR_TCP_2T_RULES                  "performance.steering_rules.tcp.2t_rules"
 #define NEW_CONFIG_VAR_TCP_3T_RULES                  "performance.steering_rules.tcp.3t_rules"
 #define NEW_CONFIG_VAR_UDP_3T_RULES                  "performance.steering_rules.udp.3t_rules"
-#define NEW_CONFIG_VAR_ETH_MC_L2_ONLY_RULES          "performance.steering_rules.only_mc_l2_rules"
+#define NEW_CONFIG_VAR_ETH_MC_L2_ONLY_RULES          "performance.steering_rules.udp.only_mc_l2_rules"
 #define NEW_CONFIG_VAR_MC_FORCE_FLOWTAG              "network.multicast.mc_flowtag_acceleration"
 #define NEW_CONFIG_VAR_TX_SEGS_RING_BATCH_TCP        "performance.buffers.tcp_segments.ring_batch_size"
 #define NEW_CONFIG_VAR_TX_SEGS_POOL_BATCH_TCP        "performance.buffers.tcp_segments.pool_batch_size"


### PR DESCRIPTION
## Description
The NEW_CONFIG_VAR_ETH_MC_L2_ONLY_RULES macro was pointing to an incorrect configuration path.
It was using:
"performance.steering_rules.only_mc_l2_rules"
instead of the correct path:
"performance.steering_rules.udp.only_mc_l2_rules".

Update the configuration path to include the "udp" namespace to match the expected configuration schema structure.

##### What
Fix multicast L2 rules configuration path to include "udp" namespace in the configuration key.

##### Why ?
Fix 4567877.

##### How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc._

## Change type
What kind of change does this PR introduce?
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

