### PR TITLE
issue: 4640792 fix incorrect cast

### DIFF
--- a/src/core/util/sys_vars.cpp
+++ b/src/core/util/sys_vars.cpp
@@ -1940,7 +1940,7 @@ void mce_sys_var::initialize_base_variables(const config_registry &registry)
         registry.get_default_value<uint32_t>("performance.polling.rx_kernel_fd_attention_level");
     hw_ts_conversion_mode = static_cast<ts_conversion_mode_t>(
         registry.get_default_value<int>("network.timing.hw_ts_conversion"));
-    rx_poll_yield_loops = registry.get_default_value<bool>("performance.polling.yield_on_poll");
+    rx_poll_yield_loops = registry.get_default_value<int>("performance.polling.yield_on_poll");
     select_handle_cpu_usage_stats = registry.get_default_value<bool>("monitor.stats.cpu_usage");
     rx_ready_byte_min_limit =
         registry.get_default_value<uint32_t>("performance.override_rcvbuf_limit");
@@ -2053,7 +2053,7 @@ void mce_sys_var::initialize_base_variables(const config_registry &registry)
     nginx_udp_socket_pool_size =
         registry.get_default_value<uint32_t>("applications.nginx.udp_pool_size");
     nginx_udp_socket_pool_rx_num_buffs_reuse =
-        registry.get_default_value<bool>("applications.nginx.udp_socket_pool_reuse");
+        registry.get_default_value<int>("applications.nginx.udp_socket_pool_reuse");
 #endif
 #if defined(DEFINED_NGINX) || defined(DEFINED_ENVOY)
     app.type = APP_NONE;


### PR DESCRIPTION
## Description
Fix incorrect boolean type definitions for two configuration parameters that should be integer types based on their actual usage and environment variable mappings.

The parameters were incorrectly defined as boolean when they should be integer, causing build failures. This is a follow-up fix to correct the type mismatches.

Changes:
- performance.polling.yield_on_poll: Change from bool to int
  - Controls number of polling iterations before yielding
  - Disable with 0, not false
- applications.nginx.udp_socket_pool_reuse: Change from bool to int
  - Controls UDP socket pool reuse behavior
  - Disable with 0, not false

These parameters map to environment variables that expect int values:
- XLIO_RX_POLL_YIELD
- XLIO_NGINX_UDP_POOL_RX_NUM_BUFFS_REUSE

##### What
_Subject: what this PR is doing in one line._ 

##### Why ?
_Justification for the PR. If there is existing issue/bug please reference._

##### How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc._

## Change type
What kind of change does this PR introduce?
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

