### PR TITLE
issue: 4561511 remove obsolete global_array_size

### DIFF
--- a/README
+++ b/README
@@ -588,10 +588,6 @@ performance.buffers.tx.buf_size
 Size of Tx data buffer elements allocation. Cannot be less than MTU (Maximum Transfer Unit) and greater than 256KB. Default value is calculated based on MTU and MSS. Maps to **XLIO_TX_BUF_SIZE** environment variable.
 Default value is 0
 
-performance.buffers.tx.global_array_size
-Number of global zerocopy data buffer elements allocation. Maps to **XLIO_TX_BUFS** environment variable. Controls how many buffers are pre-allocated for TX operations.
-Default value is 200000
-
 performance.buffers.tx.prefetch_size
 Accelerate offloaded send operation by optimizing cache. Maps to **XLIO_TX_PREFETCH_BYTES** environment variable. Different values give optimized send rate on different machines. We recommend you tune this for your specific hardware.
 Value range is 0 to MTU size

--- a/src/core/config/descriptor_providers/xlio_config_schema.json
+++ b/src/core/config/descriptor_providers/xlio_config_schema.json
@@ -1176,13 +1176,6 @@
                                     "description": "Size of Tx data buffer elements allocation. Cannot be less than MTU (Maximum Transfer Unit) and greater than 256KB. Default value is calculated based on MTU and MSS. Maps to XLIO_TX_BUF_SIZE environment variable.",
                                     "x-memory-size": true
                                 },
-                                "global_array_size": {
-                                    "type": "integer",
-                                    "default": 200000,
-                                    "minimum": 0,
-                                    "title": "Global TX buffer array size",
-                                    "description": "Number of global zerocopy data buffer elements allocation. Maps to XLIO_TX_BUFS environment variable. Controls how many buffers are pre-allocated for TX operations."
-                                },
                                 "prefetch_size": {
                                     "type": "integer",
                                     "default": 256,

--- a/src/core/config/mappings.py
+++ b/src/core/config/mappings.py
@@ -66,7 +66,6 @@ config_mapping = {
     "performance.buffers.tcp_segments.ring_batch_size": "XLIO_TX_SEGS_RING_BATCH_TCP",
     "performance.buffers.tcp_segments.socket_batch_size": "XLIO_TX_SEGS_BATCH_TCP",
     "performance.buffers.tx.buf_size": "XLIO_TX_BUF_SIZE",
-    "performance.buffers.tx.global_array_size": "XLIO_TX_BUFS",
     "performance.buffers.tx.prefetch_size": "XLIO_TX_PREFETCH_BYTES",
     "performance.completion_queue.interrupt_moderation.adaptive_change_frequency_msec": "XLIO_CQ_AIM_INTERVAL_MSEC",
     "performance.completion_queue.interrupt_moderation.adaptive_count": "XLIO_CQ_AIM_MAX_COUNT",


### PR DESCRIPTION
## Description
The performance.buffers.tx.global_array_size parameter was removed from the codebase in commit cb731c3b17b3e10fd0b6976a3cea3a45797c8cdf, but references to it remained in the configuration schema, mappings, and documentation. This caused non-default values to not be shown in the header as the parameter was no longer functional.

Remove all remaining references to this obsolete parameter:
- Remove from README documentation
- Remove from xlio_config_schema.json
- Remove from mappings.py

##### What
Remove obsolete performance.buffers.tx.global_array_size parameter

##### Why ?
Fixes: 4561511

##### How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc._

## Change type
What kind of change does this PR introduce?
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

