### PR TITLE
issue: 4896482 Optimize remove_from_all_epfds lock contention

### DIFF
--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -337,6 +337,7 @@ libxlio_la_SOURCES := \
 	util/list.h \
 	util/cached_obj_pool.h \
 	util/sg_array.h \
+	util/sharded_map.h \
 	util/ip_address.h \
 	util/sock_addr.h \
 	util/sysctl_reader.h \

--- a/src/core/iomux/epfd_info.cpp
+++ b/src/core/iomux/epfd_info.cpp
@@ -294,6 +294,7 @@ int epfd_info::add_fd(int fd, epoll_event *event)
     } else {
         fd_rec.offloaded_index = -1;
         m_fd_non_offloaded_map[fd] = fd_rec;
+        g_p_fd_collection->add_non_offloaded_fd(fd, this);
     }
 
     __log_func("fd %d added in epfd %d with events=%#x and data=%#x", fd, m_epfd, event->events,
@@ -439,6 +440,7 @@ int epfd_info::del_fd(int fd, bool passthrough)
             // This can happen after bind(), listen() or accept() calls.
             m_fd_non_offloaded_map[fd] = *fi;
             m_fd_non_offloaded_map[fd].offloaded_index = -1;
+            g_p_fd_collection->add_non_offloaded_fd(fd, this);
         }
 
         remove_socket_from_ready_list(temp_sock_fd_api);
@@ -466,6 +468,7 @@ int epfd_info::del_fd(int fd, bool passthrough)
         fd_info_map_t::iterator fd_iter = m_fd_non_offloaded_map.find(fd);
         if (fd_iter != m_fd_non_offloaded_map.end()) {
             m_fd_non_offloaded_map.erase(fd_iter);
+            g_p_fd_collection->remove_non_offloaded_fd(fd, this);
         }
     }
 

--- a/src/core/sock/fd_collection.cpp
+++ b/src/core/sock/fd_collection.cpp
@@ -29,6 +29,9 @@
 #define fdcoll_logdbg     __log_dbg
 #define fdcoll_logfunc    __log_func
 
+// Sentinel value indicating fd is mapped to multiple epfds (caller should walk all)
+#define MULTI_EPFD_SENTINEL reinterpret_cast<epfd_info *>(1)
+
 fd_collection *g_p_fd_collection = nullptr;
 
 fd_collection::fd_collection()
@@ -506,6 +509,7 @@ int fd_collection::del_epfd(int fd, bool b_cleanup /*=false*/)
 
 void fd_collection::remove_epfd_from_list(epfd_info *epfd)
 {
+    m_non_offloaded_epfd_map.remove_all_for_value(epfd);
     lock();
     m_epfd_lst.erase(epfd);
     unlock();
@@ -562,15 +566,53 @@ int fd_collection::del_socket(int fd, sockinfo **map_type)
     return -1;
 }
 
