### PR TITLE
issue: 4684689 Remove core.syscall.dup2_close_fd configuration option

### DIFF
--- a/docs/xlio_config_reference.md
+++ b/docs/xlio_config_reference.md
@@ -1,6 +1,6 @@
 # XLIO Configuration Reference
 
-This file documents all 121 XLIO runtime configuration parameters with their types, defaults, environment variables, and constraints.
+This file documents all 120 XLIO runtime configuration parameters with their types, defaults, environment variables, and constraints.
 
 > **Auto-generated** from the JSON schema by `generate_docs.py`. Do not edit manually.
 
@@ -27,7 +27,6 @@ This file documents all 121 XLIO runtime configuration parameters with their typ
   - [`core.signals.sigsegv.backtrace`](#coresignalssigsegvbacktrace) — Print backtrace on SIGSEGV
   - [`core.syscall.avoid_ctl_syscalls`](#coresyscallavoid_ctl_syscalls) — Avoid system control calls on TCP
   - [`core.syscall.deferred_close`](#coresyscalldeferred_close) — Defer closing of file descriptors
-  - [`core.syscall.dup2_close_fd`](#coresyscalldup2_close_fd) — Support dup2 calls
   - [`core.syscall.fork_support`](#coresyscallfork_support) — Enable fork support
   - [`core.syscall.sendfile_cache_limit`](#coresyscallsendfile_cache_limit) — Sendfile byte limit
 - **[HARDWARE_FEATURES](#hardware_features)**
@@ -664,27 +663,6 @@ incoming (accepted) TCP sockets are generally unaffected.
 or applications experiencing steering rule creation failures after socket close.
 
 **Default:** `false`
-
-### `core.syscall.dup2_close_fd`
-
-> **Type:** boolean
->
-> **Maps to:** `XLIO_CLOSE_ON_DUP2`
-
-When enabled, XLIO cleans up internal socket structures before dup2() forwards to the kernel.
-
-**How it works:**
-dup2(oldfd, newfd) atomically closes newfd and makes it a copy of oldfd.
-When newfd is an XLIO-managed socket, XLIO must release its internal resources first.
-
-**Tradeoffs:**
-
-- *true* (default): Small per-call overhead. Prevents resource leaks and undefined behavior
-  when dup2() closes XLIO sockets.
-- *false*: No interception overhead. Only safe if application never uses dup2() to close
-  XLIO-offloaded sockets; otherwise causes memory leaks and stale internal state.
-
-**Default:** `true`
 
 ### `core.syscall.fork_support`
 

--- a/src/core/config/config_var_definitions.h
+++ b/src/core/config/config_var_definitions.h
@@ -124,7 +124,6 @@ extern const config_var_info_t<size_t, int64_t> CONFIG_VAR_MEMORY_LIMIT_USER;
 extern const config_var_info_t<size_t, int64_t> CONFIG_VAR_HEAP_METADATA_BLOCK;
 extern const config_var_info_t<size_t, int64_t> CONFIG_VAR_HUGEPAGE_SIZE;
 extern const config_var_info_t<bool> CONFIG_VAR_FORK;
-extern const config_var_info_t<bool> CONFIG_VAR_CLOSE_ON_DUP2;
 extern const config_var_info_t<uint32_t, int64_t> CONFIG_VAR_MTU;
 #if defined(DEFINED_NGINX)
 extern const config_var_info_t<int, int64_t> CONFIG_VAR_NGINX_UDP_POOL_SIZE;

--- a/src/core/config/descriptor_providers/xlio_config_schema.json
+++ b/src/core/config/descriptor_providers/xlio_config_schema.json
@@ -176,12 +176,6 @@
                     "type": "object",
                     "description": "System call handling behavior.",
                     "properties": {
-                        "dup2_close_fd": {
-                            "type": "boolean",
-                            "default": true,
-                            "title": "Support dup2 calls",
-                            "description": "Maps to XLIO_CLOSE_ON_DUP2 environment variable.\nWhen enabled, XLIO cleans up internal socket structures before dup2() forwards to the kernel.\n\n**How it works:**\ndup2(oldfd, newfd) atomically closes newfd and makes it a copy of oldfd.\nWhen newfd is an XLIO-managed socket, XLIO must release its internal resources first.\n\n**Tradeoffs:**\n\n- *true* (default): Small per-call overhead. Prevents resource leaks and undefined behavior\n  when dup2() closes XLIO sockets.\n- *false*: No interception overhead. Only safe if application never uses dup2() to close\n  XLIO-offloaded sockets; otherwise causes memory leaks and stale internal state."
-                        },
                         "fork_support": {
                             "type": "boolean",
                             "default": true,

--- a/src/core/config/mappings.py
+++ b/src/core/config/mappings.py
@@ -18,7 +18,6 @@ config_mapping = {
     "core.syscall.allow_privileged_sockopt": "XLIO_ALLOW_PRIVILEGED_SOCK_OPT",
     "core.syscall.avoid_ctl_syscalls": "XLIO_AVOID_SYS_CALLS_ON_TCP_FD",
     "core.syscall.deferred_close": "XLIO_DEFERRED_CLOSE",
-    "core.syscall.dup2_close_fd": "XLIO_CLOSE_ON_DUP2",
     "core.syscall.fork_support": "XLIO_FORK",
     "core.syscall.sendfile_cache_limit": "XLIO_ZC_CACHE_THRESHOLD",
     

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -791,9 +791,6 @@ void print_env_vars_xlio_global_settings()
 #endif /* DEFINED_ENVOY */
     VLOG_PARAM_STRING("fork() support", safe_mce_sys().handle_fork, MCE_DEFAULT_FORK_SUPPORT,
                       SYS_VAR_FORK, safe_mce_sys().handle_fork ? "Enabled " : "Disabled");
-    VLOG_PARAM_STRING("close on dup2()", safe_mce_sys().close_on_dup2, MCE_DEFAULT_CLOSE_ON_DUP2,
-                      SYS_VAR_CLOSE_ON_DUP2,
-                      safe_mce_sys().close_on_dup2 ? "Enabled " : "Disabled");
     switch (safe_mce_sys().mtu) {
     case MTU_FOLLOW_INTERFACE:
         VLOG_PARAM_NUMSTR("MTU", safe_mce_sys().mtu, MCE_DEFAULT_MTU, SYS_VAR_MTU,

--- a/src/core/sock/sock-redirect.cpp
+++ b/src/core/sock/sock-redirect.cpp
@@ -2232,7 +2232,7 @@ EXPORT_SYMBOL int XLIO_SYMBOL(dup2)(int __fd, int __fd2)
 {
     PROFILE_FUNC
 
-    if (safe_mce_sys().close_on_dup2 && __fd != __fd2) {
+    if (__fd != __fd2) {
         srdr_logdbg("oldfd=%d, newfd=%d. Closing %d in XLIO.", __fd, __fd2, __fd2);
         handle_close(__fd2);
     }

--- a/src/core/util/sys_vars.cpp
+++ b/src/core/util/sys_vars.cpp
@@ -869,7 +869,6 @@ void mce_sys_var::get_env_params()
 #endif /* DEFINED_UTLS */
     enable_lro = MCE_DEFAULT_LRO;
     handle_fork = MCE_DEFAULT_FORK_SUPPORT;
-    close_on_dup2 = MCE_DEFAULT_CLOSE_ON_DUP2;
     mtu = MCE_DEFAULT_MTU;
 #if defined(DEFINED_NGINX)
     nginx_udp_socket_pool_size = MCE_DEFAULT_NGINX_UDP_POOL_SIZE;
@@ -1711,10 +1710,6 @@ void mce_sys_var::get_env_params()
 
     if ((env_ptr = getenv(SYS_VAR_LRO))) {
         enable_lro = option_3::from_str(env_ptr, MCE_DEFAULT_LRO);
-    }
-
-    if ((env_ptr = getenv(SYS_VAR_CLOSE_ON_DUP2))) {
-        close_on_dup2 = atoi(env_ptr) ? true : false;
     }
 
     if ((env_ptr = getenv(SYS_VAR_MTU))) {

--- a/src/core/util/sys_vars.h
+++ b/src/core/util/sys_vars.h
@@ -264,7 +264,6 @@ public:
     size_t heap_metadata_block;
     size_t hugepage_size;
     bool handle_fork;
-    bool close_on_dup2;
     uint32_t mtu; /* effective MTU. If mtu==0 then auto calculate the MTU */
     uint32_t lwip_cc_algo_mod;
     uint32_t lwip_mss;
@@ -483,7 +482,6 @@ extern const mce_sys_var &safe_mce_sys();
 #define SYS_VAR_HEAP_METADATA_BLOCK       "XLIO_HEAP_METADATA_BLOCK"
 #define SYS_VAR_HUGEPAGE_SIZE             "XLIO_HUGEPAGE_SIZE"
 #define SYS_VAR_FORK                      "XLIO_FORK"
-#define SYS_VAR_CLOSE_ON_DUP2             "XLIO_CLOSE_ON_DUP2"
 #define SYS_VAR_MTU                       "XLIO_MTU"
 #if defined(DEFINED_NGINX)
 #define SYS_VAR_NGINX_WORKERS_NUM                 "XLIO_NGINX_WORKERS_NUM"
@@ -631,7 +629,6 @@ extern const mce_sys_var &safe_mce_sys();
 #define MCE_DEFAULT_HUGEPAGE_SIZE                  (0)
 #define MCE_MAX_HUGEPAGE_SIZE                      (1ULL << 63ULL) - 1
 #define MCE_DEFAULT_FORK_SUPPORT                   (true)
-#define MCE_DEFAULT_CLOSE_ON_DUP2                  (true)
 #define MCE_DEFAULT_MTU                            (0)
 #if defined(DEFINED_NGINX)
 #define MCE_DEFAULT_NGINX_UDP_POOL_SIZE               (0)

--- a/src/core/util/sys_vars_configurator.cpp
+++ b/src/core/util/sys_vars_configurator.cpp
@@ -186,7 +186,6 @@ const config_var_info_t<size_t, int64_t> CONFIG_VAR_HEAP_METADATA_BLOCK {
     "core.resources.heap_metadata_block_size"};
 const config_var_info_t<size_t, int64_t> CONFIG_VAR_HUGEPAGE_SIZE {"core.resources.hugepages.size"};
 const config_var_info_t<bool> CONFIG_VAR_FORK {"core.syscall.fork_support"};
-const config_var_info_t<bool> CONFIG_VAR_CLOSE_ON_DUP2 {"core.syscall.dup2_close_fd"};
 const config_var_info_t<uint32_t, int64_t> CONFIG_VAR_MTU {"network.protocols.ip.mtu"};
 #if defined(DEFINED_NGINX)
 const config_var_info_t<int, int64_t> CONFIG_VAR_NGINX_UDP_POOL_SIZE {
@@ -608,8 +607,6 @@ void sys_var_configurator::initialize_base_variables()
 #endif /* DEFINED_UTLS */
     m_runtime_registry.register_and_set_default_value(&m_sys_vars.enable_lro, CONFIG_VAR_LRO);
     m_runtime_registry.register_and_set_default_value(&m_sys_vars.handle_fork, CONFIG_VAR_FORK);
-    m_runtime_registry.register_and_set_default_value(&m_sys_vars.close_on_dup2,
-                                                      CONFIG_VAR_CLOSE_ON_DUP2);
     m_runtime_registry.register_and_set_default_value(&m_sys_vars.mtu, CONFIG_VAR_MTU);
 #if defined(DEFINED_NGINX)
     m_runtime_registry.register_and_set_default_value(&m_sys_vars.nginx_udp_socket_pool_size,

--- a/tests/gtest/xlio_config_full_coverage.json
+++ b/tests/gtest/xlio_config_full_coverage.json
@@ -22,7 +22,6 @@
             }
         },
         "syscall": {
-            "dup2_close_fd": true,
             "fork_support": true,
             "deferred_close": false,
             "avoid_ctl_syscalls": false,


### PR DESCRIPTION
## Description
The dup2_close_fd option controlled whether XLIO cleans up internal state when dup2() implicitly closes the target fd.

Since:
- The default was already true (always enabled)
- The behavior is semantically correct (dup2 does close the target fd)
- The perf cost is negligible (array lookups when fd isn't accelerated)

There's no practical reason to allow disabling this behavior. Simplify the codebase by removing the option and always performing the close handling.

##### What
Remove core.syscall.dup2_close_fd configuration option

##### Why ?
OOB experience.

##### How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc._

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

