### PR TITLE
issue: 4896482 Optimize remove_from_all_epfds to avoid epfd lock cont…

### DIFF
--- a/src/core/iomux/epfd_info.cpp
+++ b/src/core/iomux/epfd_info.cpp
@@ -114,6 +114,13 @@ epfd_info::~epfd_info()
         BULLSEYE_EXCLUDE_BLOCK_END
     }
 
+    // Clear m_non_offloaded_epfd_map for all non-offloaded fds in this epfd
+    if (g_p_fd_collection) {
+        for (const auto &entry : m_fd_non_offloaded_map) {
+            g_p_fd_collection->clear_non_offloaded_epfd(entry.first, this);
+        }
+    }
+
     unlock();
 
     xlio_stats_instance_remove_epoll_block(&m_stats->stats);
@@ -294,6 +301,9 @@ int epfd_info::add_fd(int fd, epoll_event *event)
     } else {
         fd_rec.offloaded_index = -1;
         m_fd_non_offloaded_map[fd] = fd_rec;
+        if (g_p_fd_collection) {
+            g_p_fd_collection->set_non_offloaded_epfd(fd, this);
+        }
     }
 
     __log_func("fd %d added in epfd %d with events=%#x and data=%#x", fd, m_epfd, event->events,
@@ -439,6 +449,9 @@ int epfd_info::del_fd(int fd, bool passthrough)
             // This can happen after bind(), listen() or accept() calls.
             m_fd_non_offloaded_map[fd] = *fi;
             m_fd_non_offloaded_map[fd].offloaded_index = -1;
+            if (g_p_fd_collection) {
+                g_p_fd_collection->set_non_offloaded_epfd(fd, this);
+            }
         }
 
         remove_socket_from_ready_list(temp_sock_fd_api);
@@ -466,6 +479,9 @@ int epfd_info::del_fd(int fd, bool passthrough)
         fd_info_map_t::iterator fd_iter = m_fd_non_offloaded_map.find(fd);
         if (fd_iter != m_fd_non_offloaded_map.end()) {
             m_fd_non_offloaded_map.erase(fd_iter);
+            if (g_p_fd_collection) {
+                g_p_fd_collection->clear_non_offloaded_epfd(fd, this);
+            }
         }
     }
 

--- a/src/core/sock/fd_collection.cpp
+++ b/src/core/sock/fd_collection.cpp
@@ -562,15 +562,89 @@ int fd_collection::del_socket(int fd, sockinfo **map_type)
     return -1;
 }
 
