### PR TITLE
issue: 4684689 Remove quick_init parameter

### DIFF
--- a/docs/xlio_config_reference.md
+++ b/docs/xlio_config_reference.md
@@ -1,6 +1,6 @@
 # XLIO Configuration Reference
 
-This file documents all 121 XLIO runtime configuration parameters with their types, defaults, environment variables, and constraints.
+This file documents all 120 XLIO runtime configuration parameters with their types, defaults, environment variables, and constraints.
 
 > **Auto-generated** from the JSON schema by `generate_docs.py`. Do not edit manually.
 
@@ -17,7 +17,6 @@ This file documents all 121 XLIO runtime configuration parameters with their typ
   - [`applications.nginx.workers_num`](#applicationsnginxworkers_num) — Number of Nginx workers
 - **[CORE](#core)**
   - [`core.exception_handling.mode`](#coreexception_handlingmode) — Exception handling mode
-  - [`core.quick_init`](#corequick_init) — Quick initialization
   - [`core.resources.external_memory_limit`](#coreresourcesexternal_memory_limit) — External memory limit (bytes)
   - [`core.resources.heap_metadata_block_size`](#coreresourcesheap_metadata_block_size) — Heap metadata block size
   - [`core.resources.hugepages.enable`](#coreresourceshugepagesenable) — Enable hugepages
@@ -345,34 +344,6 @@ Strict modes (2, 3) surface incompatibilities immediately but may break applicat
 **Guidance:** Production: -1 or 0. Development/testing: 2 or 3.
 
 **Default:** `"handle_debug" (-1)`
-
-### `core.quick_init`
-
-> **Type:** boolean
->
-> **Maps to:** `XLIO_QUICK_START`
-
-Skips hugepage residency validation during startup when enabled.
-
-**Behavior:** When disabled (false), XLIO calls mincore() for each allocated hugepage to verify
-pages are resident before use. When enabled (true), this validation is skipped.
-
-**Value Tradeoffs:**
-
-*false (Default):*
-Safe. Catches cgroup misconfigurations that would cause SIGBUS crashes on first memory access.
-Adds startup latency proportional to hugepage count.
-
-*true:*
-Faster startup. Risk: In cgroup-limited environments (containers, Kubernetes), mmap() may succeed
-even when hugepages exceed the limit. First memory access triggers SIGBUS with no earlier warning.
-
-**Decision guide:**
-
-- Containers, Kubernetes, cgroup-limited: Keep disabled (runtime SIGBUS is worse than startup delay)
-- Bare metal with verified hugepage config: Safe to enable for faster startup
-
-**Default:** `false`
 
 ### `core.resources.external_memory_limit`
 

--- a/src/core/config/config_var_definitions.h
+++ b/src/core/config/config_var_definitions.h
@@ -38,7 +38,6 @@ extern const config_var_info_t<bool> CONFIG_VAR_LOG_COLORS;
 extern const config_var_info_t<bool> CONFIG_VAR_HANDLE_SIGINTR;
 extern const config_var_info_t<bool> CONFIG_VAR_HANDLE_SIGSEGV;
 extern const config_var_info_t<uint32_t, int64_t> CONFIG_VAR_STATS_FD_NUM;
-extern const config_var_info_t<bool> CONFIG_VAR_QUICK_START;
 
 extern const config_var_info_t<ring_logic_t, int64_t> CONFIG_VAR_RING_ALLOCATION_LOGIC_TX;
 extern const config_var_info_t<ring_logic_t, int64_t> CONFIG_VAR_RING_ALLOCATION_LOGIC_RX;

--- a/src/core/config/descriptor_providers/xlio_config_schema.json
+++ b/src/core/config/descriptor_providers/xlio_config_schema.json
@@ -97,12 +97,6 @@
                     },
                     "additionalProperties": false
                 },
-                "quick_init": {
-                    "type": "boolean",
-                    "default": false,
-                    "title": "Quick initialization",
-                    "description": "Maps to XLIO_QUICK_START environment variable.\nSkips hugepage residency validation during startup when enabled.\n\n**Behavior:** When disabled (false), XLIO calls mincore() for each allocated hugepage to verify\npages are resident before use. When enabled (true), this validation is skipped.\n\n**Value Tradeoffs:**\n\n*false (Default):*\nSafe. Catches cgroup misconfigurations that would cause SIGBUS crashes on first memory access.\nAdds startup latency proportional to hugepage count.\n\n*true:*\nFaster startup. Risk: In cgroup-limited environments (containers, Kubernetes), mmap() may succeed\neven when hugepages exceed the limit. First memory access triggers SIGBUS with no earlier warning.\n\n**Decision guide:**\n\n- Containers, Kubernetes, cgroup-limited: Keep disabled (runtime SIGBUS is worse than startup delay)\n- Bare metal with verified hugepage config: Safe to enable for faster startup"
-                },
                 "exception_handling": {
                     "type": "object",
                     "description": "How XLIO handles exceptions and errors.",

--- a/src/core/config/mappings.py
+++ b/src/core/config/mappings.py
@@ -7,7 +7,6 @@
 config_mapping = {
     # core section
     "core.exception_handling.mode": "XLIO_EXCEPTION_HANDLING",
-    "core.quick_init": "XLIO_QUICK_START",
     "core.resources.external_memory_limit": "XLIO_MEMORY_LIMIT_USER",
     "core.resources.heap_metadata_block_size": "XLIO_HEAP_METADATA_BLOCK",
     "core.resources.hugepages.enable": "XLIO_MEM_ALLOC_TYPE",

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -476,8 +476,6 @@ void print_env_vars_xlio_global_settings()
                       safe_mce_sys().handle_segfault ? "Enabled " : "Disabled");
     VLOG_PARAM_STRING("Print a report", safe_mce_sys().print_report, MCE_DEFAULT_PRINT_REPORT,
                       SYS_VAR_PRINT_REPORT, safe_mce_sys().print_report ? "Enabled " : "Disabled");
-    VLOG_PARAM_STRING("Quick start", safe_mce_sys().quick_start, MCE_DEFAULT_QUICK_START,
-                      SYS_VAR_QUICK_START, safe_mce_sys().quick_start ? "Enabled " : "Disabled");
 
     VLOG_PARAM_NUMSTR("Ring allocation logic TX", safe_mce_sys().ring_allocation_logic_tx,
                       MCE_DEFAULT_RING_ALLOCATION_LOGIC_TX, SYS_VAR_RING_ALLOCATION_LOGIC_TX,

--- a/src/core/util/hugepage_mgr.cpp
+++ b/src/core/util/hugepage_mgr.cpp
@@ -113,7 +113,7 @@ void *hugepage_mgr::alloc_hugepages_helper(size_t &size, size_t hugepage)
     if (ptr == MAP_FAILED) {
         ptr = nullptr;
         __log_info_dbg("mmap failed (errno=%d)", errno);
-    } else if (!safe_mce_sys().quick_start) {
+    } else {
         /* Check whether all the pages are resident. Allocation beyond the cgroup limit can be
          * successful and lead to a SIGBUS on an access. For example, the limit can be configured
          * for a container.

--- a/src/core/util/sys_vars.cpp
+++ b/src/core/util/sys_vars.cpp
@@ -763,7 +763,6 @@ void mce_sys_var::get_env_params()
     strcpy(internal_thread_affinity_str, MCE_DEFAULT_INTERNAL_THREAD_AFFINITY_STR);
 
     print_report = MCE_DEFAULT_PRINT_REPORT;
-    quick_start = MCE_DEFAULT_QUICK_START;
     log_level = VLOG_DEFAULT;
     log_details = MCE_DEFAULT_LOG_DETAILS;
     log_colors = MCE_DEFAULT_LOG_COLORS;
@@ -1074,10 +1073,6 @@ void mce_sys_var::get_env_params()
 
     if ((env_ptr = getenv(SYS_VAR_PRINT_REPORT))) {
         print_report = option_3::from_str(env_ptr, MCE_DEFAULT_PRINT_REPORT);
-    }
-
-    if ((env_ptr = getenv(SYS_VAR_QUICK_START))) {
-        quick_start = atoi(env_ptr) ? true : false;
     }
 
     if ((env_ptr = getenv(SYS_VAR_LOG_FILENAME))) {

--- a/src/core/util/sys_vars.h
+++ b/src/core/util/sys_vars.h
@@ -156,7 +156,6 @@ public:
     char report_file_path[PATH_MAX]; // Tuning report output file path
     char cached_ofed_version[128]; // OFED version (populated at init, used at exit)
     struct timespec init_time_monotonic; // Monotonic clock at lib init (for process duration)
-    bool quick_start;
     vlog_levels_t log_level;
     uint32_t log_details;
     char log_filename[PATH_MAX];
@@ -398,7 +397,6 @@ extern const mce_sys_var &safe_mce_sys();
 #define SYS_VAR_HANDLE_SIGINTR      "XLIO_HANDLE_SIGINTR"
 #define SYS_VAR_HANDLE_SIGSEGV      "XLIO_HANDLE_SIGSEGV"
 #define SYS_VAR_STATS_FD_NUM        "XLIO_STATS_FD_NUM"
-#define SYS_VAR_QUICK_START         "XLIO_QUICK_START"
 
 #define SYS_VAR_RING_ALLOCATION_LOGIC_TX "XLIO_RING_ALLOCATION_LOGIC_TX"
 #define SYS_VAR_RING_ALLOCATION_LOGIC_RX "XLIO_RING_ALLOCATION_LOGIC_RX"
@@ -542,7 +540,6 @@ extern const mce_sys_var &safe_mce_sys();
 #define MCE_DEFAULT_HANDLE_SIGINTR           (true)
 #define MCE_DEFAULT_HANDLE_SIGFAULT          (false)
 #define MCE_DEFAULT_STATS_FD_NUM             (0)
-#define MCE_DEFAULT_QUICK_START              (false)
 #define MCE_DEFAULT_RING_ALLOCATION_LOGIC_TX (RING_LOGIC_PER_THREAD)
 #define MCE_DEFAULT_RING_ALLOCATION_LOGIC_RX (RING_LOGIC_PER_THREAD)
 #define MCE_DEFAULT_RING_MIGRATION_RATIO_TX  (-1)

--- a/src/core/util/sys_vars_configurator.cpp
+++ b/src/core/util/sys_vars_configurator.cpp
@@ -35,7 +35,6 @@ const config_var_info_t<bool> CONFIG_VAR_LOG_COLORS {"monitor.log.colors"};
 const config_var_info_t<bool> CONFIG_VAR_HANDLE_SIGINTR {"core.signals.sigint.exit"};
 const config_var_info_t<bool> CONFIG_VAR_HANDLE_SIGSEGV {"core.signals.sigsegv.backtrace"};
 const config_var_info_t<uint32_t, int64_t> CONFIG_VAR_STATS_FD_NUM {"monitor.stats.fd_num"};
-const config_var_info_t<bool> CONFIG_VAR_QUICK_START {"core.quick_init"};
 
 const config_var_info_t<ring_logic_t, int64_t> CONFIG_VAR_RING_ALLOCATION_LOGIC_TX {
     "performance.rings.tx.allocation_logic"};
@@ -385,8 +384,6 @@ void sys_var_configurator::initialize_base_variables()
     m_runtime_registry.register_char_array_and_set_default_value(
         m_sys_vars.report_file_path, sizeof(m_sys_vars.report_file_path),
         CONFIG_VAR_REPORT_FILE_PATH);
-    m_runtime_registry.register_and_set_default_value(&m_sys_vars.quick_start,
-                                                      CONFIG_VAR_QUICK_START);
 
     m_runtime_registry.register_and_set_default_value(&m_sys_vars.log_level, CONFIG_VAR_LOG_LEVEL);
     m_runtime_registry.register_and_set_default_value(&m_sys_vars.log_details,

--- a/tests/gtest/xlio_config_full_coverage.json
+++ b/tests/gtest/xlio_config_full_coverage.json
@@ -9,7 +9,6 @@
             "external_memory_limit": 0,
             "heap_metadata_block_size": 33554432
         },
-        "quick_init": false,
         "exception_handling": {
             "mode": -1
         },

--- a/tests/unit_tests/config/inline_loader.cpp
+++ b/tests/unit_tests/config/inline_loader.cpp
@@ -595,15 +595,14 @@ TEST_F(InlineLoaderTest, accepts_comma_and_range_in_value)
 TEST_F(InlineLoaderTest, accepts_valid_configuration_with_semicolons)
 {
     env_setter setter("XLIO_INLINE_CONFIG",
-                      "network.protocols.ip.mtu=1500;core.quick_init=true;core.log.file_path=/tmp");
+                      "network.protocols.ip.mtu=1500;core.log.file_path=/tmp");
     inline_loader loader("XLIO_INLINE_CONFIG", m_descriptor);
     ASSERT_NO_THROW(loader.load_all());
 
     std::map<std::string, std::experimental::any> data = loader.load_all();
 
-    ASSERT_EQ(data.size(), 3UL);
+    ASSERT_EQ(data.size(), 2UL);
     ASSERT_TRUE(data.find("network.protocols.ip.mtu") != data.end());
-    ASSERT_TRUE(data.find("core.quick_init") != data.end());
     ASSERT_TRUE(data.find("core.log.file_path") != data.end());
 }
 


### PR DESCRIPTION
## Description
The quick_init/XLIO_QUICK_START option allowed skipping hugepage residency verification to reduce initialization time by a few milliseconds. However, this created a dangerous failure mode: in containerized environments with cgroup hugepage limits, mmap() can succeed but subsequent memory access causes SIGBUS crashes.

The performance benefit (1-10ms at startup) does not justify the risk of cryptic crashes that are difficult to diagnose. XLIO now always verifies hugepages are resident via mincore() after allocation.

##### What
Remove quick_init parameter

##### Why ?
OOB experience.

##### How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc._

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

