### PR TITLE
issue: 4830545 Link with libdpcp statically

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "submodules/libdpcp"]
+	path = submodules/libdpcp
+	url = https://github.com/Mellanox/libdpcp.git

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,33 @@
 SUBDIRS := third_party src tools docs/man
-
-
 DIST_SUBDIRS := third_party src tests tools docs/man
+
+# Build and install dpcp only if it is the built-in one.
+# So we do not put submodules/libdpcp in SUBDIRS, instead we do this:
+if BUILD_BUILTIN_DPCP
+
+# When working with the built-in dpcp, also add it to the source dist
+DIST_SUBDIRS += submodules/libdpcp
+
+# BUILT_SOURCES are built before anything else
+BUILT_SOURCES = .libdpcp-installed
+CLEANFILES = .libdpcp-installed
+
+LIBDPCP_DIR = $(top_builddir)/submodules/libdpcp
+
+.libdpcp-installed:
+	@test -f "$(LIBDPCP_DIR)/Makefile" || { echo "Error: libdpcp submodule at $(LIBDPCP_DIR) not configured."; exit 1; }
+	$(MAKE) -C "$(LIBDPCP_DIR)"
+	$(MAKE) -C "$(LIBDPCP_DIR)" install
+	touch $@
+
+clean-local:
+	-$(MAKE) -C "$(LIBDPCP_DIR)" clean 2>/dev/null || true
+	rm -f .libdpcp-installed
+
+distclean-local:
+	-$(MAKE) -C "$(LIBDPCP_DIR)" distclean 2>/dev/null || true
+
+endif  # of BUILD_BUILTIN_DPCP
 
 noinst_SCRIPTS = \
 	$(wildcard contrib/scripts/*)

--- a/README.md
+++ b/README.md
@@ -41,14 +41,17 @@ Please visit [DOCA website](https://developer.nvidia.com/networking/doca) for mo
 ##### DPCP
 
 DPCP (Direct Packet Control Plane) is mandatory to run XLIO.
-Repository: [libdpcp](https://github.com/Mellanox/libdpcp.git)
 
-```sh
-$ ./autogen.sh
-$ ./configure --prefix=/where/to/install
-$ make -j
-$ make install
-```
+XLIO uses DPCP. 
+By default libdpcp is linked statically into libxlio, this can be changed by running the libxlio `./configure` script with the `--enable-dpcp-shared` flag.
+
+XLIO utilises libdpcp as a git submodule, by that specifying a built-in DPCP version.
+To use the built-in DPCP version, use one of the following options when cloning:
+* `git clone --recurse-submodules <repo>`
+* `git clone <repo> && git submodule update --init --recursive`
+
+To link against a different DPCP version, run libxlio's `./configure` with the `--with-dpcp=/path/to/dpcp/install`
+flag.
 
 ##### Tools
 
@@ -56,24 +59,21 @@ Autoconf, Automake, libtool, unzip, patch, libnl-devel (netlink 3)
 
 #### Compiling XLIO
 
-Run the following commands from within the directory at the top of the tree:
+Building XLIO is done like this:
 
 ```sh
 $ ./autogen.sh
-$ ./configure --prefix=/where/to/install --with-dpcp=/where/dpcp/installed --enable-utls
+$ ./configure --prefix=/where/to/install
 $ make -j
 $ make install
 ```
---enable-utls : Enables uTLS HW offload for supported NVIDIA HW.
+Useful flags for `./configure` are:
 
-#### Compiling XLIO using preinstalled dpcp
-
-```sh
-$ ./autogen.sh
-$ ./configure --prefix=/where/to/install --with-dpcp --enable-utls
-$ make -j
-$ make install
-```
+`--enable-utls` : Enables uTLS HW offload for supported NVIDIA HW.
+`--enable-static --disable-shared` : Build XLIO as a static library and not as a shared object.
+`--with-dpcp=/where/dpcp/is/installed` : Use libdpcp from a pre-installed location. When this flag 
+    is used, the built-in libdpcp is not built
+`--enable-dpcp-shared` : Link with dpcp dynamically instead of statically
 
 #### Configure
 See more [Options](./docs/configuration.md)

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,6 +1,22 @@
 #!/bin/sh
 
 set -e
+
+# Initialize git submodules if git is available and we're in a git repo
+if command -v git >/dev/null 2>&1 && test -d ".git" ; then
+    echo "Updating git submodules..."
+    git submodule update --init --recursive
+fi
+
+# Bootstrap libdpcp submodule if it exists
+LIBDPCP_DIR="submodules/libdpcp"
+if [ -f "$LIBDPCP_DIR/autogen.sh" ]; then
+    echo "Bootstrapping libdpcp..."
+    (cd "$LIBDPCP_DIR" && ./autogen.sh)
+    echo "Bootstrapping libdpcp done"
+    echo
+fi
+
 rm -rf autom4te.cache
 mkdir -p config
 autoreconf -v --install || exit 1

--- a/config/m4/dpcp.m4
+++ b/config/m4/dpcp.m4
@@ -33,11 +33,11 @@ get_min_supported_version()
     echo 10158
 }
 
-AC_ARG_WITH([dpcp],
-    AS_HELP_STRING([--with-dpcp@<:@=DIR@:>@],
-                   [Search for dpcp headers and libraries in DIR @<:@default: /usr@:>@]),
-    [],
-    []
+AC_ARG_ENABLE([dpcp-shared],
+    AS_HELP_STRING([--enable-dpcp-shared],
+                   [Link libdpcp dynamically instead of statically @<:@default: static@:>@]),
+    [enable_dpcp_shared="$enableval"],
+    [enable_dpcp_shared=no]
 )
 
 if test "x$prj_cv_directverbs" != x3; then
@@ -45,11 +45,14 @@ if test "x$prj_cv_directverbs" != x3; then
 fi
 
 prj_cv_dpcp=0
-if test -z "$with_dpcp" || test "$with_dpcp" = "yes"; then
-    with_dpcp=/usr
+if test -z "$with_dpcp"; then
+    with_dpcp=$ac_abs_top_builddir/submodules/libdpcp/install
 fi
 
-FUNC_CHECK_WITHDIR([dpcp], [$with_dpcp], [include/mellanox/dpcp.h])
+# Only check directory exists when --with-dpcp was explicitly specified
+if test "x$dpcp_explicitly_specified" = "xyes"; then
+    FUNC_CHECK_WITHDIR([dpcp], [$with_dpcp], [include/mellanox/dpcp.h])
+fi
 
 prj_cv_dpcp_save_CPPFLAGS="$CPPFLAGS"
 prj_cv_dpcp_save_CXXFLAGS="$CXXFLAGS"
@@ -57,50 +60,116 @@ prj_cv_dpcp_save_CFLAGS="$CFLAGS"
 prj_cv_dpcp_save_LDFLAGS="$LDFLAGS"
 prj_cv_dpcp_save_LIBS="$LIBS"
 
-prj_cv_dpcp_CPPFLAGS="-I$with_dpcp/include"
-prj_cv_dpcp_LIBS="-ldpcp -lmlx5 -libverbs -lgcov"
-prj_cv_dpcp_LDFLAGS="-L$with_dpcp/lib -Wl,--rpath,$with_dpcp/lib"
-if test -d "$with_dpcp/lib64"; then
-    prj_cv_dpcp_LDFLAGS="-L$with_dpcp/lib64 -Wl,--rpath,$with_dpcp/lib64"
+# Make sure libdpcp install directory exists so that compilation checks will not fail due to missing include directory
+if test "x$dpcp_explicitly_specified" = "xno"; then
+    mkdir -p "$with_dpcp/include"
 fi
 
-CPPFLAGS="$prj_cv_dpcp_CPPFLAGS $CPPFLAGS"
-CXXFLAGS="-std=c++11 $CXXFLAGS"
-LDFLAGS="$prj_cv_dpcp_LDFLAGS $LDFLAGS"
-LIBS="$prj_cv_dpcp_LIBS $LIBS"
+prj_cv_dpcp_CPPFLAGS="-I$with_dpcp/include"
 
-AC_LANG_PUSH([C++])
-AC_CHECK_HEADER(
-    [mellanox/dpcp.h],
-    [AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <mellanox/dpcp.h>]],
-            [[dpcp::provider *provider;
-            dpcp::provider::get_instance(provider);]])],
-            [prj_cv_dpcp=1])
-    ])
-AC_LANG_POP()
+# Determine library directory
+prj_cv_dpcp_libdir="$with_dpcp/lib"
+if test -d "$with_dpcp/lib64"; then
+    prj_cv_dpcp_libdir="$with_dpcp/lib64"
+fi
 
-CPPFLAGS="$prj_cv_dpcp_save_CPPFLAGS"
-CXXFLAGS="$prj_cv_dpcp_save_CXXFLAGS"
-CFLAGS="$prj_cv_dpcp_save_CFLAGS"
-LDFLAGS="$prj_cv_dpcp_save_LDFLAGS"
-LIBS="$prj_cv_dpcp_save_LIBS"
-
-
-AC_MSG_CHECKING([for dpcp support])
-if test "$prj_cv_dpcp" -ne 0; then
-    CPPFLAGS="$CPPFLAGS $prj_cv_dpcp_CPPFLAGS"
-    LDFLAGS="$prj_cv_dpcp_LDFLAGS $LDFLAGS"
-    AC_SUBST([DPCP_LIBS], ["-ldpcp"])
-    dpcp_version_number=($(get_version_number))
-    min_supported_version=($(get_min_supported_version))
-
-    if test "$dpcp_version_number" -ge "$min_supported_version"; then
-        AC_DEFINE_UNQUOTED([DEFINED_DPCP_MIN], [$min_supported_version], [Define to DPCP version number (major * 10000 + minor * 100 + patch)])
-        AC_MSG_RESULT([yes])
+# Set up linking with dpcp based on static/dynamic choice
+prj_cv_dpcp_LIBS_COMMON="-lmlx5 -libverbs -lgcov"
+if test "x$enable_dpcp_shared" = "xyes"; then
+    # Dynamic linking
+    prj_cv_dpcp_SHARED_LIB="$prj_cv_dpcp_libdir/libdpcp.so"
+    # When user is not specifying --with-dpcp, i.e. the built-in libdpcp is used,
+    # Do not check that the library exists, because it will only be built at the 
+    # 'make' stage
+    if test "x$dpcp_explicitly_specified" = "xyes" && test ! -f "$prj_cv_dpcp_SHARED_LIB"; then
+        AC_MSG_ERROR([libdpcp shared library not found: $prj_cv_dpcp_SHARED_LIB. If static linking with dpcp is desired, remove the --enable-dpcp-shared flag.])
+    fi
+    prj_cv_dpcp_LIBS="-ldpcp $prj_cv_dpcp_LIBS_COMMON"
+    prj_cv_dpcp_LDFLAGS="-L$prj_cv_dpcp_libdir -Wl,--rpath,$prj_cv_dpcp_libdir"
+    prj_cv_dpcp_final_libs="-ldpcp"
+else
+    # Static linking (default)
+    prj_cv_dpcp_STATIC_LIB="$prj_cv_dpcp_libdir/libdpcp.a"
+    # When user is not specifying --with-dpcp, i.e. the built-in libdpcp is used,
+    # Do not check that the library exists, because it will only be built at the 
+    # 'make' stage
+    if test "x$dpcp_explicitly_specified" = "xyes" && test ! -f "$prj_cv_dpcp_STATIC_LIB"; then
+        AC_MSG_ERROR([Static library not found: $prj_cv_dpcp_STATIC_LIB. If dynamic linking with dpcp is desired, use --enable-dpcp-shared.])
+    fi
+    prj_cv_dpcp_LIBS="$prj_cv_dpcp_STATIC_LIB $prj_cv_dpcp_LIBS_COMMON"
+    prj_cv_dpcp_LDFLAGS=""
+    # When building XLIO as a static library, We set prj_cv_dpcp_final_libs empty because ar 
+    # cannot add a .a file into a .a file.
+    # Instead, we add the content of libdpcp.a into libxlio.a by using
+    # the rule for libxlio.la: in src/core/Makefile.am
+    if test "x$enable_static" = "xyes"; then
+        prj_cv_dpcp_final_libs=""
     else
-        AC_MSG_ERROR([found incompatible dpcp version $dpcp_version_number (min supported version $min_supported_version) ])
+        prj_cv_dpcp_final_libs="$prj_cv_dpcp_STATIC_LIB"
+    fi
+fi
+
+# Export the static library path for use in src/core/Makefile.am (all-local rule)
+AC_SUBST([DPCP_STATIC_LIB], ["$prj_cv_dpcp_STATIC_LIB"])
+AM_CONDITIONAL([XLIO_AND_DPCP_ARE_STATIC], [test "x$prj_cv_dpcp_STATIC_LIB" != "x" && test "x$enable_static" = "xyes"])
+
+# Only run header/link checks if dpcp was explicitly specified
+# For built-in submodule, we skip these checks since it's not built yet
+if test "x$dpcp_explicitly_specified" = "xyes"; then
+    CPPFLAGS="$prj_cv_dpcp_CPPFLAGS $CPPFLAGS"
+    CXXFLAGS="-std=c++11 $CXXFLAGS"
+    LDFLAGS="$prj_cv_dpcp_LDFLAGS $LDFLAGS"
+    LIBS="$prj_cv_dpcp_LIBS $LIBS"
+
+    AC_LANG_PUSH([C++])
+    AC_CHECK_HEADER(
+        [mellanox/dpcp.h],
+        [AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <mellanox/dpcp.h>]],
+                [[dpcp::provider *provider;
+                dpcp::provider::get_instance(provider);]])],
+                [prj_cv_dpcp=1])
+        ])
+    AC_LANG_POP()
+
+    CPPFLAGS="$prj_cv_dpcp_save_CPPFLAGS"
+    CXXFLAGS="$prj_cv_dpcp_save_CXXFLAGS"
+    CFLAGS="$prj_cv_dpcp_save_CFLAGS"
+    LDFLAGS="$prj_cv_dpcp_save_LDFLAGS"
+    LIBS="$prj_cv_dpcp_save_LIBS"
+
+    AC_MSG_CHECKING([for dpcp support])
+    if test "$prj_cv_dpcp" -ne 0; then
+        CPPFLAGS="$CPPFLAGS $prj_cv_dpcp_CPPFLAGS"
+        LDFLAGS="$prj_cv_dpcp_LDFLAGS $LDFLAGS"
+        AC_SUBST([DPCP_LIBS], ["$prj_cv_dpcp_final_libs"])
+        dpcp_version_number=($(get_version_number))
+        min_supported_version=($(get_min_supported_version))
+
+        if test "$dpcp_version_number" -ge "$min_supported_version"; then
+            AC_DEFINE_UNQUOTED([DEFINED_DPCP_MIN], [$min_supported_version], [Define to DPCP version number (major * 10000 + minor * 100 + patch)])
+            if test "x$enable_dpcp_shared" = "xyes"; then
+                AC_MSG_RESULT([yes (dynamic linking)])
+            else
+                AC_MSG_RESULT([yes (static linking)])
+            fi
+        else
+            AC_MSG_ERROR([found incompatible dpcp version $dpcp_version_number (min supported version $min_supported_version) ])
+        fi
+    else
+        AC_MSG_ERROR([dpcp support requested but not present])
     fi
 else
-    AC_MSG_ERROR([dpcp support requested but not present])
+    # Using built-in submodule - skip checks, assume dpcp will be built
+    AC_MSG_CHECKING([for dpcp support])
+    AC_MSG_RESULT([using built-in submodule (will be built)])
+    
+    # Set up paths for when it is built
+    CPPFLAGS="$CPPFLAGS $prj_cv_dpcp_CPPFLAGS"
+    LDFLAGS="$prj_cv_dpcp_LDFLAGS $LDFLAGS"
+    AC_SUBST([DPCP_LIBS], ["$prj_cv_dpcp_final_libs"])
+    
+    # Use a placeholder version - the real check happens at make time
+    min_supported_version=($(get_min_supported_version))
+    AC_DEFINE_UNQUOTED([DEFINED_DPCP_MIN], [$min_supported_version], [Define to DPCP version number (major * 10000 + minor * 100 + patch)])
 fi
 ])

--- a/configure.ac
+++ b/configure.ac
@@ -61,6 +61,12 @@ dnl=== SECTION 2: Initialization & Setup
 dnl===
 dnl===-----------------------------------------------------------------------===
 
+# Initialize git submodules if git is available and we're in a git repo
+if command -v git >/dev/null 2>&1 && test -d "$srcdir/.git" ; then
+    echo "Updating git submodules..."
+    git submodule update --init --recursive
+fi
+
 # Verify that the source directory is valid.
 #
 AC_CONFIG_SRCDIR(src)
@@ -92,9 +98,41 @@ m4_include([config/m4/dpcp.m4])
 m4_include([config/m4/nl.m4])
 m4_include([config/m4/prof.m4])
 m4_include([config/m4/compiler.m4])
+m4_include([third_party/config/m4/ax_subdirs_configure.m4])
+
+# This belongs in dpcp.m4 but when placed there, it executes only when 
+# DPCP_CAPABILITY_SETUP() is called, and by then we cannot use AX_SUBDIRS_CONFIGURE()
+# any more.
+
+AC_ARG_WITH([dpcp],
+    AS_HELP_STRING([--with-dpcp@<:@=DIR@:>@],
+                   [Search for dpcp headers and libraries in DIR @<:@default: /usr@:>@]),
+    [dpcp_explicitly_specified=yes],
+    [dpcp_explicitly_specified=no]
+)
+
+# Configure libdpcp - only if using the built-in version
+if test "x$dpcp_explicitly_specified" = "xno"; then
+
+    if test ! -f "$srcdir/submodules/libdpcp/configure.ac" ; then
+  	    AC_MSG_ERROR([$srcdir/submodules/libdpcp/configure.ac not found, did you run ./autogen.sh ? 
+                      This should have populated $srcdir/submodules/libdpcp, as it runs 'git submodule update --init --recursive'.
+                      For working with libdpcp from another location, use --with-dpcp])
+    fi
+
+    # Configure libdpcp - need to come after the m4_include ax_subdirs_configure above
+    # This macro is used instead of AC_CONFIG_SUBDIRS because we need to specify a --prefix
+    # for libdpcp so that it does not install itself into libxlio's install dir
+    AX_SUBDIRS_CONFIGURE(
+        [submodules/libdpcp],
+        [--prefix=${ac_abs_top_builddir}/submodules/libdpcp/install],
+        [],
+        [],
+        [])
+
+fi
 
 FUNC_CONFIGURE_INIT()
-
 
 dnl===-----------------------------------------------------------------------===
 dnl===
@@ -415,6 +453,9 @@ EOF
 else
     AC_MSG_ERROR([${CONFIG_SCHEMA_JSON} not found])
 fi
+
+# Define conditional for building built-in libdpcp
+AM_CONDITIONAL([BUILD_BUILTIN_DPCP], [test "x$dpcp_explicitly_specified" != "xyes"])
 
 AC_CONFIG_FILES([
 		Makefile

--- a/contrib/jenkins_tests/copyright-check-map.yaml
+++ b/contrib/jenkins_tests/copyright-check-map.yaml
@@ -5,6 +5,7 @@ general:
         - "\\.dockers.*"
         - "build.*"
         - "third_party\\.*"
+        - "config/m4/ax_subdirs_configure.m4"
         - "contrib/jenkins_tests.*"
         - "contrib/valgrind.*"
         - "contrib/xlio-bench.*"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,19 +18,20 @@ This option manages  debugging information in the executable, such as the names 
 
 ### --enable-nginx
 
-This option allows to use the library with popular open source software for web serving, reverse proxying, caching, load balancing, media streaming, and more as NGINX.
+This option allows using the library with popular open source software for web serving, reverse proxying, caching, load balancing, media streaming, and more as NGINX.
 
 ### --enable-utls
 
 This option enables uTLS HW offload for supported NVIDIA HW.
 
-### --with-dpcp
+### --with-dpcp=<libdpcp-install-path>
 
-This option allows to use DPCP library for programming Infiniband devices.
-DPCP (Direct Packet Control Plane) is mandatory to enable advanced HW features for supported NVIDIA HW.
-This library should be installed on your system.
+DPCP (Direct Packet Control Plane) is a library for programming Infiniband devices.
+DPCP is mandatory to enable advanced HW features for supported NVIDIA HW.
+By default, libxlio uses the libdpcp submodule, which is installed to submodules/libdpcp/install
+This option allows using a non-default location for libdpcp.
 
-Git repository: https://github.com/Mellanox/libdpcp
+DPCP Git repository: https://github.com/Mellanox/libdpcp
 
 ### --with-ibprof
 

--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -64,7 +64,6 @@ libxlio_la_LIBADD = \
 
 dist_noinst_DATA = config/descriptor_providers/xlio_config_schema.json
 
-
 libxlio_la_SOURCES := \
 	dev/allocator.cpp \
 	dev/buffer_pool.cpp \
@@ -359,3 +358,26 @@ libxlio_la_DEPENDENCIES = \
 	$(top_builddir)/src/core/infra/libinfra.la \
 	libconfig_parser.la \
 	$(LIBJSON_LIBS)
+
+if XLIO_AND_DPCP_ARE_STATIC
+
+# Adding libdpcp.a into libxlio.so is easy - ar does this automatically.
+# For adding the .o files from libdpcp.a into libxlio.a, we need to use a trick, since
+# simply specifying libdpcp.a, or libdpcp.la, as a dependancy of libxlio, does not work.
+# So we override the rule for libxlio.la which is normally generated into Makefile.
+# After standard linking , we extract the .o files out of libdpcp.a and add them into libxlio.a .
+libxlio.la: $(libxlio_la_OBJECTS) $(libxlio_la_DEPENDENCIES) $(EXTRA_libxlio_la_DEPENDENCIES) 
+	@echo Running the standard link step for static library...
+	$(AM_V_CXXLD)$(libxlio_la_LINK) -rpath $(libdir) $(libxlio_la_OBJECTS) $(libxlio_la_LIBADD) $(LIBS)
+	@echo "Merging $(DPCP_STATIC_LIB) into .libs/libxlio.a ..."; \
+	cd .libs && rm -rf dpcp_objs && mkdir -p dpcp_objs && \
+	cd dpcp_objs && $(AR) x $(DPCP_STATIC_LIB) && cd .. && \
+	if [ -n "$$(ls -A dpcp_objs/*.o 2>/dev/null)" ]; then \
+		$(AR) rcs libxlio.a dpcp_objs/*.o; \
+	else \
+		echo "Error: No object files extracted from $(DPCP_STATIC_LIB), look at src/core/.libs/dpcp_objs/"; \
+		false;     # Make the command fail \
+	fi && \
+	rm -rf dpcp_objs;
+
+endif

--- a/third_party/config/m4/ax_subdirs_configure.m4
+++ b/third_party/config/m4/ax_subdirs_configure.m4
@@ -1,0 +1,334 @@
+# ===========================================================================
+#   https://www.gnu.org/software/autoconf-archive/ax_subdirs_configure.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_SUBDIRS_CONFIGURE( [subdirs], [mandatory arguments], [possibly merged arguments], [replacement arguments], [forbidden arguments])
+#
+# DESCRIPTION
+#
+#   AX_SUBDIRS_CONFIGURE attempts to be the equivalent of AC_CONFIG_SUBDIRS
+#   with customizable options for configure scripts.
+#
+#   Run the configure script for each directory from the comma-separated m4
+#   list 'subdirs'. This macro can be used multiple times. All arguments of
+#   this macro must be comma-separated lists.
+#
+#   All command line arguments from the parent configure script will be
+#   given to the subdirectory configure script after the following
+#   modifications (in that order):
+#
+#   1. The arguments from the 'mandatory arguments' list shall always be
+#   appended to the argument list.
+#
+#   2. The arguments from the 'possibly merged arguments' list shall be
+#   added if not present in the arguments of the parent configure script or
+#   merged with the existing argument otherwise.
+#
+#   3. The arguments from the 'replacement arguments' list shall be added if
+#   not present in the arguments of the parent configure script or replace
+#   the existing argument otherwise.
+#
+#   4. The arguments from the 'forbidden arguments' list shall always be
+#   removed from the argument list.
+#
+#   The lists 'mandatory arguments' and 'forbidden arguments' can hold any
+#   kind of argument. The 'possibly merged arguments' and 'replacement
+#   arguments' expect their arguments to be of the form --option-name=value.
+#
+#   This macro aims to remain as close as possible to the AC_CONFIG_SUBDIRS
+#   macro. It corrects the paths for '--srcdir' and adds
+#   '--disable-option-checking' and '--silent' if necessary. However, it
+#   does not change the '--cache-file' argument: typically, configure
+#   scripts run with different arguments will not be able to share the same
+#   cache. If you wish to share a single cache, you should give an absolute
+#   path to '--cache-file'.
+#
+#   This macro also sets the output variable subdirs_extra to the list of
+#   directories recorded with AX_SUBDIRS_CONFIGURE. This variable can be
+#   used in Makefile rules or substituted in configured files.
+#
+#   This macro shall do nothing more than managing the arguments of the
+#   configure script. Just like when using AC_CONFIG_SUBDIRS, it is up to
+#   the user to check any requirements or define and substitute any required
+#   variable for the remainder of the project.
+#
+#   Configure scripts recorded with AX_SUBDIRS_CONFIGURE may be executed
+#   before configure scripts recorded with AC_CONFIG_SUBDIRS.
+#
+#   Without additional arguments, the behaviour of AX_SUBDIRS_CONFIGURE
+#   should be identical to the behaviour of AC_CONFIG_SUBDIRS, apart from
+#   the contents of the variables subdirs and subdirs_extra (except that
+#   AX_SUBDIRS_CONFIGURE expects a comma-separated m4 list):
+#
+#     AC_CONFIG_SUBDIRS([something])
+#     AX_SUBDIRS_CONFIGURE([something])
+#
+#   This macro may be called multiple times.
+#
+#   Usage example:
+#
+#   Let us assume our project has 4 dependencies, namely A, B, C and D. Here
+#   are some characteristics of our project and its dependencies:
+#
+#   - A does not require any special option.
+#
+#   - we want to build B with an optional feature which can be enabled with
+#   its configure script's option '--enable-special-feature'.
+#
+#   - B's configure script is strange and has an option '--with-B=build'.
+#   After close inspection of its documentation, we don't want B to receive
+#   this option.
+#
+#   - C and D both need B.
+#
+#   - Just like our project, C and D can build B themselves with the option
+#   '--with-B=build'.
+#
+#   - We want C and D to use the B we build instead of building it
+#   themselves.
+#
+#   Our top-level configure script will be called as follows:
+#
+#     $ <path/to/configure> --with-A=build --with-B=build --with-C=build \
+#       --with-D=build --some-option
+#
+#   Thus we have to make sure that:
+#
+#   - neither B, C or D receive the option '--with-B=build'
+#
+#   - C and D know where to find the headers and libraries of B.
+#
+#   Under those conditions, we can use the AC_CONFIG_SUBDIRS macro for A,
+#   but need to use AX_SUBDIRS_CONFIGURE for B, C and D:
+#
+#   - B must receive '--enable-special-feature' but cannot receive
+#   '--with-B=build'
+#
+#   - C and D cannot receive '--with-B=build' (or else it would be built
+#   thrice) and need to be told where to find B (since we are building it,
+#   it would probably not be available in standard paths).
+#
+#   Here is a configure.ac snippet that solves our problem:
+#
+#     AC_CONFIG_SUBDIRS([dependencies/A])
+#     AX_SUBDIRS_CONFIGURE(
+#         [dependencies/B], [--enable-special-feature], [], [],
+#         [--with-B=build])
+#     AX_SUBDIRS_CONFIGURE(
+#         [[dependencies/C],[dependencies/D]],
+#         [],
+#         [[CPPFLAGS=-I${ac_top_srcdir}/dependencies/B -I${ac_top_builddir}/dependencies/B],
+#          [LDFLAGS=-L${ac_abs_top_builddir}/dependencies/B/.libs]],
+#         [--with-B=system],
+#         [])
+#
+#   If using automake, the following can be added to the Makefile.am (we use
+#   both $(subdirs) and $(subdirs_extra) since our example above used both
+#   AC_CONFIG_SUBDIRS and AX_SUBDIRS_CONFIGURE):
+#
+#     SUBDIRS = $(subdirs) $(subdirs_extra)
+#
+# LICENSE
+#
+#   Copyright (c) 2017 Harenome Ranaivoarivony-Razanajato <ranaivoarivony-razanajato@hareno.me>
+#
+#   This program is free software; you can redistribute it and/or modify it
+#   under the terms of the GNU General Public License as published by the
+#   Free Software Foundation; either version 3 of the License, or (at your
+#   option) any later version.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+#   Public License for more details.
+#
+#   Under Section 7 of GPL version 3, you are granted additional permissions
+#   described in the Autoconf Configure Script Exception, version 3.0, as
+#   published by the Free Software Foundation.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program. If not, see <https://www.gnu.org/licenses/>.
+
+#serial 6
+
+AC_DEFUN([AX_SUBDIRS_CONFIGURE],
+[
+  dnl Calls to AC_CONFIG_SUBDIRS perform preliminary steps and build a list
+  dnl '$subdirs' which is used later by _AC_OUTPUT_SUBDIRS (used by AC_OUTPUT)
+  dnl to actually run the configure scripts.
+  dnl This macro performs similar preliminary steps but uses
+  dnl AC_CONFIG_COMMANDS_PRE to delay the final tasks instead of building an
+  dnl intermediary list and relying on another macro.
+  dnl
+  dnl Since each configure script can get different options, a special variable
+  dnl named 'ax_sub_configure_args_<subdir>' is constructed for each
+  dnl subdirectory.
+
+  # Various preliminary checks.
+  AC_REQUIRE([AC_DISABLE_OPTION_CHECKING])
+  AC_REQUIRE([AC_CONFIG_AUX_DIR_DEFAULT])
+  AS_LITERAL_IF([$1], [],
+      [AC_DIAGNOSE([syntax], [$0: you should use literals])])
+
+  m4_foreach(subdir_path, [$1],
+  [
+    ax_dir="subdir_path"
+
+    dnl Build the argument list in a similar fashion to AC_CONFIG_SUBDIRS.
+    dnl A few arguments found in the final call to the configure script are not
+    dnl added here because they rely on variables that may not yet be available
+    dnl (see below the part that is similar to _AC_OUTPUT_SUBDIRS).
+    # Do not complain, so a configure script can configure whichever parts of a
+    # large source tree are present.
+    if test -d "$srcdir/$ax_dir"; then
+      _AC_SRCDIRS(["$ax_dir"])
+      # Remove --cache-file, --srcdir, and --disable-option-checking arguments
+      # so they do not pile up.
+      ax_args=
+      ax_prev=
+      eval "set x $ac_configure_args"
+      shift
+      for ax_arg; do
+        if test -n "$ax_prev"; then
+          ax_prev=
+          continue
+        fi
+        case $ax_arg in
+          -cache-file | --cache-file | --cache-fil | --cache-fi | --cache-f \
+          | --cache- | --cache | --cach | --cac | --ca | --c)
+            ax_prev=cache_file ;;
+          -cache-file=* | --cache-file=* | --cache-fil=* | --cache-fi=* \
+          | --cache-f=* | --cache-=* | --cache=* | --cach=* | --cac=* | --ca=* \
+          | --c=*)
+            ;;
+          --config-cache | -C)
+            ;;
+          -srcdir | --srcdir | --srcdi | --srcd | --src | --sr)
+            ax_prev=srcdir ;;
+          -srcdir=* | --srcdir=* | --srcdi=* | --srcd=* | --src=* | --sr=*)
+            ;;
+          -prefix | --prefix | --prefi | --pref | --pre | --pr | --p)
+            ax_prev=prefix ;;
+          -prefix=* | --prefix=* | --prefi=* | --pref=* | --pre=* | --pr=* \
+          | --p=*)
+            ;;
+          --disable-option-checking)
+            ;;
+          *) case $ax_arg in
+              *\'*) ax_arg=$(AS_ECHO(["$ax_arg"]) | sed "s/'/'\\\\\\\\''/g");;
+            esac
+            AS_VAR_APPEND([ax_args], [" '$ax_arg'"]) ;;
+        esac
+      done
+      # Always prepend --disable-option-checking to silence warnings, since
+      # different subdirs can have different --enable and --with options.
+      ax_args="--disable-option-checking $ax_args"
+      # Options that must be added as they are provided.
+      m4_ifnblank([$2], [m4_foreach(opt, [$2], [AS_VAR_APPEND(ax_args, " 'opt'")
+      ])])
+      # New options that may need to be merged with existing options.
+      m4_ifnblank([$3], [m4_foreach(opt, [$3],
+          [ax_candidate="opt"
+           ax_candidate_flag="${ax_candidate%%=*}"
+           ax_candidate_content="${ax_candidate#*=}"
+           if test "x$ax_candidate" != "x" -a "x$ax_candidate_flag" != "x"; then
+             if echo "$ax_args" | grep -- "${ax_candidate_flag}=" >/dev/null 2>&1; then
+               [ax_args=$(echo $ax_args | sed "s,\(${ax_candidate_flag}=[^']*\),\1 ${ax_candidate_content},")]
+             else
+               AS_VAR_APPEND(ax_args, " 'opt'")
+             fi
+           fi
+      ])])
+      # New options that must replace existing options.
+      m4_ifnblank([$4], [m4_foreach(opt, [$4],
+          [ax_candidate="opt"
+           ax_candidate_flag="${ax_candidate%%=*}"
+           ax_candidate_content="${ax_candidate#*=}"
+           if test "x$ax_candidate" != "x" -a "x$ax_candidate_flag" != "x"; then
+             if echo "$ax_args" | grep -- "${ax_candidate_flag}=" >/dev/null 2>&1; then
+               [ax_args=$(echo $ax_args | sed "s,${ax_candidate_flag}=[^']*,${ax_candidate},")]
+             else
+               AS_VAR_APPEND(ax_args, " 'opt'")
+             fi
+           fi
+      ])])
+      # Options that must be removed.
+      m4_ifnblank([$5], [m4_foreach(opt, [$5], [ax_args=$(echo $ax_args | sed "s,'opt',,")
+      ])])
+      AS_VAR_APPEND([ax_args], [" '--srcdir=$ac_srcdir'"])
+
+      # Add the subdirectory to the list of target subdirectories.
+      ax_subconfigures="$ax_subconfigures $ax_dir"
+      # Save the argument list for this subdirectory.
+      dnl $1 is a path to some subdirectory: m4_bpatsubsts() is used to convert
+      dnl $1 into a valid shell variable name.
+      dnl For instance, "ax_sub_configure_args_path/to/subdir" becomes
+      dnl "ax_sub_configure_args_path_to_subdir".
+      ax_var=$(printf "$ax_dir" | tr -c "0-9a-zA-Z_" "_")
+      eval "ax_sub_configure_args_$ax_var=\"$ax_args\""
+      eval "ax_sub_configure_$ax_var=\"yes\""
+    else
+      AC_MSG_WARN([could not find source tree for $ax_dir])
+    fi
+
+    dnl Add some more arguments to the argument list and then actually run the
+    dnl configure script. This is mostly what happens in _AC_OUTPUT_SUBDIRS
+    dnl except it does not iterate over an intermediary list.
+    AC_CONFIG_COMMANDS_PRE(
+      dnl This very line cannot be quoted! m4_foreach has some work here.
+      ax_dir="subdir_path"
+    [
+      # Convert the path to the subdirectory into a shell variable name.
+      ax_var=$(printf "$ax_dir" | tr -c "0-9a-zA-Z_" "_")
+      ax_configure_ax_var=$(eval "echo \"\$ax_sub_configure_$ax_var\"")
+      if test "$no_recursion" != "yes" -a "x$ax_configure_ax_var" = "xyes"; then
+        AC_SUBST([subdirs_extra], ["$subdirs_extra $ax_dir"])
+        ax_msg="=== configuring in $ax_dir ($(pwd)/$ax_dir)"
+        _AS_ECHO_LOG([$ax_msg])
+        _AS_ECHO([$ax_msg])
+        AS_MKDIR_P(["$ax_dir"])
+        _AC_SRCDIRS(["$ax_dir"])
+
+        ax_popdir=$(pwd)
+        cd "$ax_dir"
+
+        # Check for guested configure; otherwise get Cygnus style configure.
+        if test -f "$ac_srcdir/configure.gnu"; then
+          ax_sub_configure=$ac_srcdir/configure.gnu
+        elif test -f "$ac_srcdir/configure"; then
+          ax_sub_configure=$ac_srcdir/configure
+        elif test -f "$ac_srcdir/configure.in"; then
+          # This should be Cygnus configure.
+          ax_sub_configure=$ac_aux_dir/configure
+        else
+          AC_MSG_WARN([no configuration information is in $ax_dir])
+          ax_sub_configure=
+        fi
+
+        if test -n "$ax_sub_configure"; then
+          # Get the configure arguments for the current configure.
+          eval "ax_sub_configure_args=\"\$ax_sub_configure_args_${ax_var}\""
+
+          # Always prepend --prefix to ensure using the same prefix
+          # in subdir configurations.
+          ax_arg="--prefix=$prefix"
+          case $ax_arg in
+            *\'*) ax_arg=$(AS_ECHO(["$ax_arg"]) | sed "s/'/'\\\\\\\\''/g");;
+          esac
+          ax_sub_configure_args="'$ax_arg' $ax_sub_configure_args"
+          if test "$silent" = yes; then
+            ax_sub_configure_args="--silent $ax_sub_configure_args"
+          fi
+
+          AC_MSG_NOTICE([running $SHELL $ax_sub_configure $ax_sub_configure_args --cache-file=$cache_file])
+          eval "\$SHELL \"$ax_sub_configure\" $ax_sub_configure_args --cache-file=\"$cache_file\"" \
+              || AC_MSG_ERROR([$ax_sub_configure failed for $ax_dir])
+        fi
+
+        cd "$ax_popdir"
+      fi
+    ])
+  ])
+])


### PR DESCRIPTION
## Description
Add libdpcp as a git submodule under submodules/libdpcp, and make libxlio link with it staticaly.

##### Why ?
Bringing libdpcp as a sub-module and linking with it statically ensures that libxlio is used with a 
compatible libdpcp version. 

##### How ?
- Change libdpcp default link method to from dynamic static
- Add libdpcp as a git submodule under submodules/libdpcp
- Add ./build.sh script to build both DPCP and XLIO
- Add --enable-dpcp-dynamic configure flag for dynamic DPCP linking to allow keeping the old behavior (static linking of DPCP is now the default)
- Change default DPCP path to submodules/libdpcp/install
- Implemented work-around in src/core/Makefile.am to add the content of libdpcp.a into libxlio.a when creating a static library
- Update README.md with new build instructions

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [X] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [X] Code follows the style de facto guidelines of this project
- [X] Comments have been inserted in hard to understand places
- [X] Documentation has been updated (if necessary)
- [X] Test has been added (if possible)

