### PR TITLE
issue: 4561286 force sysconfdir to /etc

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -23,6 +23,11 @@ define([prj_ver_release], esyscmd([echo ${PRJ_RELEASE:=0}]))
 #
 AC_INIT(libxlio, [prj_ver_major.prj_ver_minor.prj_ver_revision], support@mellanox.com)
 
+# Force sysconfdir to /etc regardless of prefix
+# e.g. - "xlio_config_schema.json" will always be placed at "/etc"
+sysconfdir="/etc"
+AC_SUBST([sysconfdir])
+
 # Definitions will be placed in this file rather than
 # in the DEFS variable
 #


### PR DESCRIPTION
## Description
Force sysconfdir to /etc to ensure configuration files like xlio_config_schema.json are always placed in the standard system configuration directory, regardless of the installation prefix.

This ensures consistent configuration file location across different installation scenarios and follows standard Linux filesystem hierarchy conventions.

##### What
Force sysconfdir to /etc to ensure configuration files are placed in standard system directory regardless of prefix.

##### Why ?
Fixes 4561286.

##### How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc._

## Change type
What kind of change does this PR introduce?
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

