### PR TITLE
issue: 4550926 Warning for ring_elements_count adjustment

### DIFF
--- a/src/core/util/sys_vars.cpp
+++ b/src/core/util/sys_vars.cpp
@@ -1172,7 +1172,11 @@ void mce_sys_var::get_env_params()
         tx_num_wr_to_signal =
             std::min<uint32_t>(NUM_TX_WRE_TO_SIGNAL_MAX, std::max(1, atoi(env_ptr)));
     }
-    if (tx_num_wr <= (tx_num_wr_to_signal * 2)) {
+    if (tx_num_wr < (tx_num_wr_to_signal * 2)) {
+        vlog_printf(VLOG_WARNING,
+                    SYS_VAR_TX_NUM_WRE "=%d must be at least " SYS_VAR_TX_NUM_WRE_TO_SIGNAL
+                                       " * 2 (%d). Increasing to %d\n",
+                    tx_num_wr, tx_num_wr_to_signal * 2, tx_num_wr_to_signal * 2);
         tx_num_wr = tx_num_wr_to_signal * 2;
     }
 
@@ -1272,7 +1276,11 @@ void mce_sys_var::get_env_params()
                     MAX_MLX5_CQ_SIZE_ITEMS, rx_num_wr);
     }
 
-    if (rx_num_wr <= (rx_num_wr_to_post_recv * 2)) {
+    if (rx_num_wr < (rx_num_wr_to_post_recv * 2)) {
+        vlog_printf(VLOG_WARNING,
+                    SYS_VAR_RX_NUM_WRE "=%d must be at least " SYS_VAR_RX_NUM_WRE_TO_POST_RECV
+                                       " * 2 (%d). Increasing to %d\n",
+                    rx_num_wr, rx_num_wr_to_post_recv * 2, rx_num_wr_to_post_recv * 2);
         rx_num_wr = rx_num_wr_to_post_recv * 2;
     }
 

--- a/src/core/util/sys_vars_configurator.cpp
+++ b/src/core/util/sys_vars_configurator.cpp
@@ -977,12 +977,12 @@ void sys_var_configurator::configure_after_user_settings()
                     MAX_STATS_FD_NUM);
     }
 
-    if (m_sys_vars.tx_num_wr <= (m_sys_vars.tx_num_wr_to_signal * 2)) {
-        m_runtime_registry.set_value(CONFIG_VAR_TX_NUM_WRE,
-                                     static_cast<int64_t>(m_sys_vars.tx_num_wr_to_signal * 2),
-                                     change_reason::AutoCorrected,
-                                     std::string(CONFIG_VAR_TX_NUM_WRE.name) + " must be > 2 * " +
-                                         CONFIG_VAR_TX_NUM_WRE_TO_SIGNAL.name);
+    if (m_sys_vars.tx_num_wr < (m_sys_vars.tx_num_wr_to_signal * 2)) {
+        m_runtime_registry.set_value(
+            CONFIG_VAR_TX_NUM_WRE, static_cast<int64_t>(m_sys_vars.tx_num_wr_to_signal * 2),
+            change_reason::AutoCorrected,
+            std::string(CONFIG_VAR_TX_NUM_WRE.name) + " must be at least " +
+                CONFIG_VAR_TX_NUM_WRE_TO_SIGNAL.name + " * 2");
     }
 
     if (m_sys_vars.enable_striding_rq &&
@@ -998,12 +998,12 @@ void sys_var_configurator::configure_after_user_settings()
                     CONFIG_VAR_STRQ_NUM_STRIDES.name, CONFIG_VAR_RX_NUM_WRE.name,
                     MAX_MLX5_CQ_SIZE_ITEMS, CONFIG_VAR_RX_NUM_WRE.name, m_sys_vars.rx_num_wr);
     }
-    if (m_sys_vars.rx_num_wr <= (m_sys_vars.rx_num_wr_to_post_recv * 2)) {
-        m_runtime_registry.set_value(CONFIG_VAR_RX_NUM_WRE,
-                                     static_cast<int64_t>(m_sys_vars.rx_num_wr_to_post_recv * 2),
-                                     change_reason::AutoCorrected,
-                                     std::string(CONFIG_VAR_RX_NUM_WRE.name) + " must be > 2 * " +
-                                         CONFIG_VAR_RX_NUM_WRE_TO_POST_RECV.name);
+    if (m_sys_vars.rx_num_wr < (m_sys_vars.rx_num_wr_to_post_recv * 2)) {
+        m_runtime_registry.set_value(
+            CONFIG_VAR_RX_NUM_WRE, static_cast<int64_t>(m_sys_vars.rx_num_wr_to_post_recv * 2),
+            change_reason::AutoCorrected,
+            std::string(CONFIG_VAR_RX_NUM_WRE.name) + " must be at least " +
+                CONFIG_VAR_RX_NUM_WRE_TO_POST_RECV.name + " * 2");
     }
 
     if (m_sys_vars.rx_poll_num == 0) {

--- a/tests/gtest/output/config-ring-elements-warning.json
+++ b/tests/gtest/output/config-ring-elements-warning.json
@@ -1,0 +1,19 @@
+{
+  "monitor": {
+    "log": {
+      "level": 3
+    }
+  },
+  "performance": {
+    "rings": {
+      "tx": {
+        "ring_elements_count": 0,
+        "completion_batch_size": 64
+      },
+      "rx": {
+        "ring_elements_count": 0,
+        "post_batch_size": 1
+      }
+    }
+  }
+}

--- a/tests/gtest/output/config.cc
+++ b/tests/gtest/output/config.cc
@@ -516,3 +516,30 @@ TEST_F(output, config_periodic_drain_max_cqes_zero)
                {// Should NOT show the old combined "CQ Drain Thread" message
                 "CQ Drain Thread"});
 }
+
+/**
+ * @test output.config_ring_elements_count_warning
+ * @brief
+ *    Tests that a warning is shown when ring_elements_count is set too low
+ *
+ * @details
+ *    When ring_elements_count is set to a value < batch_size * 2, it must be
+ *    increased. This test verifies that a warning is logged when this happens.
+ */
+TEST_F(output, config_ring_elements_count_warning)
+{
+    check_file(
+        "config-ring-elements-warning.json",
+        {
+            // clang-format off
+            // TX: ring_elements_count=0 auto-corrected to completion_batch_size * 2 (128)
+            "Config key performance.rings.tx.ring_elements_count changed from 0 to 128: "
+            "reason=Auto-corrected; performance.rings.tx.ring_elements_count must be at least "
+            "performance.rings.tx.completion_batch_size * 2",
+            // RX: ring_elements_count=0 auto-corrected to post_batch_size * 2 (2)
+            "Config key performance.rings.rx.ring_elements_count changed from 0 to 2: "
+            "reason=Auto-corrected; performance.rings.rx.ring_elements_count must be at least "
+            "performance.rings.rx.post_batch_size * 2"
+            // clang-format on
+        });
+}


### PR DESCRIPTION
## Description
When ring_elements_count is set below the required minimum (batch_size * 2), the value is silently increased. This confused users who set 0 but saw 128 (TX) or 2 (RX) in logs.

Add warning logs for both TX and RX paths (env and JSON config).

##### What
Warn when ring_elements_count is auto-adjusted

##### Why ?
UX.

##### How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc._

## Change type
What kind of change does this PR introduce?
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined validation boundaries for ring element sizing configuration, improving auto-correction behavior for queue work request parameters.
  * Updated auto-correction warning messages for more accurate feedback during configuration validation.

* **Tests**
  * Added test case for ring element count auto-correction scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mellanox/libxlio/pull/532)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->