### PR TITLE
issue: 4548076 Fix periodic_drain_max_cqes=0

### DIFF
--- a/src/core/config_printer.cpp
+++ b/src/core/config_printer.cpp
@@ -170,19 +170,24 @@ void config_printer::print_rx_num_wre_to_post_recv(const std::string &key, const
 void config_printer::print_progress_engine_interval(const std::string &key,
                                                     const std::string &title)
 {
-    const std::string key_display = key_with_reason(key);
-    if (m_mce_sys_var.progress_engine_interval_msec == MCE_CQ_DRAIN_INTERVAL_DISABLED ||
-        m_mce_sys_var.progress_engine_wce_max == 0) {
+    const std::string interval_key = key_with_reason(key);
+    const std::string max_cqes_key = key_with_reason(CONFIG_VAR_PROGRESS_ENGINE_WCE_MAX.name);
+
+    if (m_mce_sys_var.progress_engine_interval_msec == MCE_CQ_DRAIN_INTERVAL_DISABLED) {
         LOG_NUM_PARAM_AS_NUMSTR(title.c_str(), m_mce_sys_var.progress_engine_interval_msec,
-                                INT_MAX, // Ensure it is always shown - we want the user to
-                                         // know it is disabled
-                                key_display.c_str(), "(Disabled)");
+                                INT_MAX, interval_key.c_str(), "(Disabled)");
     } else {
         LOG_NUM_PARAM(title.c_str(), m_mce_sys_var.progress_engine_interval_msec,
-                      MCE_DEFAULT_PROGRESS_ENGINE_INTERVAL_MSEC, key_display.c_str());
+                      MCE_DEFAULT_PROGRESS_ENGINE_INTERVAL_MSEC, interval_key.c_str());
+    }
+
+    if (m_mce_sys_var.progress_engine_wce_max == 0) {
+        LOG_NUM_PARAM_AS_NUMSTR("Max CQEs per periodic drain",
+                                m_mce_sys_var.progress_engine_wce_max, INT_MAX,
+                                max_cqes_key.c_str(), "(Disabled)");
+    } else {
         LOG_NUM_PARAM("Max CQEs per periodic drain", m_mce_sys_var.progress_engine_wce_max,
-                      MCE_DEFAULT_PROGRESS_ENGINE_WCE_MAX,
-                      key_with_reason(CONFIG_VAR_PROGRESS_ENGINE_WCE_MAX.name).c_str());
+                      MCE_DEFAULT_PROGRESS_ENGINE_WCE_MAX, max_cqes_key.c_str());
     }
 }
 

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -643,15 +643,24 @@ void print_env_vars_xlio_global_settings()
                           MCE_DEFAULT_SELECT_SKIP_OS, SYS_VAR_SELECT_SKIP_OS, "Disabled");
     }
 
-    if (safe_mce_sys().progress_engine_interval_msec == MCE_CQ_DRAIN_INTERVAL_DISABLED ||
-        safe_mce_sys().progress_engine_wce_max == 0) {
-        vlog_printf(VLOG_INFO, FORMAT_STRING, "CQ Drain Thread", "Disabled",
-                    SYS_VAR_PROGRESS_ENGINE_INTERVAL);
-    } else {
-        VLOG_PARAM_NUMBER("CQ Drain Interval (msec)", safe_mce_sys().progress_engine_interval_msec,
+    // Always show both parameters individually
+    if (safe_mce_sys().progress_engine_interval_msec == MCE_CQ_DRAIN_INTERVAL_DISABLED) {
+        VLOG_PARAM_STRING("Periodic drain interval (msec)",
+                          safe_mce_sys().progress_engine_interval_msec,
                           MCE_DEFAULT_PROGRESS_ENGINE_INTERVAL_MSEC,
-                          SYS_VAR_PROGRESS_ENGINE_INTERVAL);
-        VLOG_PARAM_NUMBER("CQ Drain WCE (max)", safe_mce_sys().progress_engine_wce_max,
+                          SYS_VAR_PROGRESS_ENGINE_INTERVAL, "0 (Disabled)");
+    } else {
+        VLOG_PARAM_NUMBER(
+            "Periodic drain interval (msec)", safe_mce_sys().progress_engine_interval_msec,
+            MCE_DEFAULT_PROGRESS_ENGINE_INTERVAL_MSEC, SYS_VAR_PROGRESS_ENGINE_INTERVAL);
+    }
+
+    if (safe_mce_sys().progress_engine_wce_max == 0) {
+        VLOG_PARAM_STRING("Periodic drain max CQEs", safe_mce_sys().progress_engine_wce_max,
+                          MCE_DEFAULT_PROGRESS_ENGINE_WCE_MAX, SYS_VAR_PROGRESS_ENGINE_WCE_MAX,
+                          "0 (Disabled)");
+    } else {
+        VLOG_PARAM_NUMBER("Periodic drain max CQEs", safe_mce_sys().progress_engine_wce_max,
                           MCE_DEFAULT_PROGRESS_ENGINE_WCE_MAX, SYS_VAR_PROGRESS_ENGINE_WCE_MAX);
     }
 

--- a/tests/gtest/output/config-periodic-drain-max-cqes-zero.json
+++ b/tests/gtest/output/config-periodic-drain-max-cqes-zero.json
@@ -1,0 +1,12 @@
+{
+  "monitor": {
+    "log": {
+      "level": 3
+    }
+  },
+  "performance": {
+    "completion_queue": {
+      "periodic_drain_max_cqes": 0
+    }
+  }
+}

--- a/tests/gtest/output/config.cc
+++ b/tests/gtest/output/config.cc
@@ -492,3 +492,27 @@ TEST_F(output, config_stats_file_pid_substitution_after_fork_new_config)
     unlink(config_file.c_str());
     ASSERT_EQ(0, rmdir(stats_dir.c_str())) << "Failed to remove stats directory: " << stats_dir;
 }
+
+/**
+ * @test misc.config_periodic_drain_max_cqes_zero
+ * @brief
+ *    Tests that periodic_drain_max_cqes=0 shows the correct parameter in output
+ *
+ * @details
+ *    When user sets periodic_drain_max_cqes to 0, the log should show that specific
+ *    parameter with value 0 and the correct config key, not a different parameter name.
+ */
+TEST_F(output, config_periodic_drain_max_cqes_zero)
+{
+    check_file("config-periodic-drain-max-cqes-zero.json",
+               {
+                   // clang-format off
+            // Should show the parameter that was explicitly set to 0 with correct key
+            "Max CQEs per periodic drain",
+            "0 (Disabled)",
+            "[performance.completion_queue.periodic_drain_max_cqes, Reason: User-configured]"
+                   // clang-format on
+               },
+               {// Should NOT show the old combined "CQ Drain Thread" message
+                "CQ Drain Thread"});
+}


### PR DESCRIPTION
## Description
When periodic_drain_max_cqes was set to 0, the log incorrectly showed periodic_drain_msec with "Disabled" instead of showing the actual parameter that was set.

Fix by always showing both periodic drain parameters individually:
- periodic_drain_msec (interval)
- periodic_drain_max_cqes (max CQEs)

Each shows "0 (Disabled)" when set to 0, with the correct config key.

Add gtest to verify the correct parameter is displayed.

##### What
Show correct param when periodic_drain_max_cqes=0

##### Why ?
UX.

##### How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc._

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

