### PR TITLE
issue: 4892549 Fix UAF in ZCOPY TX callback during ring teardown

### DIFF
--- a/src/core/dev/ring_simple.cpp
+++ b/src/core/dev/ring_simple.cpp
@@ -846,6 +846,13 @@ int ring_simple::put_tx_buffer_helper(mem_buf_desc_t *buff)
     if (buff->lwip_pbuf.ref == 0) {
         descq_t &pool = buff->lwip_pbuf.type == PBUF_ZEROCOPY ? m_zc_pool : m_tx_pool;
         buff->p_next_desc = nullptr;
+
+        // Workaround for RM#4917604:
+        // During ring teardown, suppress ZCOPY completion callbacks to avoid
+        // use-after-free: the socket referenced by tx.zc.ctx has already been destroyed.
+        if (buff->lwip_pbuf.type == PBUF_ZEROCOPY && unlikely(!m_up_tx)) {
+            buff->m_flags &= ~mem_buf_desc_t::ZCOPY;
+        }
         free_lwip_pbuf(&buff->lwip_pbuf);
         pool.push_back(buff);
         return 1;


### PR DESCRIPTION
## Description
During poll_group destruction, sockets are closed before rings are released. When the ring tears down, it drains the TX completion queue and free_lwip_pbuf() fires the ZCOPY callback for outstanding buffers. This callback dereferences the socket (via tx.zc.ctx) which has already been freed, causing a use-after-free.

Suppress the ZCOPY completion callback during ring teardown by stripping the ZCOPY flag in put_tx_buffer_helper() when m_up_tx is false. The flag is already set to false in stop_active_queue_tx() before the CQ drain begins, so no new synchronization is needed.

##### What
Fix UAF in ZCOPY TX callback during ring teardown

##### Why ?
_Justification for the PR. If there is existing issue/bug please reference._

##### How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc._

## Change type
What kind of change does this PR introduce?
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

