### PR TITLE
issue: 4669942 Don't increase error counter on TCP EOF

### DIFF
--- a/src/core/lwip/tcp_in.c
+++ b/src/core/lwip/tcp_in.c
@@ -198,7 +198,7 @@ void L3_level_tcp_input(struct pbuf *p, struct tcp_pcb *pcb)
                        PCB. */
                     tcp_pcb_remove(pcb);
                 } else {
-                    /* If the application has registered a "sent" function to be
+                    /* If the application has registered an "acked" function to be
                        called when new send buffer space is available, we call it
                        now. */
                     if (pcb->acked > 0) {
@@ -225,7 +225,7 @@ void L3_level_tcp_input(struct pbuf *p, struct tcp_pcb *pcb)
                         if (err == ERR_ABRT) {
                             goto aborted;
                         }
-                        /* If the upper layer can't receive this data, store it */
+                        /* If the upper layer can't receive this data, drop it */
                         if (err != ERR_OK) {
                             pcb->rcv_wnd += in_data.recv_data->tot_len;
                             pbuf_free(in_data.recv_data);

--- a/src/core/sock/sockinfo_tcp.cpp
+++ b/src/core/sock/sockinfo_tcp.cpp
@@ -2234,7 +2234,7 @@ int sockinfo_tcp::handle_rx_error(bool blocking)
         errno = EAGAIN;
     }
 
-    if (m_p_socket_stats) {
+    if (unlikely(m_p_socket_stats) && ret == -1) {
         if (errno == EAGAIN) {
             m_p_socket_stats->counters.n_rx_eagain++;
         } else {


### PR DESCRIPTION
## Description
EOF is a regular scenario. Treating it as an error in the stats can be confusing.

##### What
Don't treat TCP EOF as an error.

##### Why ?
Avoid confusion and noise in stats.

## Change type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