-void fd_collection::remove_from_all_epfds(int fd, bool passthrough)
+void fd_collection::set_non_offloaded_epfd(int fd, epfd_info *epfd)
 {
     lock();
-    for (epfd_info *ep = m_epfd_lst.front(); ep; ep = m_epfd_lst.next(ep)) {
-        ep->fd_closed(fd, passthrough);
+    auto it = m_non_offloaded_epfd_map.find(fd);
+    if (it == m_non_offloaded_epfd_map.end()) {
+        m_non_offloaded_epfd_map[fd] = epfd;
+        fdcoll_logdbg("fd=%d added to non_offloaded_epfd_map (epfd=%d)", fd, epfd->get_epoll_fd());
+    } else if (it->second != epfd && it->second != multi_epfd_sentinel()) {
+        fdcoll_logdbg("fd=%d in multiple epfds, marking as multi-epfd sentinel", fd);
+        it->second = multi_epfd_sentinel();
     }
     unlock();
+}
 
-    return;
+void fd_collection::clear_non_offloaded_epfd(int fd, epfd_info *epfd)
+{
+    lock();
+    auto it = m_non_offloaded_epfd_map.find(fd);
+    if (it != m_non_offloaded_epfd_map.end() && it->second == epfd) {
+        m_non_offloaded_epfd_map.erase(it);
+        fdcoll_logdbg("fd=%d cleared from non_offloaded_epfd_map (epfd=%d)", fd,
+                      epfd->get_epoll_fd());
+    }
+    // If multi_epfd_sentinel(), we can't know if other epfds still reference it, so leave it.
+    // It will be cleared when all epfds remove this fd or on fd reuse.
+    unlock();
+}
+
+epfd_info *fd_collection::get_non_offloaded_epfd(int fd)
+{
+    lock();
+    auto it = m_non_offloaded_epfd_map.find(fd);
+    epfd_info *result = (it != m_non_offloaded_epfd_map.end()) ? it->second : nullptr;
+    unlock();
+    return result;
+}
+
+void fd_collection::remove_from_all_epfds(int fd, bool passthrough)
+{
+    fdcoll_logfunc("fd=%d passthrough=%d", fd, passthrough);
+
+    // Fast path for offloaded sockets:
+    // XLIO limits each socket to at most one epfd, tracked by m_econtext.
+    // Target that epfd directly instead of walking the entire list
+    // and contending on every epfd_info lock.
+    sockinfo *sockfd = get_sockfd(fd);
+    if (sockfd) {
+        epfd_info *ep = sockfd->get_epoll_context();
+        if (ep) {
+            fdcoll_logdbg("fd=%d offloaded socket fast path: epfd=%d", fd, ep->get_epoll_fd());
+            ep->fd_closed(fd, passthrough);
+        } else {
+            fdcoll_logdbg("fd=%d offloaded socket not in any epfd", fd);
+        }
+        return;
+    }
+
+    // Non-offloaded fd path:
+    lock();
+
+    auto it = m_non_offloaded_epfd_map.find(fd);
+    if (it == m_non_offloaded_epfd_map.end()) {
+        fdcoll_logdbg("fd=%d not in non_offloaded_epfd_map, skipping", fd);
+        unlock();
+        return;
+    }
+
+    epfd_info *epfd = it->second;
+    m_non_offloaded_epfd_map.erase(it);
+
+    if (epfd != multi_epfd_sentinel()) {
+        // Fast path: fd is in exactly one epfd
+        fdcoll_logdbg("fd=%d non-offloaded fast path: single epfd=%d", fd, epfd->get_epoll_fd());
+        epfd->fd_closed(fd, passthrough);
+    } else {
+        // Slow path: fd is in multiple epfds, walk all
+        fdcoll_logdbg("fd=%d non-offloaded slow path: walking all epfds (multi-epfd case)", fd);
+        for (epfd_info *ep = m_epfd_lst.front(); ep; ep = m_epfd_lst.next(ep)) {
+            ep->fd_closed(fd, passthrough);
+        }
+    }
+
+    unlock();
 }
 
 #if defined(DEFINED_NGINX)

--- a/src/core/sock/fd_collection.h
+++ b/src/core/sock/fd_collection.h
@@ -185,6 +185,18 @@ private:
     epfd_info **m_p_epfd_map;
     cq_channel_info **m_p_cq_channel_map;
 
+    // Reverse-index: maps fd -> epfd for non-offloaded fds.
+    // Value is the epfd_info* that contains the fd, or multi_epfd_sentinel() if in multiple epfds.
+    std::unordered_map<int, epfd_info *> m_non_offloaded_epfd_map;
+
+public:
+    static inline epfd_info *multi_epfd_sentinel() { return reinterpret_cast<epfd_info *>(1); }
+
+    void set_non_offloaded_epfd(int fd, epfd_info *epfd);
+    void clear_non_offloaded_epfd(int fd, epfd_info *epfd);
+    epfd_info *get_non_offloaded_epfd(int fd);
+
+private:
     epfd_info_list_t m_epfd_lst;
     // Contains fds which are in closing process
     sockinfo_list_t m_pending_to_remove_lst;

--- a/src/core/sock/sockinfo.h
+++ b/src/core/sock/sockinfo.h
@@ -330,6 +330,7 @@ public:
     int add_epoll_context(epfd_info *epfd);
     void remove_epoll_context(epfd_info *epfd);
     int get_epoll_context_fd();
+    epfd_info *get_epoll_context() { return m_econtext; }
 
     // Calling OS transmit
     ssize_t tx_os(const tx_call_t call_type, const iovec *p_iov, const ssize_t sz_iov,


### PR DESCRIPTION
…ention

Problem:
On every close(), XLIO calls remove_from_all_epfds(fd) which walks all epfds and takes each epfd_info lock to check if the fd needs removal. This causes lock contention when other threads hold epfd_info locks (e.g., worker thread mode harvesting child epfds, epoll_wait operations).

Solution:
Add a reverse-index map (fd -> epfd) to enable O(1) lookup instead of walking all epfds:

1. For offloaded sockets: Use existing m_econtext to directly find the single epfd containing the socket (XLIO limits sockets to one epfd).

2. For non-offloaded fds: Maintain m_non_offloaded_epfd_map in fd_collection that maps fd to its containing epfd. Use a sentinel value to indicate rare multi-epfd subscirption case requiring fallback walk.

3. Skip entirely for fds not in any epfd.

Changes:
- fd_collection: Add m_non_offloaded_epfd_map and helper methods
- epfd_info: Update add_fd/del_fd/destructor to maintain reverse-index
- remove_from_all_epfds: Use fast paths, only walk all epfds when fd is in multiple epfds (rare sentinel case)

## Description
Please provide a summary of the change.

##### What
_Subject: what this PR is doing in one line._ 

##### Why ?
_Justification for the PR. If there is existing issue/bug please reference._

##### How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc._

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

