### PR TITLE
issue: 4683517 Fallback to passthrough on entity-context connect failure

### DIFF
--- a/contrib/jenkins_tests/gtest.sh
+++ b/contrib/jenkins_tests/gtest.sh
@@ -136,6 +136,42 @@ rc=$(($rc+$?))
 eval "${sudo_cmd} $timeout_exe env XLIO_WORKER_THREADS=3 GTEST_TAP=2 LD_PRELOAD=$gtest_lib $gtest_app $gtest_opt --gtest_filter=$worker_threads_filter --gtest_output=xml:${WORKSPACE}/${prefix}/test-worker-threads-not-pow2.xml"
 rc=$(($rc+$?))
 
+# Passthrough tests
+
+passthrough_filter="tcp_listen_connect_nb.server_client_nb"
+
+# Passthrough via non-offloadable NIC (loopback)
+
+# worker threads mode
+gtest_opt_lo="--addr=127.0.0.1,127.0.0.1"
+eval "${sudo_cmd} $timeout_exe env XLIO_WORKER_THREADS=1 GTEST_TAP=2 LD_PRELOAD=$gtest_lib $gtest_app $gtest_opt_lo --gtest_filter=$passthrough_filter --gtest_output=xml:${WORKSPACE}/${prefix}/test-passthrough-loopback-wt.xml"
+rc=$(($rc+$?))
+
+# R2C mode
+eval "${sudo_cmd} $timeout_exe env GTEST_TAP=2 LD_PRELOAD=$gtest_lib $gtest_app $gtest_opt_lo --gtest_filter=$passthrough_filter --gtest_output=xml:${WORKSPACE}/${prefix}/test-passthrough-loopback-r2c.xml"
+rc=$(($rc+$?))
+
+###### Passthrough via XLIO offload rules
+
+
+# Create a temporary libxlio.conf with passthrough rules and point XLIO_CONFIG_FILE to it.
+server_ip=$(ip -f inet addr show net2 | awk '/inet / {print $2}' | cut -d/ -f1)
+passthrough_conf=$(mktemp /tmp/libxlio-passthrough-XXXXXX.conf)
+printf "use os tcp_client %s:*:*:*\nuse os tcp_server %s:*\n" "$server_ip" "$server_ip" > "$passthrough_conf"
+
+# worker threads mode
+eval "${sudo_cmd} $timeout_exe env XLIO_CONFIG_FILE=$passthrough_conf XLIO_WORKER_THREADS=1 GTEST_TAP=2 LD_PRELOAD=$gtest_lib $gtest_app $gtest_opt --gtest_filter=$passthrough_filter --gtest_output=xml:${WORKSPACE}/${prefix}/test-passthrough-rules-wt.xml"
+rc=$(($rc+$?))
+
+# R2C mode
+eval "${sudo_cmd} $timeout_exe env XLIO_CONFIG_FILE=$passthrough_conf GTEST_TAP=2 LD_PRELOAD=$gtest_lib $gtest_app $gtest_opt --gtest_filter=$passthrough_filter --gtest_output=xml:${WORKSPACE}/${prefix}/test-passthrough-rules-r2c.xml"
+rc=$(($rc+$?))
+
+rm -f "$passthrough_conf"
+###### End of Passthrough via XLIO offload rules
+
+
+
 eval "${sudo_cmd} pkill -9 ${prj_service} 2>/dev/null || true"
 
 set -eE

--- a/src/core/event/entity_context.cpp
+++ b/src/core/event/entity_context.cpp
@@ -35,6 +35,7 @@
 #include "entity_context.h"
 #include "vlogger/vlogger.h"
 #include "sock/sockinfo_tcp.h"
+#include "sock/sock-redirect.h"
 
 using namespace std::chrono;
 
@@ -125,6 +126,14 @@ void entity_context::connect_socket_job(const job_desc &job)
         sock->set_entity_context(this);
         add_socket(reinterpret_cast<sockinfo_tcp *>(sock));
         reinterpret_cast<sockinfo_tcp *>(sock)->connect_entity_context();
+        if (sock->isPassthrough()) {
+            int fd = sock->get_fd();
+            /* copy before handle_close may destroy sock */
+            sock_addr peer = sock->get_peername();
+            handle_close(fd, false, true);
+            SYSCALL(connect, fd, peer.get_p_sa(), peer.get_socklen());
+            return;
+        }
         ++m_stats.socket_num_added;
         ctx_logdbg("New TCP socket added (sock: %p)", sock);
     } else {
@@ -198,7 +207,7 @@ void entity_context::close_socket_job(const job_desc &job)
             sockinfo_tcp *parent = tcp_si->get_listen_context()->get_parent_listen_socket();
             parent->get_listen_context()->increment_finish_counter();
             --m_stats.listen_rsschild_num;
-        } else {
+        } else if (!tcp_si->isPassthrough()) {
             ++m_stats.socket_num_removed;
         }
         // Use poll_group::close_socket_helper which handles :

--- a/src/core/sock/sockinfo.h
+++ b/src/core/sock/sockinfo.h
@@ -312,6 +312,7 @@ public:
     bool has_epoll_context() { return (!!m_econtext); }
     bool get_rx_pkt_ready_list_count() const { return m_n_rx_pkt_ready_list_count; }
     int get_fd() const { return m_fd; };
+    const sock_addr &get_peername() const { return m_connected; }
     sa_family_t get_family() { return m_family; }
     bool get_reuseaddr(void) { return m_reuseaddr; }
     bool get_reuseport(void) { return m_reuseport; }


### PR DESCRIPTION
On connect run-time (e.g. tx/rx ring creation failure) failure in worker-thread mode, fall back to passthrough
(handle_close + SYSCALL(connect)) instead of failing the connection.

## Description
Please provide a summary of the change.

##### What
_Subject: what this PR is doing in one line._ 

##### Why ?
_Justification for the PR. If there is existing issue/bug please reference._

##### How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc._

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

