### PR TITLE
issue: 4551265 Fix config values display

### DIFF
--- a/src/core/config_printer.cpp
+++ b/src/core/config_printer.cpp
@@ -153,18 +153,20 @@ void config_printer::print_log_level(const std::string &key, const std::string &
 
 void config_printer::print_rx_num_wre(const std::string &key, const std::string &title)
 {
-    LOG_NUM_PARAM(
-        title.c_str(), m_mce_sys_var.rx_num_wr,
-        (m_mce_sys_var.enable_striding_rq ? MCE_DEFAULT_STRQ_NUM_WRE : MCE_DEFAULT_RX_NUM_WRE),
-        key_with_reason(key).c_str());
+    const config_registry &registry =
+        m_mce_sys_var.get_runtime_registry().value().get_config_registry();
+    LOG_NUM_PARAM_AS(title.c_str(), m_mce_sys_var.rx_num_wr,
+                     registry.get_default_value<int64_t>(key), key_with_reason(key).c_str(),
+                     to_str_accurate(m_mce_sys_var.rx_num_wr).c_str());
 }
 
 void config_printer::print_rx_num_wre_to_post_recv(const std::string &key, const std::string &title)
 {
-    LOG_NUM_PARAM(title.c_str(), m_mce_sys_var.rx_num_wr_to_post_recv,
-                  (m_mce_sys_var.enable_striding_rq ? MCE_DEFAULT_STRQ_NUM_WRE_TO_POST_RECV
-                                                    : MCE_DEFAULT_RX_NUM_WRE_TO_POST_RECV),
-                  key_with_reason(key).c_str());
+    const config_registry &registry =
+        m_mce_sys_var.get_runtime_registry().value().get_config_registry();
+    LOG_NUM_PARAM_AS(title.c_str(), m_mce_sys_var.rx_num_wr_to_post_recv,
+                     registry.get_default_value<int64_t>(key), key_with_reason(key).c_str(),
+                     to_str_accurate(m_mce_sys_var.rx_num_wr_to_post_recv).c_str());
 }
 
 void config_printer::print_progress_engine_interval(const std::string &key,
@@ -192,8 +194,11 @@ void config_printer::print_nothing(const std::string & /*key*/, const std::strin
 
 void config_printer::print_qp_compensation_level(const std::string &key, const std::string &title)
 {
-    LOG_NUM_PARAM(title.c_str(), m_mce_sys_var.qp_compensation_level, m_mce_sys_var.rx_num_wr / 2U,
-                  key_with_reason(key).c_str());
+    const config_registry &registry =
+        m_mce_sys_var.get_runtime_registry().value().get_config_registry();
+    LOG_NUM_PARAM_AS(title.c_str(), m_mce_sys_var.qp_compensation_level,
+                     registry.get_default_value<int64_t>(key), key_with_reason(key).c_str(),
+                     to_str_accurate(m_mce_sys_var.qp_compensation_level).c_str());
 }
 
 #if defined(DEFINED_NGINX)

--- a/tests/gtest/output/config-default-rx-values.json
+++ b/tests/gtest/output/config-default-rx-values.json
@@ -1,0 +1,15 @@
+{
+  "monitor": {
+    "log": {
+      "level": 3
+    }
+  },
+  "performance": {
+    "rings": {
+      "rx": {
+        "post_batch_size": 1024,
+        "spare_buffers": 32768
+      }
+    }
+  }
+}

--- a/tests/gtest/output/config-nondefault-rx-values.json
+++ b/tests/gtest/output/config-nondefault-rx-values.json
@@ -1,0 +1,15 @@
+{
+  "monitor": {
+    "log": {
+      "level": 3
+    }
+  },
+  "performance": {
+    "rings": {
+      "rx": {
+        "post_batch_size": 512,
+        "spare_buffers": 16384
+      }
+    }
+  }
+}

--- a/tests/gtest/output/config.cc
+++ b/tests/gtest/output/config.cc
@@ -441,3 +441,62 @@ TEST_F(output, config_pid_substitution_new_config)
     unlink(config_file.c_str());
     int unused __attribute__((unused)) = system(("rm -rf " + report_dir).c_str());
 }
+
+/**
+ * @test misc.config_values_at_schema_default_not_shown
+ * @brief
+ *    When setting config values to their schema defaults, they should NOT be shown at INFO level
+ *
+ * @details
+ *    This test verifies the fix for the bug where setting:
+ *    - performance.rings.rx.post_batch_size=1024 (schema default)
+ *    - performance.rings.rx.spare_buffers=32768 (schema default)
+ *    was incorrectly displaying these values at INFO level.
+ *    The expected behavior is that default values are not displayed.
+ */
+TEST_F(output, config_values_at_schema_default_not_shown)
+{
+    check_file("config-default-rx-values.json",
+               {
+                   // clang-format off
+            // The config sources are shown
+            "output/config-default-rx-values.json",
+            // Log level is always shown
+            "XLIO INFO   : Log level                      INFO                       [monitor.log.level]"
+                   // clang-format on
+               },
+               {
+                   // These should NOT be shown because they are set to schema defaults
+                   // clang-format off
+            "[performance.rings.rx.post_batch_size",
+            "[performance.rings.rx.spare_buffers"
+                   // clang-format on
+               });
+}
+
+/**
+ * @test misc.config_values_not_at_schema_default_shown
+ * @brief
+ *    When setting config values to non-default values, they SHOULD be shown at INFO level
+ *
+ * @details
+ *    This test verifies that non-default values for:
+ *    - performance.rings.rx.post_batch_size
+ *    - performance.rings.rx.spare_buffers
+ *    are correctly displayed at INFO level.
+ */
+TEST_F(output, config_values_not_at_schema_default_shown)
+{
+    check_file("config-nondefault-rx-values.json",
+               {
+                   // clang-format off
+            // The config sources are shown
+            "output/config-nondefault-rx-values.json",
+            // Log level is always shown
+            "XLIO INFO   : Log level                      INFO                       [monitor.log.level]",
+            // Non-default RX values should be shown
+            "XLIO INFO   : RX WRE batch size              512                        [performance.rings.rx.post_batch_size, Reason: User-configured",
+            "XLIO INFO   : Spare RX buffers               16K                        [performance.rings.rx.spare_buffers, Reason: User-configured"
+                   // clang-format on
+               });
+}


### PR DESCRIPTION
## Description
When using the new JSON config system, setting parameters to their schema default values was incorrectly displaying them at XLIO Header.

The root cause was that config_printer.cpp special treatment functions were comparing against runtime-adjusted defaults (e.g., based on enable_striding_rq) instead of the static schema defaults.

Fix by using registry.get_default_value() to retrieve the schema default for comparison. Also update these functions to use to_str_accurate() for consistent K/M/G suffix formatting.

Affected parameters:
- performance.rings.rx.post_batch_size
- performance.rings.rx.spare_buffers
- performance.rings.rx.ring_elements_count

##### What
_Subject: what this PR is doing in one line._ 

##### Why ?
UX

##### How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc._

## Change type
What kind of change does this PR introduce?
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

