### PR TITLE
issue: 4642277 Reorder socket cleanup in poll_group::close_socket

### DIFF
--- a/src/core/event/poll_group.cpp
+++ b/src/core/event/poll_group.cpp
@@ -236,8 +236,9 @@ void poll_group::reuse_sockfd(int fd, sockinfo_tcp *si)
 
 void poll_group::close_socket(sockinfo_tcp *si, bool force /*=false*/)
 {
-    g_p_fd_collection->clear_socket(si->get_fd());
+    int fd = si->get_fd();
     close_socket_helper(si, force);
+    g_p_fd_collection->clear_socket(fd);
 }
 
 void poll_group::close_socket_helper(sockinfo_tcp *si, bool force /*=false*/)


### PR DESCRIPTION
Call prepare_to_close before clear_socket, as prepare_to_close expects g_p_fd_collection to be cleared only after it.


## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

