### PR TITLE
issue: 4578714 Remove "all" and 6 from profiles

### DIFF
--- a/src/core/config/descriptor_providers/xlio_config_schema.json
+++ b/src/core/config/descriptor_providers/xlio_config_schema.json
@@ -1511,8 +1511,7 @@
                                 2,
                                 3,
                                 4,
-                                5,
-                                6
+                                5
                             ],
                             "default": 0
                         },
@@ -1524,8 +1523,7 @@
                                 "latency",
                                 "nginx",
                                 "nginx_dpu",
-                                "nvme_bf3",
-                                "all"
+                                "nvme_bf3"
                             ],
                             "default": "none"
                         }


### PR DESCRIPTION
## Description
Remove the "all" string and the integer value 6 from the list of allowed values for the "spec" profile in the configuration schema.

##### What
all was never an option for profile - remove it.

##### Why ?
Fixes 4578714.

##### How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc._

## Change type
What kind of change does this PR introduce?
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