+void fd_collection::add_non_offloaded_fd(int fd, epfd_info *epfd)
+{
+    m_non_offloaded_epfd_map.add_or_replace(fd, epfd, MULTI_EPFD_SENTINEL);
+    fdcoll_logdbg("fd=%d epfd=%p add_non_offloaded_fd", fd, epfd);
+}
+
+void fd_collection::remove_non_offloaded_fd(int fd, epfd_info *epfd)
+{
+    m_non_offloaded_epfd_map.remove_if_equals(fd, epfd);
+}
+
 void fd_collection::remove_from_all_epfds(int fd, bool passthrough)
 {
+    fdcoll_logfunc("fd=%d passthrough=%d", fd, passthrough);
+
+    // Hold lock to prevent epfd destruction while we use it.
+    // del_epfd() takes this lock before destroying epfd_info.
     lock();
-    for (epfd_info *ep = m_epfd_lst.front(); ep; ep = m_epfd_lst.next(ep)) {
-        ep->fd_closed(fd, passthrough);
+
+    // Offloaded sockets: use m_econtext (limited to one epfd)
+    sockinfo *sockfd = get_sockfd(fd);
+    if (sockfd) {
+        epfd_info *ep = sockfd->get_epoll_context();
+        if (ep) {
+            ep->fd_closed(fd, passthrough);
+        }
+        unlock();
+        return;
+    }
+
+    // Non-offloaded fds: use sharded map
+    epfd_info *epfd = m_non_offloaded_epfd_map.remove_and_get(fd, nullptr);
+    if (!epfd) {
+        fdcoll_logdbg("fd=%d not in non_offloaded_epfd_map", fd);
+        unlock();
+        return;
+    }
+
+    if (epfd != MULTI_EPFD_SENTINEL) {
+        epfd->fd_closed(fd, passthrough);
+    } else {
+        // fd is in multiple epfds: walk all
+        for (epfd_info *ep = m_epfd_lst.front(); ep; ep = m_epfd_lst.next(ep)) {
+            ep->fd_closed(fd, passthrough);
+        }
     }
     unlock();
-
-    return;
 }
 
 #if defined(DEFINED_NGINX)

--- a/src/core/sock/fd_collection.h
+++ b/src/core/sock/fd_collection.h
@@ -17,6 +17,7 @@
 #include "sock/sockinfo.h"
 #include "iomux/epfd_info.h"
 #include "utils/lock_wrapper.h"
+#include <util/sharded_map.h>
 
 typedef xlio_list_t<sockinfo, sockinfo::pending_to_remove_node_offset> sockinfo_list_t;
 typedef xlio_list_t<epfd_info, epfd_info::epfd_info_node_offset> epfd_info_list_t;
@@ -157,6 +158,10 @@ public:
      */
     void statistics_print(int fd, vlog_levels_t log_level);
 
+    // Add/remove non-offloaded fd->epfd mapping (called from epfd_info)
+    void add_non_offloaded_fd(int fd, epfd_info *epfd);
+    void remove_non_offloaded_fd(int fd, epfd_info *epfd);
+
 #if defined(DEFINED_NGINX)
     bool pop_socket_pool(int &fd, bool &add_to_udp_pool, int type);
     void push_socket_pool(sockinfo *sockfd);
@@ -188,6 +193,9 @@ private:
     epfd_info_list_t m_epfd_lst;
     // Contains fds which are in closing process
     sockinfo_list_t m_pending_to_remove_lst;
+
+    // Sharded map for non-offloaded fd -> epfd reverse lookup.
+    sharded_map<int, epfd_info *> m_non_offloaded_epfd_map;
 
     const bool m_b_sysvar_offloaded_sockets;
 

--- a/src/core/sock/sockinfo.h
+++ b/src/core/sock/sockinfo.h
@@ -330,6 +330,7 @@ public:
     int add_epoll_context(epfd_info *epfd);
     void remove_epoll_context(epfd_info *epfd);
     int get_epoll_context_fd();
+    epfd_info *get_epoll_context() { return m_econtext; }
 
     // Calling OS transmit
     ssize_t tx_os(const tx_call_t call_type, const iovec *p_iov, const ssize_t sz_iov,

--- a/src/core/util/sharded_map.h
+++ b/src/core/util/sharded_map.h
@@ -1,0 +1,129 @@
+/*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+ * Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: GPL-2.0-only or BSD-2-Clause
+ */
+
+#ifndef SHARDED_MAP_H
+#define SHARDED_MAP_H
+
+#include <unordered_map>
+#include <functional>
+#include <utils/lock_wrapper.h>
+
+/**
+ * A sharded map that distributes entries across multiple buckets to reduce lock contention.
+ * Each bucket has its own lock, so operations on different buckets can proceed in parallel.
+ *
+ * @tparam Key    The key type
+ * @tparam Value  The value type
+ * @tparam N      Number of buckets
+ */
+template <typename Key, typename Value, size_t N = 1024> class sharded_map {
+public:
+    sharded_map() = default;
+    ~sharded_map() = default;
+
+    /**
+     * Adds a key->value mapping.
+     * If key already exists with the same value, does nothing.
+     * If key already exists with a different value, replaces its value with replace_with.
+     * @return true if this is a new entry, false if key already existed
+     */
+    bool add_or_replace(const Key &key, Value value, Value replace_with)
+    {
+        size_t idx = bucket_index(key);
+        bucket_t &b = m_buckets[idx];
+
+        b.lock.lock();
+        auto it = b.map.find(key);
+        if (it == b.map.end()) {
+            b.map[key] = value;
+            b.lock.unlock();
+            return true;
+        } else if (it->second != value && it->second != replace_with) {
+            it->second = replace_with;
+        }
+        b.lock.unlock();
+        return false;
+    }
+
+    /**
+     * Remove a specific key->value mapping.
+     * Only removes if the current value equals the specified value.
+     * @return true if entry was removed, false otherwise
+     */
+    bool remove_if_equals(const Key &key, Value value)
+    {
+        size_t idx = bucket_index(key);
+        bucket_t &b = m_buckets[idx];
+
+        b.lock.lock();
+        auto it = b.map.find(key);
+        if (it != b.map.end() && it->second == value) {
+            b.map.erase(it);
+            b.lock.unlock();
+            return true;
+        }
+        b.lock.unlock();
+        return false;
+    }
+
+    /**
+     * Atomically remove and return the value for a key.
+     * @param not_found Value to return if key is not found
+     * @return The value that was stored, or not_found if key was not present
+     */
+    Value remove_and_get(const Key &key, Value not_found)
+    {
+        size_t idx = bucket_index(key);
+        bucket_t &b = m_buckets[idx];
+
+        b.lock.lock();
+        auto it = b.map.find(key);
+        if (it == b.map.end()) {
+            b.lock.unlock();
+            return not_found;
+        }
+        Value result = it->second;
+        b.map.erase(it);
+        b.lock.unlock();
+        return result;
+    }
+
+    /**
+     * Remove all entries that have a specific value.
+     * @param value The value to remove
+     * @return Number of entries removed
+     */
+    size_t remove_all_for_value(Value value)
+    {
+        size_t removed = 0;
+        for (size_t i = 0; i < N; ++i) {
+            bucket_t &b = m_buckets[i];
+            b.lock.lock();
+            for (auto it = b.map.begin(); it != b.map.end();) {
+                if (it->second == value) {
+                    it = b.map.erase(it);
+                    ++removed;
+                } else {
+                    ++it;
+                }
+            }
+            b.lock.unlock();
+        }
+        return removed;
+    }
+
+private:
+    struct bucket_t {
+        std::unordered_map<Key, Value> map;
+        lock_mutex lock;
+    };
+
+    bucket_t m_buckets[N];
+
+    static size_t bucket_index(const Key &key) { return std::hash<Key> {}(key) % N; }
+};
+
+#endif // SHARDED_MAP_H


### PR DESCRIPTION
On every close(), XLIO calls remove_from_all_epfds(fd), which walked all epfds and took each epfd_info lock to check if the fd needs removal. This caused lock contention when other threads held epfd_info locks.

Solution:
- Offloaded sockets: Use existing m_econtext for  epfd lookup
- Non-offloaded fds: Use sharded map for lookup Add a sharded map (1024 buckets) to track non-offloaded fd->epfd mappings. Each bucket has its own lock, reducing contention by distributing entries.
- Multi-epfd case: Fall back to walking all epfds (rare)

Changes:
- Add src/core/util/sharded_map.h: Generic sharded map template class
- epfd_info: Maintain sharded map on epoll_ctl ADD/DEL and epfd close
- close(): Update remove_from_all_epfds function

## Description
Please provide a summary of the change.

##### What
_Subject: what this PR is doing in one line._ 

##### Why ?
_Justification for the PR. If there is existing issue/bug please reference._

##### How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc._

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

