### PR TITLE
[CI] issue: HPCINFRA-4279 Git clone fails over permissions

### DIFF
--- a/.ci/blackduck_source.sh
+++ b/.ci/blackduck_source.sh
@@ -15,7 +15,7 @@ json=$(jq -n \
 
 export SPRING_APPLICATION_JSON="$json"
 export PROJECT_NAME=libxlio
-export PROJECT_VERSION="$sha1"
+export PROJECT_VERSION=${release_tag:-${sha1}}
 export PROJECT_SRC_PATH="$topdir"/
 
 echo "Running BlackDuck (SRC) on $name"

--- a/.ci/pipeline/release_matrix_job.yaml
+++ b/.ci/pipeline/release_matrix_job.yaml
@@ -62,7 +62,7 @@ steps:
     containerSelector:
       - "{name: 'rhel8.6'}"
     run: |
-      git clone https://github.com/Mellanox/libdpcp.git libdpcp
+      git clone git@github.com:Mellanox/libdpcp.git libdpcp
       cd libdpcp
       ./autogen.sh && ./configure --prefix=/usr && sudo make install
 


### PR DESCRIPTION
## Description
The git clone in the release pipeline is attempting to use the svc user's credentials to clone the public repository of libdpcp, causing permissions denied.

##### What
Swapping from clonning over HTTPS to clonning over SSH

##### Why ?
[HPCINFRA-4279](https://jirasw.nvidia.com/browse/HPCINFRA-4279)

##### How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc._

## Change type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

