### PR TITLE
issue: 4724535 Fix TSO SS aggressive cwnd/ssthresh

### DIFF
--- a/docs/xlio_config_reference.md
+++ b/docs/xlio_config_reference.md
@@ -1,6 +1,6 @@
 # XLIO Configuration Reference
 
-This file documents all 125 XLIO runtime configuration parameters with their types, defaults, environment variables, and constraints.
+This file documents all 126 XLIO runtime configuration parameters with their types, defaults, environment variables, and constraints.
 
 > **Auto-generated** from the JSON schema by `generate_docs.py`. Do not edit manually.
 
@@ -66,6 +66,7 @@ This file documents all 125 XLIO runtime configuration parameters with their typ
   - [`network.neighbor.update_interval_msec`](#networkneighborupdate_interval_msec) — Neighbor update interval (msec)
   - [`network.protocols.ip.mtu`](#networkprotocolsipmtu) — MTU size
   - [`network.protocols.tcp.congestion_control`](#networkprotocolstcpcongestion_control) — TCP congestion control algorithm
+  - [`network.protocols.tcp.congestion_control_tso_aware`](#networkprotocolstcpcongestion_control_tso_aware) — TSO-aware congestion control
   - [`network.protocols.tcp.linger_0`](#networkprotocolstcplinger_0) — Abort TCP connections on close
   - [`network.protocols.tcp.mss`](#networkprotocolstcpmss) — Maximum Segment Size
   - [`network.protocols.tcp.nodelay.byte_threshold`](#networkprotocolstcpnodelaybyte_threshold) — Data threshold for flush
@@ -1503,6 +1504,28 @@ Use:
    - "disable" or 2 to disable the congestion algorithm.
 
 **Default:** `"lwip" (0)`
+
+### `network.protocols.tcp.congestion_control_tso_aware`
+
+> **Type:** boolean
+>
+> **Maps to:** `XLIO_TCP_CC_TSO_AWARE`
+
+Enables TSO-aware congestion-control sizing for TCP connections that use TCP Segmentation Offload (TSO).
+
+**Behavior:**
+
+- *true* (default): Uses larger startup and recovery congestion-control thresholds sized for TSO payloads, allowing high-bandwidth flows to ramp up faster.
+- *false*: Uses conservative congestion-control thresholds.
+
+**Tradeoffs:**
+
+- *true*: Better throughput ramp-up for TSO-enabled flows; may send larger bursts during startup or recovery.
+- *false*: More conservative behavior; useful when lower burstiness or stricter legacy behavior is preferred.
+
+**Scope:** Only affects connections with TSO enabled.
+
+**Default:** `true`
 
 ### `network.protocols.tcp.linger_0`
 

--- a/src/core/config/config_var_definitions.h
+++ b/src/core/config/config_var_definitions.h
@@ -140,6 +140,7 @@ extern const config_var_info_t<bool> CONFIG_VAR_DISTRIBUTE_CQ;
 #endif
 extern const config_var_info_t<uint32_t, int64_t> CONFIG_VAR_MSS;
 extern const config_var_info_t<uint32_t, int64_t> CONFIG_VAR_TCP_CC_ALGO;
+extern const config_var_info_t<bool> CONFIG_VAR_TCP_CC_TSO_AWARE;
 extern const config_var_info_t<uint32_t, int64_t> CONFIG_VAR_SPEC;
 
 extern const config_var_info_t<option_3::mode_t, int64_t> CONFIG_VAR_TSO;

--- a/src/core/config/descriptor_providers/xlio_config_schema.json
+++ b/src/core/config/descriptor_providers/xlio_config_schema.json
@@ -391,6 +391,12 @@
                                     "title": "TCP congestion control algorithm",
                                     "description": "Maps to XLIO_TCP_CC_ALGO environment variable.\nTCP congestion control algorithm.\nThe default algorithm coming with LwIP is a variation of Reno.\nThe new Cubic algorithm was adapted from FreeBSD implementation.\n\nUse:\n   - \"lwip\" or 0 for LwIP algorithm.\n   - \"cubic\" or 1 for Cubic algorithm.\n   - \"disable\" or 2 to disable the congestion algorithm."
                                 },
+                                "congestion_control_tso_aware": {
+                                    "type": "boolean",
+                                    "default": true,
+                                    "title": "TSO-aware congestion control",
+                                    "description": "Maps to XLIO_TCP_CC_TSO_AWARE environment variable.\nEnables TSO-aware congestion-control sizing for TCP connections that use TCP Segmentation Offload (TSO).\n\n**Behavior:**\n\n- *true* (default): Uses larger startup and recovery congestion-control thresholds sized for TSO payloads, allowing high-bandwidth flows to ramp up faster.\n- *false*: Uses conservative congestion-control thresholds.\n\n**Tradeoffs:**\n\n- *true*: Better throughput ramp-up for TSO-enabled flows; may send larger bursts during startup or recovery.\n- *false*: More conservative behavior; useful when lower burstiness or stricter legacy behavior is preferred.\n\n**Scope:** Only affects connections with TSO enabled."
+                                },
                                 "timestamps": {
                                     "oneOf": [
                                         {

--- a/src/core/config/mappings.py
+++ b/src/core/config/mappings.py
@@ -34,6 +34,7 @@ config_mapping = {
     "network.neighbor.update_interval_msec": "XLIO_NETLINK_TIMER",
     "network.protocols.ip.mtu": "XLIO_MTU",
     "network.protocols.tcp.congestion_control": "XLIO_TCP_CC_ALGO",
+    "network.protocols.tcp.congestion_control_tso_aware": "XLIO_TCP_CC_TSO_AWARE",
     "network.protocols.tcp.linger_0": "XLIO_TCP_ABORT_ON_CLOSE",
     "network.protocols.tcp.mss": "XLIO_MSS",
     "network.protocols.tcp.nodelay.byte_threshold": "XLIO_TCP_NODELAY_TRESHOLD",

--- a/src/core/lwip/cc_cubic.c
+++ b/src/core/lwip/cc_cubic.c
@@ -129,7 +129,9 @@ static void cubic_ack_received(struct tcp_pcb *pcb, uint16_t type)
              * Critical for TSO where one ACK can acknowledge many segments (e.g., 64KB = 44
              * segments).
              */
-            pcb->cwnd += pcb->acked;
+            if ((u32_t)(pcb->cwnd + pcb->acked) > pcb->cwnd) {
+                pcb->cwnd += pcb->acked;
+            }
         } else if (cubic_data->min_rtt_ticks > 0) {
             ticks_since_cong = ticks - cubic_data->t_last_cong;
 

--- a/src/core/lwip/tcp.c
+++ b/src/core/lwip/tcp.c
@@ -93,6 +93,7 @@ enum cc_algo_mod lwip_cc_algo_module = CC_MOD_LWIP;
 u16_t lwip_tcp_mss = CONST_TCP_MSS;
 u8_t enable_push_flag = 1;
 u8_t enable_ts_option = 0;
+u8_t tcp_cc_tso_aware = 1;
 u32_t lwip_tcp_nodelay_treshold = 0;
 
 /* slow timer value */
@@ -513,36 +514,23 @@ bool tcp_recved(struct tcp_pcb *pcb, u32_t len, bool do_output)
 /**
  * Set initial congestion window and slow start threshold.
  *
- * For TSO-enabled connections:
- * - cwnd: 0.25 * TSO_max_payload (to fill pipe immediately)
- * - ssthresh: Very high value (allows slow start to discover optimal window)
- *
- * For non-TSO connections:
- * - cwnd: RFC 3390 compliant
- * - ssthresh: 10 * MSS (allows moderate growth)
+ * With TSO and tcp_cc_tso_aware enabled:
+ *   cwnd = 0.25 * TSO_max (64KB), ssthresh = 2GB
+ * Otherwise:
+ *   cwnd = RFC 3390, ssthresh = 10*MSS
  *
  * @param pcb the tcp_pcb for which to set initial window parameters
  */
 void tcp_set_initial_cwnd_ssthresh(struct tcp_pcb *pcb)
 {
-    if (tcp_tso(pcb)) {
-        /* TSO enabled: aggressive initial window
-         * Use 25% of TSO max payload as initial cwnd.
-         * Default TSO max is 256KB, so initial cwnd = 64KB.
-         * This provides enough BDP for high-speed networks.
-         */
+    if (tcp_tso(pcb) && tcp_cc_tso_aware) {
+        /* TSO-aware: cwnd = 25% of TSO max (default 64KB) */
         pcb->cwnd = pcb->tso.max_payload_sz / 4;
 
-        /* Set ssthresh very high (following industry best practice).
-         * This keeps TCP in slow start mode until network conditions
-         * dictate otherwise, allowing exponential growth to discover
-         * the optimal sending rate.
-         */
+        /* High ssthresh allows slow start to discover optimal window */
         pcb->ssthresh = 0x7FFFFFFF; /* 2GB - effectively unlimited */
     } else {
-        /* Non-TSO: RFC 3390 compliant initial window
-         * IW = min(4*MSS, max(2*MSS, 4380 bytes))
-         */
+        /* RFC 3390: IW = min(4*MSS, max(2*MSS, 4380 bytes)) */
         if (pcb->mss * 4 <= 4380) {
             pcb->cwnd = pcb->mss * 4;
         } else {
@@ -557,59 +545,37 @@ void tcp_set_initial_cwnd_ssthresh(struct tcp_pcb *pcb)
 /**
  * Reset cwnd and ssthresh after a congestion event (RTO or fast retransmit).
  *
- * This is more conservative than initial window settings, as a congestion
- * event indicates network issues.
- *
- * For TSO connections (TSO-optimized, deviates from RFC 5681):
- * - Reset cwnd to 10% of TSO max (26KB) instead of 1 MSS
- * - Set ssthresh to 25% of TSO max (64KB) to enable slow start recovery
- * - Rationale: RFC 5681 (cwnd=1 MSS) is too conservative for modern TSO hardware
- *   that sends 256KB super-packets. Even Linux CUBIC suffers from slow RTO
- *   recovery with aggressive TSO. Our approach balances fast recovery with safety.
- *
- * For non-TSO connections:
- * - Follow RFC 5681: cwnd = 1 MSS, ssthresh = max(FlightSize/2, 2*MSS)
+ * With TSO and tcp_cc_tso_aware enabled (deviates from RFC 5681):
+ *   cwnd = 10% of TSO_max (26KB), ssthresh = max(FlightSize/2, 64KB)
+ * Otherwise:
+ *   cwnd = 1*MSS, ssthresh = max(FlightSize/2, 2*MSS) per RFC 5681
  *
  * @param pcb the tcp_pcb experiencing congestion
  * @param is_rto true if this is an RTO event, false for fast retransmit
  */
 void tcp_reset_cwnd_on_congestion(struct tcp_pcb *pcb, bool is_rto)
 {
-    if (tcp_tso(pcb)) {
-        /* TSO-aware recovery (deviates from RFC 5681 and modern CUBIC):
-         *
-         * RFC 5681 & Modern CUBIC (Linux 2024): cwnd = 1 MSS (1460 bytes)
-         * Our TSO approach: cwnd = 26KB (10% of TSO max)
-         *
-         * Rationale:
-         * - RFC 5681 was written before aggressive TSO (256KB super-packets)
-         * - Linux CUBIC follows RFC but suffers slow RTO recovery with large TSO
-         * - 1460 bytes is artificially small when hardware sends 256KB packets
-         * - 26KB restart allows reasonable BDP while still being conservative
-         *
-         * This ensures cwnd < ssthresh after RTO, allowing exponential growth
-         * from 26KB → 64KB during recovery. The 64KB threshold is the same as
-         * our initial connection window, providing consistent behavior.
+    if (tcp_tso(pcb) && tcp_cc_tso_aware) {
+        /* TSO-aware recovery: more aggressive than RFC 5681 (1 MSS)
+         * to better handle large TSO segments (256KB super-packets).
          */
         u32_t tso_recovery_cwnd = pcb->tso.max_payload_sz / 10; // 26KB
         u32_t tso_recovery_ssthresh = pcb->tso.max_payload_sz / 4; // 64KB
 
-        /* For very large windows before congestion, respect TCP's halving rule */
         u32_t eff_wnd = LWIP_MIN(pcb->cwnd, pcb->snd_wnd);
         u32_t halved_wnd = eff_wnd >> 1;
 
-        /* Use the larger of: halved window or our TSO recovery threshold */
+        /* ssthresh = max(halved window, TSO recovery threshold) */
         pcb->ssthresh = LWIP_MAX(halved_wnd, tso_recovery_ssthresh);
 
         if (is_rto) {
-            /* RTO: Conservative restart */
             pcb->cwnd = tso_recovery_cwnd;
         } else {
-            /* Fast retransmit: Less conservative, add 3*MSS for quick recovery */
+            /* Fast retransmit: add 3*MSS for quick recovery */
             pcb->cwnd = pcb->ssthresh + 3 * pcb->mss;
         }
     } else {
-        /* Non-TSO: RFC 5681 standard behavior */
+        /* RFC 5681 standard behavior */
         u32_t eff_wnd = LWIP_MIN(pcb->cwnd, pcb->snd_wnd);
         pcb->ssthresh = eff_wnd >> 1;
 

--- a/src/core/lwip/tcp.c
+++ b/src/core/lwip/tcp.c
@@ -511,6 +511,121 @@ bool tcp_recved(struct tcp_pcb *pcb, u32_t len, bool do_output)
 }
 
 /**
+ * Set initial congestion window and slow start threshold.
+ *
+ * For TSO-enabled connections:
+ * - cwnd: 0.25 * TSO_max_payload (to fill pipe immediately)
+ * - ssthresh: Very high value (allows slow start to discover optimal window)
+ *
+ * For non-TSO connections:
+ * - cwnd: RFC 3390 compliant
+ * - ssthresh: 10 * MSS (allows moderate growth)
+ *
+ * @param pcb the tcp_pcb for which to set initial window parameters
+ */
+void tcp_set_initial_cwnd_ssthresh(struct tcp_pcb *pcb)
+{
+    if (tcp_tso(pcb)) {
+        /* TSO enabled: aggressive initial window
+         * Use 25% of TSO max payload as initial cwnd.
+         * Default TSO max is 256KB, so initial cwnd = 64KB.
+         * This provides enough BDP for high-speed networks.
+         */
+        pcb->cwnd = pcb->tso.max_payload_sz / 4;
+
+        /* Set ssthresh very high (following industry best practice).
+         * This keeps TCP in slow start mode until network conditions
+         * dictate otherwise, allowing exponential growth to discover
+         * the optimal sending rate.
+         */
+        pcb->ssthresh = 0x7FFFFFFF; /* 2GB - effectively unlimited */
+    } else {
+        /* Non-TSO: RFC 3390 compliant initial window
+         * IW = min(4*MSS, max(2*MSS, 4380 bytes))
+         */
+        if (pcb->mss * 4 <= 4380) {
+            pcb->cwnd = pcb->mss * 4;
+        } else {
+            pcb->cwnd = (pcb->mss * 2 > 4380) ? pcb->mss * 2 : 4380;
+        }
+
+        /* Set ssthresh higher than IW to allow slow start growth */
+        pcb->ssthresh = pcb->mss * 10;
+    }
+}
+
+/**
+ * Reset cwnd and ssthresh after a congestion event (RTO or fast retransmit).
+ *
+ * This is more conservative than initial window settings, as a congestion
+ * event indicates network issues.
+ *
+ * For TSO connections (TSO-optimized, deviates from RFC 5681):
+ * - Reset cwnd to 10% of TSO max (26KB) instead of 1 MSS
+ * - Set ssthresh to 25% of TSO max (64KB) to enable slow start recovery
+ * - Rationale: RFC 5681 (cwnd=1 MSS) is too conservative for modern TSO hardware
+ *   that sends 256KB super-packets. Even Linux CUBIC suffers from slow RTO
+ *   recovery with aggressive TSO. Our approach balances fast recovery with safety.
+ *
+ * For non-TSO connections:
+ * - Follow RFC 5681: cwnd = 1 MSS, ssthresh = max(FlightSize/2, 2*MSS)
+ *
+ * @param pcb the tcp_pcb experiencing congestion
+ * @param is_rto true if this is an RTO event, false for fast retransmit
+ */
+void tcp_reset_cwnd_on_congestion(struct tcp_pcb *pcb, bool is_rto)
+{
+    if (tcp_tso(pcb)) {
+        /* TSO-aware recovery (deviates from RFC 5681 and modern CUBIC):
+         *
+         * RFC 5681 & Modern CUBIC (Linux 2024): cwnd = 1 MSS (1460 bytes)
+         * Our TSO approach: cwnd = 26KB (10% of TSO max)
+         *
+         * Rationale:
+         * - RFC 5681 was written before aggressive TSO (256KB super-packets)
+         * - Linux CUBIC follows RFC but suffers slow RTO recovery with large TSO
+         * - 1460 bytes is artificially small when hardware sends 256KB packets
+         * - 26KB restart allows reasonable BDP while still being conservative
+         *
+         * This ensures cwnd < ssthresh after RTO, allowing exponential growth
+         * from 26KB → 64KB during recovery. The 64KB threshold is the same as
+         * our initial connection window, providing consistent behavior.
+         */
+        u32_t tso_recovery_cwnd = pcb->tso.max_payload_sz / 10; // 26KB
+        u32_t tso_recovery_ssthresh = pcb->tso.max_payload_sz / 4; // 64KB
+
+        /* For very large windows before congestion, respect TCP's halving rule */
+        u32_t eff_wnd = LWIP_MIN(pcb->cwnd, pcb->snd_wnd);
+        u32_t halved_wnd = eff_wnd >> 1;
+
+        /* Use the larger of: halved window or our TSO recovery threshold */
+        pcb->ssthresh = LWIP_MAX(halved_wnd, tso_recovery_ssthresh);
+
+        if (is_rto) {
+            /* RTO: Conservative restart */
+            pcb->cwnd = tso_recovery_cwnd;
+        } else {
+            /* Fast retransmit: Less conservative, add 3*MSS for quick recovery */
+            pcb->cwnd = pcb->ssthresh + 3 * pcb->mss;
+        }
+    } else {
+        /* Non-TSO: RFC 5681 standard behavior */
+        u32_t eff_wnd = LWIP_MIN(pcb->cwnd, pcb->snd_wnd);
+        pcb->ssthresh = eff_wnd >> 1;
+
+        if (pcb->ssthresh < (u32_t)(2 * pcb->mss)) {
+            pcb->ssthresh = 2 * pcb->mss;
+        }
+
+        if (is_rto) {
+            pcb->cwnd = pcb->mss;
+        } else {
+            pcb->cwnd = pcb->ssthresh + 3 * pcb->mss;
+        }
+    }
+}
+
+/**
  * Connects to another host. The function given as the "connected"
  * argument will be called when the connection has been established.
  *
@@ -559,8 +674,10 @@ err_t tcp_connect(struct tcp_pcb *pcb, const ip_addr_t *ipaddr, u16_t port, bool
 
     pcb->advtsd_mss = tcp_send_mss(pcb);
     pcb->mss = pcb->advtsd_mss;
-    pcb->cwnd = 1;
-    pcb->ssthresh = pcb->mss * 10;
+
+    /* Set initial congestion window and slow start threshold */
+    tcp_set_initial_cwnd_ssthresh(pcb);
+
     pcb->connected = connected;
 
     /* Send a SYN together with the MSS option. */
@@ -952,7 +1069,10 @@ void tcp_pcb_init(struct tcp_pcb *pcb, u8_t prio, void *container)
     }
     cc_init(pcb);
 #endif
-    pcb->cwnd = 1;
+
+    /* Set initial congestion window and slow start threshold */
+    tcp_set_initial_cwnd_ssthresh(pcb);
+
     iss = tcp_next_iss();
     pcb->snd_wl2 = iss;
     pcb->snd_nxt = iss;
@@ -1000,7 +1120,10 @@ void tcp_pcb_recycle(struct tcp_pcb *pcb)
 #if TCP_CC_ALGO_MOD
     cc_init(pcb);
 #endif
-    pcb->cwnd = 1;
+
+    /* Set initial congestion window and slow start threshold */
+    tcp_set_initial_cwnd_ssthresh(pcb);
+
     iss = tcp_next_iss();
     pcb->acked = 0;
     pcb->snd_wl2 = iss;

--- a/src/core/lwip/tcp.h
+++ b/src/core/lwip/tcp.h
@@ -405,6 +405,8 @@ void register_ip_route_mtu(ip_route_mtu_fn fn);
 /*Initialization of tcp_pcb structure*/
 void tcp_pcb_init(struct tcp_pcb *pcb, u8_t prio, void *container);
 void tcp_pcb_recycle(struct tcp_pcb *pcb);
+void tcp_set_initial_cwnd_ssthresh(struct tcp_pcb *pcb);
+void tcp_reset_cwnd_on_congestion(struct tcp_pcb *pcb, bool is_rto);
 
 void tcp_arg(struct tcp_pcb *pcb, void *arg);
 void tcp_ip_output(struct tcp_pcb *pcb, ip_output_fn ip_output);

--- a/src/core/lwip/tcp.h
+++ b/src/core/lwip/tcp.h
@@ -423,6 +423,10 @@ void tcp_err(struct tcp_pcb *pcb, tcp_err_fn err);
 #define tcp_nagle_enable(pcb)   ((pcb)->flags &= ~TF_NODELAY)
 #define tcp_nagle_disabled(pcb) (((pcb)->flags & TF_NODELAY) != 0)
 
+/* Returns pcb->tso.max_payload_sz. Acts as both:
+ * - Boolean check: 0 (false) when TSO not configured
+ * - Value provider: max payload size when TSO configured
+ * Safe to use in conditionals followed by division. */
 #define tcp_tso(pcb) ((pcb)->tso.max_payload_sz)
 
 bool tcp_recved(struct tcp_pcb *pcb, u32_t len, bool do_output);

--- a/src/core/lwip/tcp_impl.h
+++ b/src/core/lwip/tcp_impl.h
@@ -319,6 +319,7 @@ extern int32_t enable_wnd_scale;
 extern u32_t rcv_wnd_scale;
 extern u8_t enable_push_flag;
 extern u8_t enable_ts_option;
+extern u8_t tcp_cc_tso_aware;
 extern u32_t tcp_ticks;
 extern ip_route_mtu_fn external_ip_route_mtu;
 

--- a/src/core/lwip/tcp_in.c
+++ b/src/core/lwip/tcp_in.c
@@ -579,14 +579,12 @@ static err_t tcp_process(struct tcp_pcb *pcb, tcp_in_data *in_data)
             pcb->mss = LWIP_MIN(pcb->mss, tcp_send_mss(pcb));
 #endif /* TCP_CALCULATE_EFF_SEND_MSS */
 
-            /* Set ssthresh again after changing pcb->mss (already set in tcp_connect
-             * but for the default value of pcb->mss) */
-            pcb->ssthresh = pcb->mss * 10;
-#if TCP_CC_ALGO_MOD
+            /* Re-initialize cwnd/ssthresh after MSS negotiation.
+             * For TSO: maintain aggressive values independent of negotiated MSS.
+             * For non-TSO: scale with negotiated MSS per RFC 3390.
+             */
+            tcp_set_initial_cwnd_ssthresh(pcb);
             cc_conn_init(pcb);
-#else
-            pcb->cwnd = ((pcb->cwnd == 1) ? (pcb->mss * 2) : pcb->mss);
-#endif
             rseg = pcb->unacked;
             pcb->unacked = rseg->next;
 

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -824,6 +824,9 @@ void print_env_vars_xlio_global_settings()
     VLOG_PARAM_NUMSTR("TCP CC Algorithm", safe_mce_sys().lwip_cc_algo_mod,
                       MCE_DEFAULT_LWIP_CC_ALGO_MOD, SYS_VAR_TCP_CC_ALGO,
                       lwip_cc_algo_str(safe_mce_sys().lwip_cc_algo_mod));
+    VLOG_PARAM_STRING("TCP CC TSO aware", safe_mce_sys().tcp_cc_tso_aware,
+                      MCE_DEFAULT_TCP_CC_TSO_AWARE, SYS_VAR_TCP_CC_TSO_AWARE,
+                      safe_mce_sys().tcp_cc_tso_aware ? "true" : "false");
     VLOG_PARAM_STRING("Deferred close", safe_mce_sys().deferred_close, MCE_DEFAULT_DEFERRED_CLOSE,
                       SYS_VAR_DEFERRED_CLOSE,
                       safe_mce_sys().deferred_close ? "Enabled " : "Disabled");

--- a/src/core/proto/xlio_lwip.cpp
+++ b/src/core/proto/xlio_lwip.cpp
@@ -78,6 +78,7 @@ xlio_lwip::xlio_lwip()
 
     enable_push_flag = !!safe_mce_sys().tcp_push_flag;
     enable_ts_option = read_tcp_timestamp_option();
+    tcp_cc_tso_aware = safe_mce_sys().tcp_cc_tso_aware ? 1 : 0;
     int is_window_scaling_enabled = safe_mce_sys().sysctl_reader.get_tcp_window_scaling();
     if (is_window_scaling_enabled) {
         int rmem_max_value = safe_mce_sys().sysctl_reader.get_tcp_rmem()->max_value;

--- a/src/core/util/sys_vars.cpp
+++ b/src/core/util/sys_vars.cpp
@@ -888,6 +888,7 @@ void mce_sys_var::get_env_params()
 #endif
     lwip_mss = MCE_DEFAULT_MSS;
     lwip_cc_algo_mod = MCE_DEFAULT_LWIP_CC_ALGO_MOD;
+    tcp_cc_tso_aware = MCE_DEFAULT_TCP_CC_TSO_AWARE;
     mce_spec = MCE_SPEC_NONE;
 
     neigh_num_err_retries = MCE_DEFAULT_NEIGH_NUM_ERR_RETRIES;
@@ -1766,6 +1767,10 @@ void mce_sys_var::get_env_params()
 
     if ((env_ptr = getenv(SYS_VAR_TCP_CC_ALGO))) {
         lwip_cc_algo_mod = (uint32_t)atoi(env_ptr);
+    }
+
+    if ((env_ptr = getenv(SYS_VAR_TCP_CC_TSO_AWARE))) {
+        tcp_cc_tso_aware = atoi(env_ptr) ? true : false;
     }
 
     if ((env_ptr = getenv(SYS_VAR_DEFERRED_CLOSE))) {

--- a/src/core/util/sys_vars.h
+++ b/src/core/util/sys_vars.h
@@ -271,6 +271,7 @@ public:
     bool close_on_dup2;
     uint32_t mtu; /* effective MTU. If mtu==0 then auto calculate the MTU */
     uint32_t lwip_cc_algo_mod;
+    bool tcp_cc_tso_aware;
     uint32_t lwip_mss;
     char internal_thread_cpuset[FILENAME_MAX];
     char internal_thread_affinity_str[FILENAME_MAX];
@@ -506,10 +507,11 @@ extern const mce_sys_var &safe_mce_sys();
 #define SYS_VAR_SRC_PORT_STRIDE "XLIO_SRC_PORT_STRIDE"
 #define SYS_VAR_DISTRIBUTE_CQ   "XLIO_DISTRIBUTE_CQ"
 #endif
-#define SYS_VAR_MSS         "XLIO_MSS"
-#define SYS_VAR_TCP_CC_ALGO "XLIO_TCP_CC_ALGO"
-#define SYS_VAR_SPEC        "XLIO_SPEC"
-#define SYS_VAR_TSO         "XLIO_TSO"
+#define SYS_VAR_MSS              "XLIO_MSS"
+#define SYS_VAR_TCP_CC_ALGO      "XLIO_TCP_CC_ALGO"
+#define SYS_VAR_TCP_CC_TSO_AWARE "XLIO_TCP_CC_TSO_AWARE"
+#define SYS_VAR_SPEC             "XLIO_SPEC"
+#define SYS_VAR_TSO              "XLIO_TSO"
 #ifdef DEFINED_UTLS
 #define SYS_VAR_UTLS_RX                        "XLIO_UTLS_RX"
 #define SYS_VAR_UTLS_TX                        "XLIO_UTLS_TX"
@@ -657,6 +659,7 @@ extern const mce_sys_var &safe_mce_sys();
 #define MCE_DEFAULT_SRC_PORT_STRIDE              (2)
 #define MCE_DEFAULT_MSS                          (0)
 #define MCE_DEFAULT_LWIP_CC_ALGO_MOD             (0)
+#define MCE_DEFAULT_TCP_CC_TSO_AWARE             (true)
 #define MCE_DEFAULT_INTERNAL_THREAD_AFFINITY     (-1)
 #define MCE_DEFAULT_INTERNAL_THREAD_AFFINITY_STR ("-1")
 #define MCE_DEFAULT_INTERNAL_THREAD_CPUSET       ("")

--- a/src/core/util/sys_vars_configurator.cpp
+++ b/src/core/util/sys_vars_configurator.cpp
@@ -208,6 +208,8 @@ const config_var_info_t<bool> CONFIG_VAR_DISTRIBUTE_CQ {"applications.nginx.dist
 const config_var_info_t<uint32_t, int64_t> CONFIG_VAR_MSS {"network.protocols.tcp.mss"};
 const config_var_info_t<uint32_t, int64_t> CONFIG_VAR_TCP_CC_ALGO {
     "network.protocols.tcp.congestion_control"};
+const config_var_info_t<bool> CONFIG_VAR_TCP_CC_TSO_AWARE {
+    "network.protocols.tcp.congestion_control_tso_aware"};
 const config_var_info_t<uint32_t, int64_t> CONFIG_VAR_SPEC {"profiles.spec"};
 
 const config_var_info_t<option_3::mode_t, int64_t> CONFIG_VAR_TSO {
@@ -645,6 +647,8 @@ void sys_var_configurator::initialize_base_variables()
     m_runtime_registry.register_and_set_default_value(&m_sys_vars.lwip_mss, CONFIG_VAR_MSS);
     m_runtime_registry.register_and_set_default_value(&m_sys_vars.lwip_cc_algo_mod,
                                                       CONFIG_VAR_TCP_CC_ALGO);
+    m_runtime_registry.register_and_set_default_value(&m_sys_vars.tcp_cc_tso_aware,
+                                                      CONFIG_VAR_TCP_CC_TSO_AWARE);
     m_runtime_registry.register_and_set_default_value(&m_sys_vars.mce_spec, CONFIG_VAR_SPEC);
 
     m_runtime_registry.register_and_set_default_value(&m_sys_vars.neigh_num_err_retries,


### PR DESCRIPTION
## Description
Resolve 30-second throughput ramp-up issue for TSO-enabled TCP connections by implementing proper initial congestion window (cwnd) and slow start threshold (ssthresh) values.

Problem:
Applications using TSO experienced ~30 seconds of near-zero throughput before achieving line-rate. Debug analysis revealed that ssthresh was being unconditionally reset to 10*MSS (14,600 bytes) during SYN-ACK processing in tcp_in.c line 582, forcing TCP into congestion avoidance mode immediately. This caused linear cwnd growth instead of exponential slow start, resulting in extremely slow ramp-up.

Solution:
Created centralized helper function tcp_set_initial_cwnd_ssthresh() that sets TSO-aware parameters:

For TSO-enabled connections:
  - cwnd = TSO_max_payload / 4 (64KB with default 256KB TSO)
  - ssthresh = 0x7FFFFFFF (2GB - effectively unlimited)

For non-TSO connections:
  - cwnd = RFC 3390 compliant: min(4*MSS, max(2*MSS, 4380 bytes))
  - ssthresh = 10 * MSS

Technical Rationale:
1. Very high ssthresh (2GB) follows industry best practices, allowing slow start to run until network conditions dictate otherwise rather than artificially limiting growth (Excentis research on optimizing TCP for gigabit networks).

2. TSO max payload is independent of negotiated MSS (determined by hardware capabilities), so initial window should also be independent of MSS for TSO connections.

3. Initial cwnd of 64KB (TSO_max/4) balances aggressive throughput with conservative buffer management. This exceeds RFC 6928's recommendation of 10 segments (~15KB) but is appropriate for XLIO's controlled environment where TSO hardware handles segmentation and applications target high-throughput scenarios. Empirically verified to achieve 200 Gbps in <1 second.

Implementation Details:
- Replaced duplicate TSO initialization logic in 6 locations:
  * tcp_pcb_init() - initial PCB setup
  * tcp_pcb_recycle() - PCB reuse after TIME_WAIT
  * tcp_connect() - client-side connection initiation
  * tcp_in.c SYN-ACK handler - CRITICAL FIX (line 584)
  * lwip_conn_init() - LWIP CC module initialization
  * cubic_conn_init() - Cubic CC module initialization

Performance Impact:
Before: 20+ seconds to reach line-rate (200 Gbps)
After: Line-rate achieved in <1 second

Verification: GDB debugging confirmed ssthresh was being overwritten during SYN-ACK processing. After fix, cwnd=64KB and ssthresh=2GB are maintained throughout connection establishment, enabling exponential growth as designed.

References:
- RFC 3390: Increasing TCP's Initial Window
- RFC 5681: TCP Congestion Control
- RFC 6928: Increasing TCP's Initial Window (10 segments standard)
- Excentis: "Optimizing TCP Congestion Avoidance Parameters for Gigabit Networks" - recommends very high ssthresh (approaching 2^31) for fast networks
- NASA: "Performance Analysis of TCP with Large Segmentation Offload"
  - analysis of TSO impact on congestion control

##### What
Fix TSO slow start with aggressive cwnd/ssthresh

##### Why ?
xlio_benchmark to alpha.

##### How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc._

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

