### PR TITLE
issue: 4578243 fix cpu_affinity type mismatch

### DIFF
--- a/src/core/config/descriptor_providers/xlio_config_schema.json
+++ b/src/core/config/descriptor_providers/xlio_config_schema.json
@@ -876,8 +876,16 @@
                             "description": "Control locking type mechanism for some specific flows. Maps to XLIO_MULTILOCK environment variable. Note that usage of Mutex might increase latency.\n0 - Spin\n1 - Mutex\nDefault: 0 (Spin)"
                         },
                         "cpu_affinity": {
-                            "type": "string",
-                            "default": "-1",
+                            "oneOf": [
+                                {
+                                    "type": "integer",
+                                    "default": -1
+                                },
+                                {
+                                    "type": "string",
+                                    "default": "-1"
+                                }
+                            ],
                             "title": "CPU affinity",
                             "description": "Control which CPU core(s) the XLIO internal thread is serviced on. Maps to XLIO_INTERNAL_THREAD_AFFINITY environment variable. The cpu set should be provided as *EITHER* a hexadecimal value that represents a bitmask. *OR* as a comma delimited of values (ranges are ok). Both the bitmask and comma delimited list methods are identical to what is supported by the taskset command. See the man page on taskset for additional information.\nWhere value of -1 disables internal thread affinity setting by XLIO\nBitmask Examples:\n0x00000001 - Run on processor 0.\n0x00000007 - Run on processors 1,2, and 3.\nComma Delimited Examples:\n0,4,8      - Run on processors 0,4, and 8.\n0,1,7-10   - Run on processors 0,1,7,8,9 and 10.\nDefault value is -1 (Disabled)."
                         },


### PR DESCRIPTION
## Description
The cpu_affinity parameter was defined as string type in the schema but the inline loader would convert numeric values like "-1" to int64_t, causing a bad_any_cast error when the code tried to retrieve it as std::string.

This occurred because the inline loader's parse_value() function automatically converts string values that can be parsed as numbers to int64_t, but cpu_affinity needs to support both simple numeric values (-1, 0, 2) and complex string values ("0,4,8", "0x00000001").

Fix by:
1. Changing the schema to use oneOf (integer | string) instead of string-only type
2. Updating the retrieval code to handle both integer and string types with fallback logic

This allows:
- Simple values: cpu_affinity=-1, cpu_affinity=2 (int64_t)
- Complex values: cpu_affinity="0,4,8", cpu_affinity="0x00000001" (str)

Fixes the error:
  XLIO ERROR: Configuration failed to load. Bad cast for key: performance.threading.cpu_affinity - bad any_cast

Tested with:
  XLIO_USE_NEW_CONFIG=1 \ XLIO_INLINE_CONFIG="performance.threading.cpu_affinity=-1" \ LD_PRELOAD=libxlio.so ls

##### What
Fix cpu_affinity type mismatch causing bad_any_cast error in inline configuration.

##### Why ?
Fix 4578243.

##### How ?
**Root Cause:**
The `cpu_affinity` parameter was defined as string-only in the schema, but the inline loader's `parse_value()` function automatically converts numeric-looking strings (like "-1") to `int64_t`. When the code tried to retrieve the value as `std::string`, it caused a `bad_any_cast` exception.

**Solution:**
1. **Schema Change**: Changed `cpu_affinity` from `"type": "string"` to `oneOf` with both integer and string options, following the same pattern as memory parameters
2. **Code Change**: Updated retrieval logic in `sys_vars.cpp` to try string first, then fallback to integer with conversion to string

**Design:**
- **Type Detection**: The existing `oneOf` infrastructure automatically determines whether a value should be stored as integer or string based on the schema
- **Fallback Logic**: Simple try-catch pattern ensures backward compatibility - complex values like "0,4,8" work as strings, simple values like -1 work as integers
- **Minimal Impact**: Only affects `cpu_affinity` parameter, no changes to other configuration handling

**Benefits:**
- Fixes the immediate bug without breaking existing functionality
- Supports all valid CPU affinity formats (simple integers, comma-delimited lists, hex bitmasks)
- Follows established patterns in the codebase (same as memory parameters)
- Minimal code changes with low risk of regression

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

