### PR TITLE
issue: 4579042 Fix new/old defaults discrepancy

### DIFF
--- a/src/core/config/descriptor_providers/xlio_config_schema.json
+++ b/src/core/config/descriptor_providers/xlio_config_schema.json
@@ -769,7 +769,7 @@
                                 },
                                 "udp_buffer_batch": {
                                     "type": "integer",
-                                    "default": 16,
+                                    "default": 8,
                                     "minimum": 1,
                                     "title": "TX buffer batch size",
                                     "description": "Number of TX buffers fetched by a UDP socket at once. Maps to TX_BUFS_BATCH_UDP environment variable."
@@ -826,14 +826,14 @@
                                 },
                                 "ring_elements_count": {
                                     "type": "integer",
-                                    "default": 16000,
+                                    "default": 32768,
                                     "minimum": 0,
                                     "title": "RX WRE global array size",
                                     "description": "Number of Work Request Elements allocated in all RQs. Maps to XLIO_RX_WRE environment variable. "
                                 },
                                 "spare_buffers": {
                                     "type": "integer",
-                                    "default": 64,
+                                    "default": 32768,
                                     "title": "Spare RX buffers",
                                     "description": "Number of spare receive buffer a ring holds to allow for filling up QP while full receive buffers are being processed inside XLIO. Maps to XLIO_QP_COMPENSATION_LEVEL environment variable.\nDefault value is XLIO_RX_WRE / 2"
                                 },
@@ -1214,7 +1214,7 @@
                                 },
                                 "pool_batch_size": {
                                     "type": "integer",
-                                    "default": 1024,
+                                    "default": 16384,
                                     "minimum": 1,
                                     "title": "Pool segment batch size",
                                     "description": "Number of TCP segments batched when fetched from the segments pool. Maps to XLIO_TX_SEGS_POOL_BATCH_TCP environment variable. Min value is 1"


### PR DESCRIPTION
## Description
Fixed 4 critical discrepancies between the new JSON config system and the legacy environment variable system defaults in xlio_config_schema.json.

1. **RX Ring Elements Count**: 16000 → 32768
   - Path: performance.rings.rx.ring_elements_count
   - Maps to: XLIO_RX_WRE
   - Impact: Restored proper RX ring capacity

2. **RX Spare Buffers**: 64 → 32768
   - Path: performance.rings.rx.spare_buffers
   - Maps to: XLIO_QP_COMPENSATION_LEVEL
   - Impact: Restored critical buffer compensation level

3. **TX UDP Buffer Batch**: 16 → 8
   - Path: performance.rings.tx.udp_buffer_batch
   - Maps to: XLIO_TX_BUFS_BATCH_UDP
   - Impact: Restored original UDP batching behavior

4. **TX TCP Segments Pool Batch**: 1024 → 16384
   - Path: performance.buffers.tcp_segments.pool_batch_size
   - Maps to: XLIO_TX_SEGS_POOL_BATCH_TCP
   - Impact: Restored proper TCP segment pool batching


##### What
Fix alignment on new config system defaults with legacy environment variables.

##### Why ?
maintains backwards compatibility. fixes 4579042.

##### How ?
1. **Systematic Comparison**: Extracted all MCE_DEFAULT_* values from sys_vars.h
2. **Schema Mapping**: Used mappings.py to correlate env vars with new config paths
3. **Default Verification**: Cross-referenced schema defaults in xlio_config_schema.json
4. **Comprehensive Review**: Verified 10+ additional parameters were already aligned


## Change type
What kind of change does this PR introduce?
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

