### PR TITLE
issue: 4315534 Define MCE_DEFAULT_SRC_PORT_STRIDE unconditionally

### DIFF
--- a/src/core/dev/rfs.cpp
+++ b/src/core/dev/rfs.cpp
@@ -247,7 +247,6 @@ bool rfs::attach_flow(sockinfo *sink)
             if (!create_flow()) {
                 return false;
             }
-            rfs_logdbg("Added secondary rule to worker: %d", g_p_app->get_worker_id());
         }
     } else {
         rfs_logdbg("rfs: Joining existing flow");

--- a/src/core/util/sys_vars.h
+++ b/src/core/util/sys_vars.h
@@ -949,9 +949,9 @@ extern mce_sys_var &safe_mce_sys();
 #endif
 #if defined(DEFINED_NGINX) || defined(DEFINED_ENVOY)
 #define MCE_DEFAULT_APP_WORKERS_NUM (0)
-#define MCE_DEFAULT_SRC_PORT_STRIDE (2)
 #define MCE_DEFAULT_DISTRIBUTE_CQ   (false)
 #endif
+#define MCE_DEFAULT_SRC_PORT_STRIDE              (2)
 #define MCE_DEFAULT_MSS                          (0)
 #define MCE_DEFAULT_LWIP_CC_ALGO_MOD             (0)
 #define MCE_DEFAULT_INTERNAL_THREAD_AFFINITY     (-1)


### PR DESCRIPTION
Previously, MCE_DEFAULT_SRC_PORT_STRIDE was defined only when DEFINED_NGINX, which prevented usage of the macro when NGINX was not defined. This changes defines the macro unconditionally.

## Description
Please provide a summary of the change.

##### What
_Subject: what this PR is doing in one line._ 

##### Why ?
_Justification for the PR. If there is existing issue/bug please reference._

##### How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc._

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

