### PR TITLE
issue: 4555151 fix XLIO_USE_NEW_CONFIG env check

### DIFF
--- a/src/core/util/sys_vars.cpp
+++ b/src/core/util/sys_vars.cpp
@@ -2990,11 +2990,8 @@ void mce_sys_var::get_params()
     get_app_name();
 
     // legacy method - config registry is not relevant for this case
-    if (!std::getenv("XLIO_USE_NEW_CONFIG")) {
-        vlog_printf(VLOG_WARNING, "Using deprecated environment variables.\n");
-        vlog_printf(VLOG_WARNING,
-                    "------------------------------------------------"
-                    "---------------------------\n");
+    const char *use_new_config = std::getenv("XLIO_USE_NEW_CONFIG");
+    if (!use_new_config || std::string(use_new_config) != "1") {
         legacy_get_env_params();
     } else {
         try {


### PR DESCRIPTION
## Description
The current implementation only checks if the environment variable is set, but doesn't validate its value.
This can lead to incorrect behavior when the variable is set to an empty string or any non-"1" value.

Change the condition to explicitly check both:
1. If the variable is not set (NULL)
2. If the variable is set but not equal to "1"

This ensures the legacy configuration path is only used when the new config is explicitly disabled or not set.

##### What
Fix XLIO_USE_NEW_CONFIG environment variable validation to check both existence and value ("1") instead of just existence.

##### Why ?
Fixes 4555151.

##### How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc._

## Change type
What kind of change does this PR introduce?
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

