### PR TITLE
issue: 4808527 Replace malloc() with mmap() in xlio_allocator

### DIFF
--- a/src/core/dev/allocator.h
+++ b/src/core/dev/allocator.h
@@ -30,8 +30,8 @@ public:
     void *alloc_aligned(size_t size, size_t align);
 
     void *alloc_huge(size_t size);
+    void *alloc_mmap(size_t size);
     void *alloc_posix_memalign(size_t size, size_t align);
-    void *alloc_malloc(size_t size);
 
     void dealloc();
 

--- a/src/core/util/sys_vars_types.h
+++ b/src/core/util/sys_vars_types.h
@@ -88,6 +88,8 @@ typedef enum {
     ALLOC_TYPE_HUGEPAGES = option_alloc_type::HUGE,
     ALLOC_TYPE_LAST_ALLOWED_TO_USE,
 
+    // Regular pages allocated using mmap, user requests it with ALLOC_TYPE_ANON
+    ALLOC_TYPE_MMAP,
     // Same as ALLOC_TYPE_HUGE, but doesn't print a warning on the fallback
     ALLOC_TYPE_PREFER_HUGE,
     // External type cannot be configured with XLIO_MEM_ALLOC_TYPE

--- a/src/core/xlio_types.h
+++ b/src/core/xlio_types.h
@@ -284,6 +284,8 @@ typedef void (*xlio_socket_accept_cb_t)(xlio_socket_t sock, xlio_socket_t parent
  *
  * @par External Allocator Notes:
  * - When external allocator is provided, XLIO uses it instead of internal allocation
+ * - External allocator should provide page-aligned memory allocation, because
+ *   madvise(MADV_DONTFORK) may be called for the memory block
  * - Current implementation allocates a single memory block during xlio_init_ex()
  * - For external allocators, hugepage_size in memory_cb is always reported as zero
  *


### PR DESCRIPTION
## Description
malloc() doesn't guarantee alignment. Although it uses mmap() internally for
big allocations, the heap allocator can be replaced.

madvise(MADV_DONTFORK) fails if the pointer is not aligned to the page size.
Unaligned pointer can also fail ibv_regmr() if it calls madvise() internally.

To eliminate possibility of the above problem, avoid using malloc() for the
registered memory and use either mmap() or posix_memalign().

Additionally, in the posix_memalign() method, align the allocation size to
the alignment value to prepare for possible future aligned_alloc()
integration.

##### What

- Replace malloc() with mmap() in xlio_allocator.
- Document page-alignment requirement for the external allocator in Ultra API.

##### Why ?
Avoid (unlikely) unaligned memory for XLIO buffers. Otherwise, madvise() fails.

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

