### PR TITLE
issue: 4640792 Fix incorrect type definitions

### DIFF
--- a/src/core/config/descriptor_providers/xlio_config_schema.json
+++ b/src/core/config/descriptor_providers/xlio_config_schema.json
@@ -1013,10 +1013,10 @@
                             }
                         },
                         "yield_on_poll": {
-                            "type": "boolean",
-                            "default": false,
+                            "type": "integer",
+                            "default": 0,
                             "title": "Yield CPU when no UDP packets found",
-                            "description": "When an application is running with multiple threads, on a limited number of cores, there is a need for each thread polling inside XLIO (read, readv, recv & recvfrom) to yield the CPU to other polling thread so not to starve them from processing incoming packets. Maps to XLIO_RX_POLL_YIELD environment variable."
+                            "description": "When an application is running with multiple threads, on a limited number of cores, there is a need for each thread polling inside XLIO (read, readv, recv & recvfrom) to yield the CPU to other polling thread so not to starve them from processing incoming packets. Maps to XLIO_RX_POLL_YIELD environment variable. The value is the number of iterations before yielding the CPU. Disable with 0."
                         },
                         "offload_transition_poll_count": {
                             "type": "integer",
@@ -1302,10 +1302,10 @@
                             "description": "The size of UDP socket pool for NGINX. Maps to XLIO_NGINX_UDP_POOL_SIZE environment variable. For any value different than 0 - close() socket will not destroy the socket, but will place it in a pool for next socket UDP creation.\nDisable with 0"
                         },
                         "udp_socket_pool_reuse": {
-                            "type": "boolean",
-                            "default": false,
+                            "type": "integer",
+                            "default": 0,
                             "title": "Enable UDP socket pool reuse",
-                            "description": "Allows reuse of UDP socket pools for NGINX deployments. Maps to XLIO_NGINX_UDP_POOL_RX_NUM_BUFFS_REUSE environment variable."
+                            "description": "Controls the reuse of UDP socket pools for NGINX deployments. Maps to XLIO_NGINX_UDP_POOL_RX_NUM_BUFFS_REUSE environment variable. Disable with 0."
                         },
                         "distribute_cq": {
                             "type": "boolean",


### PR DESCRIPTION
## Description
Both parameters were incorrectly defined as boolean type when they should be integer type based on their actual usage and environment variable mappings.

Changes:
- yield_on_poll: Change from bool (default: false) to int (default: 0)
  - Updated description - clarify the num of iterations before yielding
  - Disable with 0, not false
- udp_socket_pool_reuse: Change from bool to int
  - Updated description to clarify it controls reuse behavior
  - Disable with 0, not false

These parameters map to environment variables that expect integer values:
- XLIO_RX_POLL_YIELD
- XLIO_NGINX_UDP_POOL_RX_NUM_BUFFS_REUSE

##### What
config: Fix incorrect type definitions for yield_on_poll and udp_socket_pool_reuse

##### Why ?
Fixes 4640792 , 4561798, 4558998.

##### How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc._

## Change type
What kind of change does this PR introduce?
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

