### PR TITLE
issue: 4642229 fix memory leaks during termination

### DIFF
--- a/contrib/valgrind/valgrind_xlio.supp
+++ b/contrib/valgrind/valgrind_xlio.supp
@@ -89,6 +89,23 @@
    fun:create_rdma_channel
    fun:_ZN15neigh_table_mgrC1Ev
 }
+{
+   rdma_create_event_channel_fp_leak
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:calloc
+   obj:/usr/lib/x86_64-linux-gnu/librdmacm.so.1.3.56.0
+   obj:/usr/lib/x86_64-linux-gnu/librdmacm.so.1.3.56.0
+   obj:/usr/lib/x86_64-linux-gnu/librdmacm.so.1.3.56.0
+   fun:rdma_create_event_channel
+   fun:_ZN15neigh_table_mgr19create_rdma_channelEv
+   fun:UnknownInlinedFun
+   fun:_ZL22do_global_ctors_helperv.lto_priv.0
+   fun:_Z15do_global_ctorsv
+   fun:_Z15socket_internaliiibb
+   fun:_Z7bringupPKi
+   fun:main
+}
 ###########################################################
 # false positive libmlx5\4
 {

--- a/src/core/event/event_handler_manager.cpp
+++ b/src/core/event/event_handler_manager.cpp
@@ -680,10 +680,6 @@ void event_handler_manager::priv_unregister_command_events(command_reg_info_t &i
 
 void event_handler_manager::handle_registration_action(reg_action_t &reg_action)
 {
-    if (!m_b_continue_running && reg_action.type != UNREGISTER_TIMERS_AND_DELETE) {
-        return;
-    }
-
     evh_logfunc("event action %d", reg_action.type);
     sockinfo_tcp *sock;
     switch (reg_action.type) {
@@ -1019,7 +1015,20 @@ void *event_handler_manager::thread_loop()
 
     } // while (m_b_continue_running)
 
+    process_remaining_registration_actions();
+
     free(p_events);
 
     return nullptr;
+}
+
+void event_handler_manager::process_remaining_registration_actions()
+{
+    assert(m_p_reg_action_q_to_pop_from->empty());
+
+    while (!m_p_reg_action_q_to_push_to->empty()) {
+        reg_action_t reg_action = m_p_reg_action_q_to_push_to->front();
+        m_p_reg_action_q_to_push_to->pop_front();
+        handle_registration_action(reg_action);
+    }
 }

--- a/src/core/event/event_handler_manager.h
+++ b/src/core/event/event_handler_manager.h
@@ -220,6 +220,20 @@ protected:
     void handle_registration_action(reg_action_t &reg_action);
     void process_ibverbs_event(event_handler_map_t::iterator &i);
     void process_rdma_cm_event(event_handler_map_t::iterator &i);
+    /**
+     * @brief Process any remaining registration actions in the queue after thread loop exits
+     *
+     * This method is called after the event handler thread loop has exited to ensure
+     * that any pending registration actions (such as socket cleanup actions) are
+     * processed before the event handler manager is destroyed. This prevents memory
+     * leaks by ensuring that UNREGISTER_TCP_SOCKET_TIMER_AND_DELETE actions are
+     * executed even when the thread stops before processing them.
+     *
+     * @note This method should only be called after m_b_continue_running is set to false
+     *       and the event handler thread has exited, as no new actions can be added
+     *       to the queue at that point.
+     */
+    void process_remaining_registration_actions();
     int start_thread();
 
     void event_channel_post_process_for_rdma_events(void *p_event);


### PR DESCRIPTION
## Description
Fix Valgrind issues.

one is a FP for rdmalib, but the other is a very real XLIO bug:

The event handler manager thread loop exits without processing pending registration actions in the queue, causing memory leaks when UNREGISTER_TCP_SOCKET_TIMER_AND_DELETE actions remain unprocessed.

This occurs during XLIO shutdown when:
1. Socket cleanup requests are posted to the registration queue
2. The event handler thread is stopped (m_b_continue_running = false)
3. The thread loop exits without processing the queue
4. sockinfo_tcp objects are never deleted, causing definite memory leaks

Fix by adding process_remaining_registration_actions() method that:
- Processes any remaining actions in the queue after thread loop exits
- Ensures UNREGISTER_TCP_SOCKET_TIMER_AND_DELETE actions are executed
- Prevents memory leaks during XLIO shutdown

Also remove the m_b_continue_running check from
handle_registration_action() since we now process all remaining actions during shutdown.

This fixes Valgrind report of definite leak of 8,546 bytes (1,856 direct + 6,690 indirect) in sockinfo_tcp object created by fd_collection::addsocket().

##### What
event_handler_manager: fix memory leak by processing remaining registration actions

##### Why ?
Fixes 4642229 + stabilizing Valgrind step in CI

##### How ?
Root cause analysis shows this occurs during library shutdown:
1. Socket cleanup requests are posted to the registration queue via
   unregister_socket_timer_and_delete()
2. The event handler thread is stopped (m_b_continue_running = false)
3. The thread loop exits without processing the queue
4. sockinfo_tcp objects are never deleted, causing definite memory leaks

Valgrind report shows definite leak of 8,546 bytes (1,856 direct + 6,690 indirect)
in sockinfo_tcp object created by fd_collection::addsocket() at line 207.

The fix implements a post-loop cleanup mechanism that processes any remaining
registration actions after the main thread loop exits. This ensures that
critical cleanup actions (like socket deletion) are executed even when the
thread stops before processing them.

Key design decisions:
1. Process ALL remaining actions (not just selective ones) since the system
   is shutting down and we want complete cleanup (actions are conducted in a serialized manner anyway)
2. No locking required since m_b_continue_running=false prevents new actions
   from being added to the queue
3. No queue swapping needed since we're the only thread accessing the queue

Implementation:
- Add process_remaining_registration_actions() method that processes the
  entire queue after thread loop exits
- Call this method from thread_loop() after the main while loop
- Remove the m_b_continue_running check from handle_registration_action()
  since we now process all remaining actions during shutdown
- Add comprehensive Doxygen documentation explaining usage constraints

Testing:
- Valgrind shows the definite memory leak is resolved
- Debug prints confirm queue is processed when not empty
- No regressions in normal operation (queue is empty in normal cases)

ALTERNATIVES CONSIDERED:
1. Queue swapping with locking: Unnecessary complexity since no new actions
   can be added after m_b_continue_running=false
2. Selective action processing: Risk of missing important actions as part of termination flow

## Change type
What kind of change does this PR introduce?
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

