### PR TITLE
[CI] issue: HPCINFRA-3931 Sockperf test Worker threads mode

### DIFF
--- a/.ci/matrix_job.yaml
+++ b/.ci/matrix_job.yaml
@@ -126,9 +126,24 @@ runs_on_dockers:
   - {
       file: '.ci/dockerfiles/Dockerfile.ubuntu22.04',
       arch: 'x86_64',
-      name: 'test',
+      name: 'sockperf',
       uri: 'xlio/$arch/ubuntu22.04/$name',
-      tag: '20250219',
+      tag: '20251015',
+      build_args: '--no-cache --target test',
+      category: 'tests',
+      annotations: [{ key: 'k8s.v1.cni.cncf.io/networks', value: 'sriov-cx6dx-p1' }],
+      limits: '{memory: 10Gi, cpu: 10000m, hugepages-2Mi: 10Gi, nvidia.com/sriov-cx6dx-p1: 1}',
+      requests: '{memory: 10Gi, cpu: 10000m, hugepages-2Mi: 10Gi, nvidia.com/sriov-cx6dx-p1: 1}',
+      caps_add: '[ IPC_LOCK, SYS_RESOURCE ]',
+      runAsUser: '0',
+      runAsGroup: '0'
+    }
+  - {
+      file: '.ci/dockerfiles/Dockerfile.ubuntu22.04',
+      arch: 'x86_64',
+      name: 'sockperf-worker-threads',
+      uri: 'xlio/$arch/ubuntu22.04/$name',
+      tag: '20251015',
       build_args: '--no-cache --target test',
       category: 'tests',
       annotations: [{ key: 'k8s.v1.cni.cncf.io/networks', value: 'sriov-cx6dx-p1' }],
@@ -342,12 +357,27 @@ steps:
   - name: Test
     enable: ${do_test}
     containerSelector:
-      - "{name: 'test'}"
+      - "{name: 'sockperf'}"
     agentSelector:
       - "{nodeLabel: 'skip-agent'}"
     run: |
       [ "x${do_test}" == "xtrue" ] && action=yes || action=no
-      env WORKSPACE=$PWD TARGET=${flags} jenkins_test_run=${action} ./contrib/test_jenkins.sh
+      env WORKSPACE=$PWD TARGET=${flags} jenkins_test_run=${action} WORKER_THREADS=false ./contrib/test_jenkins.sh
+    parallel: false
+    onfail: |
+      ./.ci/artifacts.sh
+    archiveArtifacts-onfail: |
+      jenkins/**/arch-*.tar.gz
+
+  - name: Test (Worker thread mode)
+    enable: ${do_test}
+    containerSelector:
+      - "{name: 'sockperf-worker-threads'}"
+    agentSelector:
+      - "{nodeLabel: 'skip-agent'}"
+    run: |
+      [ "x${do_test}" == "xtrue" ] && action=yes || action=no
+      env WORKSPACE=$PWD TARGET=${flags} jenkins_test_run=${action} WORKER_THREADS=true ./contrib/test_jenkins.sh
     parallel: false
     onfail: |
       ./.ci/artifacts.sh


### PR DESCRIPTION
## Description
Today we are running the Sockperf test in R2C mode only, meaning we are not testing the new worker threads mode in our CI process.

##### What
Add Worker threads mode test to the test.sh run, running both R2C mode and worker threads mode one after the other.

##### Why ?
[HPCINFRA-3931](https://jirasw.nvidia.com/browse/HPCINFRA-3931)


## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [X] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

