### PR TITLE
issue: 4550864 add minimum for nodelay_threshold

### DIFF
--- a/src/core/config/descriptor_providers/xlio_config_schema.json
+++ b/src/core/config/descriptor_providers/xlio_config_schema.json
@@ -276,6 +276,7 @@
                                         "byte_threshold": {
                                             "type": "integer",
                                             "default": 0,
+                                            "minimum": 0,
                                             "title": "Data threshold for flush",
                                             "description": "Triggers TCP nodelay only if unsent data is larger than this value. The value is in bytes. Default 0 means no threshold - immediate sending. Maps to XLIO_TCP_NODELAY_TRESHOLD environment variable."
                                         }


### PR DESCRIPTION
## Description
Add "minimum": 0 constraint to the byte_threshold field in the TCP nodelay configuration schema.

This ensures that negative values cannot be set for the data threshold, which should be a non-negative byte count.

The byte_threshold field controls when TCP nodelay is triggered based on unsent data size, and negative values would be invalid for this purpose.

##### What
Add "minimum": 0 constraint to byte_threshold field in TCP nodelay configuration schema to prevent negative values.

##### Why ?
Fixes 4550864.

##### How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc._

## Change type
What kind of change does this PR introduce?
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

