### PR TITLE
issue: 4551257 improve display clarity

### DIFF
--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -569,9 +569,9 @@ void print_xlio_global_settings()
         VLOG_PARAM_NUMBER("Rx UDP Poll OS Ratio", safe_mce_sys().rx_udp_poll_os_ratio,
                           MCE_DEFAULT_RX_UDP_POLL_OS_RATIO, NEW_CONFIG_VAR_RX_UDP_POLL_OS_RATIO);
     } else {
-        VLOG_PARAM_STRING("Rx UDP Poll OS Ratio", safe_mce_sys().rx_udp_poll_os_ratio,
+        VLOG_PARAM_NUMSTR("Rx UDP Poll OS Ratio", safe_mce_sys().rx_udp_poll_os_ratio,
                           MCE_DEFAULT_RX_UDP_POLL_OS_RATIO, NEW_CONFIG_VAR_RX_UDP_POLL_OS_RATIO,
-                          "Disabled");
+                          "(Disabled)");
     }
 
     VLOG_PARAM_NUMBER("HW TS Conversion", safe_mce_sys().hw_ts_conversion_mode,
@@ -638,22 +638,23 @@ void print_xlio_global_settings()
         VLOG_PARAM_NUMBER("Select Poll OS Ratio", safe_mce_sys().select_poll_os_ratio,
                           MCE_DEFAULT_SELECT_POLL_OS_RATIO, NEW_CONFIG_VAR_SELECT_POLL_OS_RATIO);
     } else {
-        VLOG_PARAM_STRING("Select Poll OS Ratio", safe_mce_sys().select_poll_os_ratio,
+        VLOG_PARAM_NUMSTR("Select Poll OS Ratio", safe_mce_sys().select_poll_os_ratio,
                           MCE_DEFAULT_SELECT_POLL_OS_RATIO, NEW_CONFIG_VAR_SELECT_POLL_OS_RATIO,
-                          "Disabled");
+                          "(Disabled)");
     }
 
     if (safe_mce_sys().select_skip_os_fd_check) {
         VLOG_PARAM_NUMBER("Select Skip OS", safe_mce_sys().select_skip_os_fd_check,
                           MCE_DEFAULT_SELECT_SKIP_OS, NEW_CONFIG_VAR_SELECT_SKIP_OS);
     } else {
-        VLOG_PARAM_STRING("Select Skip OS", safe_mce_sys().select_skip_os_fd_check,
-                          MCE_DEFAULT_SELECT_SKIP_OS, NEW_CONFIG_VAR_SELECT_SKIP_OS, "Disabled");
+        VLOG_PARAM_NUMSTR("Select Skip OS", safe_mce_sys().select_skip_os_fd_check,
+                          MCE_DEFAULT_SELECT_SKIP_OS, NEW_CONFIG_VAR_SELECT_SKIP_OS, "(Disabled)");
     }
 
     if (safe_mce_sys().progress_engine_interval_msec == MCE_CQ_DRAIN_INTERVAL_DISABLED ||
         safe_mce_sys().progress_engine_wce_max == 0) {
-        vlog_printf(VLOG_INFO, FORMAT_STRING, "CQ Drain Thread", "Disabled",
+        vlog_printf(VLOG_INFO, FORMAT_NUMSTR, "CQ Drain Interval (msec)",
+                    safe_mce_sys().progress_engine_interval_msec, "(Disabled)",
                     NEW_CONFIG_VAR_PROGRESS_ENGINE_INTERVAL);
     } else {
         VLOG_PARAM_NUMBER("CQ Drain Interval (msec)", safe_mce_sys().progress_engine_interval_msec,


### PR DESCRIPTION
## Description
When configuration parameters are set to 0 (disabled), the current display only shows "Disabled" without indicating the actual value. This creates ambiguity about whether the user intentionally set the value to 0 or if there was an error.

This change modifies the display format to show both the original value and the "(Disabled)" description for better clarity. The affected parameters:
- performance.polling.iomux.poll_os_ratio
- performance.polling.iomux.skip_os
- performance.polling.rx_kernel_fd_attention_level
- performance.completion_queue.periodic_drain_msec

This provides users with clear confirmation that they intentionally set the value to 0 and that "Disabled" is the intended behavior.

##### What
Improve display clarity for disabled configuration parameters

##### Why ?
Fixes 4551257.

##### How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc._

## Change type
What kind of change does this PR introduce?
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

