### PR TITLE
issue: 4625345 Fix Coverity uninitialized use

### DIFF
--- a/src/core/config/descriptor_providers/json_descriptor_provider.cpp
+++ b/src/core/config/descriptor_providers/json_descriptor_provider.cpp
@@ -150,20 +150,20 @@ std::unique_ptr<parameter_descriptor> json_descriptor_provider::create_descripto
     }
 
     // Create parameter descriptor with default value
-    auto descriptor = std::make_unique<parameter_descriptor>(analysis.default_value);
+    auto descriptor = std::make_unique<parameter_descriptor>(*analysis.default_value);
 
     // Apply constraints if present
-    if (analysis.needs_constraint_validation) {
+    if (analysis.needs_constraint_validation()) {
         apply_constraints(descriptor.get(), analysis.constraint_cfg);
     }
 
     // Apply value transformation if needed
-    if (analysis.needs_value_transformation) {
+    if (analysis.needs_value_transformation()) {
         apply_value_transformation(descriptor.get());
     }
 
     // Apply enum mapping if needed
-    if (analysis.needs_enum_mapping) {
+    if (analysis.needs_enum_mapping()) {
         apply_enum_mapping(descriptor.get(), analysis.enum_cfg);
     }
 
@@ -234,11 +234,9 @@ void json_descriptor_provider::apply_value_transformation(parameter_descriptor *
 }
 
 void json_descriptor_provider::apply_enum_mapping(parameter_descriptor *descriptor,
-                                                  const enum_mapping_config &config)
+                                                  const enum_mapping_config_t &config)
 {
-    if (config.enabled && config.int_values.size() == config.string_values.size()) {
-        for (size_t i = 0; i < config.int_values.size(); i++) {
-            descriptor->add_string_mapping(config.string_values[i], config.int_values[i]);
-        }
+    if (static_cast<bool>(config) && config->size() > 0) {
+        descriptor->set_string_mappings(*config);
     }
 }

--- a/src/core/config/descriptor_providers/json_descriptor_provider.h
+++ b/src/core/config/descriptor_providers/json_descriptor_provider.h
@@ -92,8 +92,7 @@ private:
     static void apply_value_transformation(parameter_descriptor *descriptor);
 
     static void apply_enum_mapping(parameter_descriptor *descriptor,
-                                   const enum_mapping_config &config);
-
+                                   const enum_mapping_config_t &config);
     /**
      * @brief Processes an object property (nested object)
      * @param property_obj JSON property object

--- a/src/core/config/descriptors/parameter_descriptor.cpp
+++ b/src/core/config/descriptors/parameter_descriptor.cpp
@@ -154,14 +154,14 @@ parameter_descriptor::parameter_descriptor(const parameter_descriptor &pd)
 {
 }
 
-void parameter_descriptor::add_string_mapping(const std::string &str,
-                                              const std::experimental::any &val)
+void parameter_descriptor::set_string_mappings(const std::map<std::string, int64_t> &mappings)
 {
-    if (m_string_mapping.find(str) != m_string_mapping.end()) {
-        throw_xlio_exception("String mapping already exists for value: " + str);
+    for (const auto &mapping : mappings) {
+        if (m_string_mapping.find(mapping.first) != m_string_mapping.end()) {
+            throw_xlio_exception("String mapping already exists for value: " + mapping.first);
+        }
+        m_string_mapping[mapping.first] = std::experimental::any(mapping.second);
     }
-
-    m_string_mapping[str] = val;
 }
 
 void parameter_descriptor::set_value_transformer(value_transformer_t transformer)

--- a/src/core/config/descriptors/parameter_descriptor.h
+++ b/src/core/config/descriptors/parameter_descriptor.h
@@ -72,12 +72,11 @@ public:
     parameter_descriptor(const parameter_descriptor &pd);
 
     /**
-     * @brief Adds a string-to-value mapping
-     * @param str String representation
-     * @param val Value to map to
-     * @throws xlio_exception If mapping already exists
+     * @brief Sets string-to-value mappings
+     * @param mappings Map of string-to-value mappings
+     * @throws xlio_exception If double-mapping is detected
      */
-    void add_string_mapping(const std::string &str, const std::experimental::any &val);
+    void set_string_mappings(const std::map<std::string, int64_t> &mappings);
 
     /**
      * @brief Sets a value transformer function

--- a/tests/unit_tests/config/schema_analyzer.cpp
+++ b/tests/unit_tests/config/schema_analyzer.cpp
@@ -100,12 +100,12 @@ TEST_F(schema_analyzer_test, analyze_simple_property)
 
     ASSERT_EQ(analysis.json_property_type, property_type::SIMPLE);
     ASSERT_EQ(analysis.value_type, typeid(int64_t));
-    ASSERT_FALSE(analysis.needs_value_transformation);
-    ASSERT_FALSE(analysis.needs_constraint_validation);
-    ASSERT_FALSE(analysis.needs_enum_mapping);
+    ASSERT_FALSE(analysis.needs_value_transformation());
+    ASSERT_FALSE(analysis.needs_constraint_validation());
+    ASSERT_FALSE(analysis.needs_enum_mapping());
 
     // Test default value
-    ASSERT_EQ(std::experimental::any_cast<int64_t>(analysis.default_value), 42);
+    ASSERT_EQ(std::experimental::any_cast<int64_t>(*analysis.default_value), 42);
 }
 
 TEST_F(schema_analyzer_test, analyze_extended_property)
@@ -114,12 +114,12 @@ TEST_F(schema_analyzer_test, analyze_extended_property)
 
     ASSERT_EQ(analysis.json_property_type, property_type::EXTENDED);
     ASSERT_EQ(analysis.value_type, typeid(int64_t));
-    ASSERT_TRUE(analysis.needs_value_transformation);
-    ASSERT_TRUE(analysis.memory_cfg.enabled);
-    ASSERT_FALSE(analysis.needs_constraint_validation);
-    ASSERT_FALSE(analysis.needs_enum_mapping);
-    ASSERT_EQ(std::experimental::any_cast<int64_t>(analysis.default_value), 32 * 1024 * 1024);
-    ASSERT_EQ(analysis.memory_cfg.pattern, "^[0-9]+[KMGkmg]?[B]?$");
+    ASSERT_TRUE(analysis.needs_value_transformation());
+    ASSERT_TRUE(analysis.memory_cfg);
+    ASSERT_FALSE(analysis.needs_constraint_validation());
+    ASSERT_FALSE(analysis.needs_enum_mapping());
+    ASSERT_EQ(std::experimental::any_cast<int64_t>(*analysis.default_value), 32 * 1024 * 1024);
+    ASSERT_EQ(analysis.memory_cfg, true);
 }
 
 TEST_F(schema_analyzer_test, analyze_one_of_property)
@@ -134,9 +134,9 @@ TEST_F(schema_analyzer_test, analyze_object_property)
 
     ASSERT_EQ(analysis.json_property_type, property_type::OBJECT);
     ASSERT_EQ(analysis.value_type, typeid(json_object *));
-    ASSERT_FALSE(analysis.needs_value_transformation);
-    ASSERT_FALSE(analysis.needs_constraint_validation);
-    ASSERT_FALSE(analysis.needs_enum_mapping);
+    ASSERT_FALSE(analysis.needs_value_transformation());
+    ASSERT_FALSE(analysis.needs_constraint_validation());
+    ASSERT_FALSE(analysis.needs_enum_mapping());
 }
 
 TEST_F(schema_analyzer_test, analyze_array_property)
@@ -145,9 +145,9 @@ TEST_F(schema_analyzer_test, analyze_array_property)
 
     ASSERT_EQ(analysis.json_property_type, property_type::ARRAY);
     ASSERT_EQ(analysis.value_type, typeid(std::vector<std::experimental::any>));
-    ASSERT_FALSE(analysis.needs_value_transformation);
-    ASSERT_FALSE(analysis.needs_constraint_validation);
-    ASSERT_FALSE(analysis.needs_enum_mapping);
+    ASSERT_FALSE(analysis.needs_value_transformation());
+    ASSERT_FALSE(analysis.needs_constraint_validation());
+    ASSERT_FALSE(analysis.needs_enum_mapping());
 }
 
 TEST_F(schema_analyzer_test, analyze_null_property_throws)
@@ -179,12 +179,12 @@ TEST_F(schema_analyzer_test, analyze_property_with_constraints)
     auto analysis = schema_analyzer::analyze(constrained_property, "test.constrained");
 
     ASSERT_EQ(analysis.json_property_type, property_type::SIMPLE);
-    ASSERT_TRUE(analysis.needs_constraint_validation);
+    ASSERT_TRUE(analysis.needs_constraint_validation());
     ASSERT_TRUE(analysis.constraint_cfg.has_minimum);
     ASSERT_TRUE(analysis.constraint_cfg.has_maximum);
     ASSERT_FALSE(analysis.constraint_cfg.has_enum);
     ASSERT_EQ(analysis.constraint_cfg.minimum_value, 0);
     ASSERT_EQ(analysis.constraint_cfg.maximum_value, 100);
-    ASSERT_EQ(std::experimental::any_cast<int64_t>(analysis.default_value), 50);
+    ASSERT_EQ(std::experimental::any_cast<int64_t>(*analysis.default_value), 50);
     json_object_put(constrained_property);
 }


### PR DESCRIPTION
## Description
Fix Coverity uninitialized use warnings by explicit member init

- Add explicit default initialization for std::experimental::any members
- Add explicit empty initialization for std::vector members
- Remove Coverity suppression comments that are no longer needed

This addresses static analysis warnings about potentially uninitialized struct members by making initialization explicit rather than relying on default constructors.

##### What
Fix Coverity uninitialized use warnings by explicit member initialization

##### Why ?
Fixes 4625345.

##### How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc._

## Change type
What kind of change does this PR introduce?
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

