### PR TITLE
xlio: fix netlink recv hang in VM Environment

### DIFF
--- a/src/core/proto/netlink_socket_mgr.cpp
+++ b/src/core/proto/netlink_socket_mgr.cpp
@@ -126,6 +126,14 @@ int netlink_socket_mgr::recv_info(int sockfd, uint32_t pid, uint32_t seq, char *
         buf_ptr += readLen;
         msgLen += readLen;
 
+        // Particularly in vm environment MSG_DONE is set in the last chunk
+        for (; NLMSG_OK(nlHdr, readLen); nlHdr = NLMSG_NEXT(nlHdr, readLen)) {
+            // We should exit the while loop as this is the last header
+            // if none of them has NLMSG_DONE then we should expect more data
+            if (nlHdr->nlmsg_type == NLMSG_DONE)
+                break;
+        }
+
         // Loop until this is the last message of expected reply
     } while (nlHdr->nlmsg_type != NLMSG_DONE && (nlHdr->nlmsg_flags & NLM_F_MULTI));
 


### PR DESCRIPTION
In VM environments, netlink dump responses may arrive with empty data or only NLMSG_DONE. XLIO's netlink_socket_mgr::recv_info() did not check nlmsg_type for NLMSG_DONE and blocked in recv() indefinitely. This patch updates recv_info() to iterate over nlmsghdr chain using NLMSG_NEXT and exit gracefully on NLMSG_DONE or NLMSG_ERROR.

## Description
In VM environments, netlink dump responses may arrive with empty data or only NLMSG_DONE. XLIO's netlink_socket_mgr::recv_info() did not check nlmsg_type for NLMSG_DONE and blocked in recv() indefinitely. This patch updates recv_info() to iterate over nlmsghdr chain using NLMSG_NEXT and exit gracefully on NLMSG_DONE or NLMSG_ERROR.

##### What
_Subject: Netlink: recv_info hang in vm environment

##### Why ?
It should go over the entire chain of hdr and look for MSG_DONE flag

##### How ?
This patch updates recv_info() to iterate over nlmsghdr chain using NLMSG_NEXT and exit gracefully on NLMSG_DONE or NLMSG_ERROR

## Change type
What kind of change does this PR introduce?
- [x] Bugfix
