### PR TITLE
issue: 4043231 Fix keepalive abort to honor TCP_USER_TIMEOUT

### DIFF
--- a/src/core/lwip/opt.h
+++ b/src/core/lwip/opt.h
@@ -195,15 +195,6 @@
    ---------- Socket options ----------
    ------------------------------------
 */
-/**
- * LWIP_TCP_KEEPALIVE==1: Enable TCP_KEEPIDLE, TCP_KEEPINTVL and TCP_KEEPCNT
- * options processing. Note that TCP_KEEPIDLE and TCP_KEEPINTVL have to be set
- * in seconds. (does not require sockets.c, and will affect tcp.c)
- */
-#ifndef LWIP_TCP_KEEPALIVE
-#define LWIP_TCP_KEEPALIVE 0
-#endif
-
 /* Platform endianness */
 #if !defined(__BYTE_ORDER__) || !defined(__ORDER_LITTLE_ENDIAN__) || !defined(__ORDER_BIG_ENDIAN__)
 #warning "__BYTE_ORDER__ or __ORDER_..._ENDIAN__ is not defined"

--- a/src/core/lwip/tcp.c
+++ b/src/core/lwip/tcp.c
@@ -642,6 +642,18 @@ void tcp_slowtmr(struct tcp_pcb *pcb)
                      * update without sending any data (which will force us to split the segment).
                      * tcp_zero_window_probe(pcb); */
                     tcp_keepalive(pcb);
+                    /* Anchor the TCP_USER_TIMEOUT clock for this zero-window /
+                     * persist probe: there is pending send data that cannot be
+                     * delivered because the peer's advertised window is closed.
+                     * This preserves the pre-existing behavior of aborting a
+                     * persist-stuck connection after user_timeout via
+                     * tcp_user_timeout_occured(). Pure keepalive probes (the
+                     * SOF_KEEPALIVE branch below) intentionally do NOT anchor
+                     * this - an idle connection has no unacknowledged data, so
+                     * its user_timeout is measured from last_progress_tmr. */
+                    if (pcb->ticks_since_data_sent == -1) {
+                        pcb->ticks_since_data_sent = 0;
+                    }
                 }
             } else {
                 /* Increase the retransmission timer if it is running */
@@ -714,13 +726,31 @@ void tcp_slowtmr(struct tcp_pcb *pcb)
         /* Check if KEEPALIVE should be sent */
         if ((pcb->so_options & SOF_KEEPALIVE) &&
             ((get_tcp_state(pcb) == ESTABLISHED) || (get_tcp_state(pcb) == CLOSE_WAIT))) {
-#if LWIP_TCP_KEEPALIVE
-            if ((u32_t)(tcp_ticks - pcb->tmr) >
-                tcp_ms_to_ticks(pcb->keep_idle + pcb->keep_cnt * pcb->keep_intvl))
-#else
-            if ((u32_t)(tcp_ticks - pcb->tmr) > tcp_ms_to_ticks(pcb->keep_idle + TCP_MAXIDLE))
-#endif /* LWIP_TCP_KEEPALIVE */
-            {
+            u32_t ka_elapsed = (u32_t)(tcp_ticks - pcb->tmr);
+            u8_t ka_abort = 0;
+
+            if (pcb->user_timeout_ms != 0) {
+                /* TCP_USER_TIMEOUT: abort once user_timeout has elapsed since the
+                 * connection last made forward progress (in-sequence data
+                 * received or new data acknowledged), NOT since pcb->tmr.
+                 * pcb->tmr is bumped by every received segment - including a
+                 * keepalive-probe reply (a bare dup-ACK) - which would push the
+                 * deadline out to keep_idle + user_timeout instead of just
+                 * user_timeout. last_progress_tmr is immune to those probe
+                 * replies, matching Linux tcp_keepalive_timer(), which measures
+                 * the keepalive elapsed from rcv_tstamp/lrcvtime. The keep_idle
+                 * guard ensures a probe has been attempted before we abort an
+                 * otherwise-idle connection (relevant when user_timeout is
+                 * shorter than keep_idle). */
+                u32_t ut_elapsed = (u32_t)(tcp_ticks - pcb->last_progress_tmr);
+                ka_abort = (ut_elapsed >= tcp_ms_to_ticks(pcb->user_timeout_ms)) &&
+                    (ut_elapsed >= tcp_ms_to_ticks(pcb->keep_idle));
+            } else {
+                ka_abort = (ka_elapsed >
+                            tcp_ms_to_ticks(pcb->keep_idle + pcb->keep_cnt * pcb->keep_intvl));
+            }
+
+            if (ka_abort) {
                 LWIP_DEBUGF_IP_ADDR(TCP_DEBUG,
                                     "tcp_slowtmr: KEEPALIVE timeout. Aborting connection to ",
                                     pcb->remote_ip, pcb->is_ipv6);
@@ -728,17 +758,12 @@ void tcp_slowtmr(struct tcp_pcb *pcb)
                 ++pcb_remove;
                 err = ERR_TIMEOUT;
                 ++pcb_reset;
-            }
-#if LWIP_TCP_KEEPALIVE
-            else if ((u32_t)(tcp_ticks - pcb->tmr) >
-                     tcp_ms_to_ticks(pcb->keep_idle + pcb->keep_cnt_sent * pcb->keep_intvl))
-#else
-            else if ((u32_t)(tcp_ticks - pcb->tmr) >
-                     tcp_ms_to_ticks(pcb->keep_idle + pcb->keep_cnt_sent * TCP_KEEPINTVL_DEFAULT))
-#endif /* LWIP_TCP_KEEPALIVE */
-            {
+            } else if (ka_elapsed >
+                       tcp_ms_to_ticks(pcb->keep_idle + pcb->keep_cnt_sent * pcb->keep_intvl)) {
                 tcp_keepalive(pcb);
-                pcb->keep_cnt_sent++;
+                if (pcb->keep_cnt_sent < UINT8_MAX) {
+                    pcb->keep_cnt_sent++;
+                }
             }
         }
 
@@ -967,6 +992,7 @@ void tcp_pcb_init(struct tcp_pcb *pcb, u8_t prio, void *container)
     pcb->lastack = iss;
     pcb->snd_lbb = iss;
     pcb->tmr = tcp_ticks;
+    pcb->last_progress_tmr = tcp_ticks;
     pcb->snd_sml_snt = 0;
     pcb->snd_sml_add = 0;
 
@@ -975,11 +1001,8 @@ void tcp_pcb_init(struct tcp_pcb *pcb, u8_t prio, void *container)
 
     /* Init KEEPALIVE timer */
     pcb->keep_idle = TCP_KEEPIDLE_DEFAULT;
-
-#if LWIP_TCP_KEEPALIVE
     pcb->keep_intvl = TCP_KEEPINTVL_DEFAULT;
     pcb->keep_cnt = TCP_KEEPCNT_DEFAULT;
-#endif /* LWIP_TCP_KEEPALIVE */
 
     pcb->keep_cnt_sent = 0;
     pcb->quickack = 0;
@@ -1016,6 +1039,7 @@ void tcp_pcb_recycle(struct tcp_pcb *pcb)
     pcb->lastack = iss;
     pcb->snd_lbb = iss;
     pcb->tmr = tcp_ticks;
+    pcb->last_progress_tmr = tcp_ticks;
     pcb->snd_sml_snt = 0;
     pcb->snd_sml_add = 0;
     pcb->tcp_timer = 0;
@@ -1296,13 +1320,8 @@ u16_t tcp_send_mss(struct tcp_pcb *pcb)
 void tcp_set_keepalive(struct tcp_pcb *pcb, u32_t idle, u32_t intvl, u32_t cnt)
 {
     pcb->keep_idle = idle;
-#if LWIP_TCP_KEEPALIVE
     pcb->keep_intvl = intvl;
     pcb->keep_cnt = cnt;
-#else
-    (void)intvl;
-    (void)cnt;
-#endif /* LWIP_TCP_KEEPALIVE */
 }
 
 #if TCP_DEBUG || TCP_INPUT_DEBUG || TCP_OUTPUT_DEBUG

--- a/src/core/lwip/tcp.h
+++ b/src/core/lwip/tcp.h
@@ -306,6 +306,13 @@ struct tcp_pcb {
     u8_t tcp_timer; /* Timer counter to handle calling slow-timer from tcp_tmr() */
     u32_t tmr;
 
+    /* tcp_ticks at the last forward progress: in-sequence data received or new
+     * data acknowledged. Unlike tmr, it is NOT advanced by keepalive-probe
+     * replies (bare dup-ACKs that neither carry data nor acknowledge new data),
+     * so it is the correct reference for the TCP_USER_TIMEOUT keepalive abort
+     * (mirrors Linux tcp_keepalive_timer(), which measures from rcv_tstamp). */
+    u32_t last_progress_tmr;
+
     /* Retransmission timer. */
     s16_t rtime;
 
@@ -379,10 +386,8 @@ struct tcp_pcb {
 
     /* idle time before KEEPALIVE is sent */
     u32_t keep_idle;
-#if LWIP_TCP_KEEPALIVE
     u32_t keep_intvl;
     u32_t keep_cnt;
-#endif /* LWIP_TCP_KEEPALIVE */
 
     /* Persist timer counter */
     u32_t persist_cnt;

--- a/src/core/lwip/tcp_impl.h
+++ b/src/core/lwip/tcp_impl.h
@@ -116,8 +116,9 @@ void set_tmr_resolution(u32_t v);
 #define TCP_HLEN 20
 #endif
 
-#define TCP_FIN_WAIT_TIMEOUT 20000 /* milliseconds */
-#define TCP_SYN_RCVD_TIMEOUT 20000 /* milliseconds */
+#define TCP_FIN_WAIT_TIMEOUT    20000 /* milliseconds */
+#define TCP_SYN_RCVD_TIMEOUT    20000 /* milliseconds */
+#define TCP_USER_TIMEOUT_MAX_MS 1966020000U /* RFC 5482 max: 32767 minutes in ms */
 
 #define TCP_OOSEQ_TIMEOUT 6U /* x RTO */
 
@@ -137,8 +138,6 @@ void set_tmr_resolution(u32_t v);
 #ifndef TCP_KEEPCNT_DEFAULT
 #define TCP_KEEPCNT_DEFAULT 9U /* Default Counter for KEEPALIVE probes */
 #endif
-
-#define TCP_MAXIDLE TCP_KEEPCNT_DEFAULT *TCP_KEEPINTVL_DEFAULT /* Maximum KEEPALIVE probe time */
 
 /* Fields are (of course) in network byte order.
  * Some fields are converted to host byte order in tcp_input().

--- a/src/core/lwip/tcp_in.c
+++ b/src/core/lwip/tcp_in.c
@@ -231,6 +231,13 @@ void L3_level_tcp_input(struct pbuf *p, struct tcp_pcb *pcb)
                     }
 
                     if (in_data.recv_data) {
+                        /* Forward progress: in-sequence data was received. Anchor
+                         * the TCP_USER_TIMEOUT keepalive reference so a receiver
+                         * that is actively getting data is never aborted, and its
+                         * deadline is measured from the last real data - matching
+                         * Linux lrcvtime. Keepalive-probe replies carry no data
+                         * and leave recv_data NULL, so they do not anchor here. */
+                        pcb->last_progress_tmr = tcp_ticks;
                         if (pcb->flags & TF_RXCLOSED) {
                             /* received data although already closed -> abort (send RST) to
                                            notify the remote host that not all data has been
@@ -596,6 +603,10 @@ static err_t tcp_process(struct tcp_pcb *pcb, tcp_in_data *in_data)
             pcb->snd_wnd_max = pcb->snd_wnd;
             pcb->snd_wl1 = in_data->seqno - 1; /* initialise to seqno - 1 to force window update */
             set_tcp_state(pcb, ESTABLISHED);
+            /* Connection is up: seed the forward-progress anchor so the
+             * TCP_USER_TIMEOUT keepalive deadline is measured from here and not
+             * from a stale pcb creation time. */
+            pcb->last_progress_tmr = tcp_ticks;
 
             syn_retransmitted = tcp_handle_syn_established(pcb);
             pcb->nrtx = 0;
@@ -653,6 +664,9 @@ static err_t tcp_process(struct tcp_pcb *pcb, tcp_in_data *in_data)
                 u32_t old_cwnd;
                 bool syn_retransmitted;
                 set_tcp_state(pcb, ESTABLISHED);
+                /* Connection is up: seed the forward-progress anchor (see the
+                 * active-open path above). */
+                pcb->last_progress_tmr = tcp_ticks;
 
                 syn_retransmitted = tcp_handle_syn_established(pcb);
                 pcb->nrtx = 0;
@@ -1156,6 +1170,12 @@ static void tcp_receive(struct tcp_pcb *pcb, tcp_in_data *in_data)
             /* Reset the fast retransmit variables. */
             pcb->dupacks = 0;
             pcb->lastack = in_data->ackno;
+
+            /* Forward progress: new data has been acknowledged. Anchor the
+             * TCP_USER_TIMEOUT keepalive reference here. Unlike pcb->tmr, this
+             * is not touched by keepalive-probe replies (bare dup-ACKs land in
+             * the TCP_SEQ_LEQ clause above, which never reaches this branch). */
+            pcb->last_progress_tmr = tcp_ticks;
 
             /* Update the congestion control variables (cwnd and ssthresh). */
             if (get_tcp_state(pcb) >= ESTABLISHED) {

--- a/src/core/lwip/tcp_out.c
+++ b/src/core/lwip/tcp_out.c
@@ -1758,9 +1758,13 @@ void tcp_keepalive(struct tcp_pcb *pcb)
     pcb->ip_output(p, NULL, pcb, 0);
     tcp_tx_pbuf_free(pcb, p);
 
-    if (pcb->ticks_since_data_sent == -1) {
-        pcb->ticks_since_data_sent = 0;
-    }
+    /* NOTE: a keepalive probe does NOT anchor pcb->ticks_since_data_sent. That
+     * counter drives tcp_user_timeout_occured() (the unacknowledged-data
+     * TCP_USER_TIMEOUT path); anchoring it here would make an idle keepalive
+     * connection abort at keep_idle + user_timeout instead of user_timeout.
+     * The zero-window/persist caller in tcp_slowtmr() anchors it explicitly
+     * (it has real pending data), and the idle keepalive user_timeout is
+     * handled in tcp_slowtmr() via pcb->last_progress_tmr. */
 
     LWIP_DEBUGF(
         TCP_DEBUG,

--- a/src/core/sock/sockinfo_tcp.cpp
+++ b/src/core/sock/sockinfo_tcp.cpp
@@ -89,10 +89,8 @@ static bool is_inherited_option(int __level, int __optname)
         case TCP_MAXSEG:
         case TCP_NODELAY:
         case TCP_KEEPIDLE:
-#if LWIP_TCP_KEEPALIVE
         case TCP_KEEPINTVL:
         case TCP_KEEPCNT:
-#endif
         case TCP_USER_TIMEOUT:
             ret = true;
         }
@@ -4659,9 +4657,21 @@ int sockinfo_tcp::tcp_setsockopt(int __level, int __optname, __const void *__opt
             }
             break;
         case TCP_USER_TIMEOUT: {
-            unsigned int user_timeout_ms = *(unsigned int *)__optval;
-            si_tcp_logdbg("TCP_USER_TIMEOUT value: %u", user_timeout_ms);
-            m_pcb.user_timeout_ms = user_timeout_ms;
+            if (__optlen < sizeof(unsigned int) || !__optval) {
+                errno = EINVAL;
+                ret = -1;
+            } else {
+                unsigned int user_timeout_ms = *reinterpret_cast<const unsigned int *>(__optval);
+                if (user_timeout_ms > TCP_USER_TIMEOUT_MAX_MS) {
+                    si_tcp_logdbg("TCP_USER_TIMEOUT value %u exceeds RFC 5482 maximum %u",
+                                  user_timeout_ms, TCP_USER_TIMEOUT_MAX_MS);
+                    errno = EINVAL;
+                    ret = -1;
+                } else {
+                    si_tcp_logdbg("TCP_USER_TIMEOUT value: %u", user_timeout_ms);
+                    m_pcb.user_timeout_ms = user_timeout_ms;
+                }
+            }
         } break;
         case TCP_KEEPIDLE: {
             auto *int_ptr = reinterpret_cast<const int *>(__optval);
@@ -4674,7 +4684,6 @@ int sockinfo_tcp::tcp_setsockopt(int __level, int __optname, __const void *__opt
                 m_pcb.keep_idle = idle_sec * 1000U;
             }
         } break;
-#if LWIP_TCP_KEEPALIVE
         case TCP_KEEPINTVL: {
             auto *int_ptr = reinterpret_cast<const int *>(__optval);
             if (__optlen < sizeof(int) || *int_ptr <= 0) {
@@ -4697,7 +4706,6 @@ int sockinfo_tcp::tcp_setsockopt(int __level, int __optname, __const void *__opt
                 m_pcb.keep_cnt = keep_cnt;
             }
         } break;
-#endif /* LWIP_TCP_KEEPALIVE */
         default:
             pass_to_os_always = true;
             supported = false;
@@ -5040,7 +5048,6 @@ int sockinfo_tcp::getsockopt_offload(int __level, int __optname, void *__optval,
                 errno = EINVAL;
             }
             break;
-#if LWIP_TCP_KEEPALIVE
         case TCP_KEEPINTVL:
             if (*__optlen >= sizeof(unsigned int)) {
                 *(unsigned int *)__optval = m_pcb.keep_intvl / 1000;
@@ -5061,7 +5068,6 @@ int sockinfo_tcp::getsockopt_offload(int __level, int __optname, void *__optval,
                 errno = EINVAL;
             }
             break;
-#endif /* LWIP_TCP_KEEPALIVE */
         default:
             ret = SOCKOPT_HANDLE_BY_OS;
             break;

--- a/tests/gtest/tcp/tcp_sockopt.cc
+++ b/tests/gtest/tcp/tcp_sockopt.cc
@@ -601,22 +601,18 @@ TEST_P(tcp_sockopt_positive, set_and_get_value)
 INSTANTIATE_TEST_CASE_P(
     keep_alive, tcp_sockopt_positive,
     testing::Values(
-#if LWIP_TCP_KEEPALIVE
         std::make_tuple(AF_INET, IPPROTO_TCP, TCP_KEEPINTVL, 1),
         std::make_tuple(AF_INET, IPPROTO_TCP, TCP_KEEPINTVL, std::numeric_limits<int16_t>::max()),
         std::make_tuple(AF_INET, IPPROTO_TCP, TCP_KEEPCNT, 1),
         std::make_tuple(AF_INET, IPPROTO_TCP, TCP_KEEPCNT, std::numeric_limits<int8_t>::max()),
-#endif
         std::make_tuple(AF_INET, SOL_SOCKET, SO_KEEPALIVE, 1),
         std::make_tuple(AF_INET, SOL_SOCKET, SO_KEEPALIVE, 0),
         std::make_tuple(AF_INET, IPPROTO_TCP, TCP_KEEPIDLE, 1),
         std::make_tuple(AF_INET, IPPROTO_TCP, TCP_KEEPIDLE, std::numeric_limits<int16_t>::max()),
-#if LWIP_TCP_KEEPALIVE
         std::make_tuple(AF_INET6, IPPROTO_TCP, TCP_KEEPINTVL, 1),
         std::make_tuple(AF_INET6, IPPROTO_TCP, TCP_KEEPINTVL, std::numeric_limits<int16_t>::max()),
         std::make_tuple(AF_INET6, IPPROTO_TCP, TCP_KEEPCNT, 1),
         std::make_tuple(AF_INET6, IPPROTO_TCP, TCP_KEEPCNT, std::numeric_limits<int8_t>::max()),
-#endif
         std::make_tuple(AF_INET6, SOL_SOCKET, SO_KEEPALIVE, 1),
         std::make_tuple(AF_INET6, SOL_SOCKET, SO_KEEPALIVE, 0),
         std::make_tuple(AF_INET6, IPPROTO_TCP, TCP_KEEPIDLE, 1),
@@ -648,33 +644,29 @@ TEST_P(tcp_setsockopt_negative, set_invalid_value)
  * There may be multiple instantiations of the tcp_setsockopt_negative class and
  * it's test cases.
  */
-INSTANTIATE_TEST_CASE_P(
-    keep_alive, tcp_setsockopt_negative,
-    testing::Values(
-#if LWIP_TCP_KEEPALIVE
-        std::make_tuple(AF_INET, IPPROTO_TCP, TCP_KEEPINTVL, -1),
-        std::make_tuple(AF_INET, IPPROTO_TCP, TCP_KEEPINTVL, 0),
-        std::make_tuple(AF_INET, IPPROTO_TCP, TCP_KEEPINTVL,
-                        std::numeric_limits<int16_t>::max() + 1),
-        std::make_tuple(AF_INET, IPPROTO_TCP, TCP_KEEPCNT, -1),
-        std::make_tuple(AF_INET, IPPROTO_TCP, TCP_KEEPCNT, 0),
-        std::make_tuple(AF_INET, IPPROTO_TCP, TCP_KEEPCNT, std::numeric_limits<int8_t>::max() + 1),
-#endif
-        std::make_tuple(AF_INET, IPPROTO_TCP, TCP_KEEPIDLE, -1),
-        std::make_tuple(AF_INET, IPPROTO_TCP, TCP_KEEPIDLE,
-                        std::numeric_limits<int16_t>::max() + 1),
-#if LWIP_TCP_KEEPALIVE
-        std::make_tuple(AF_INET6, IPPROTO_TCP, TCP_KEEPINTVL, -1),
-        std::make_tuple(AF_INET6, IPPROTO_TCP, TCP_KEEPINTVL, 0),
-        std::make_tuple(AF_INET6, IPPROTO_TCP, TCP_KEEPINTVL,
-                        std::numeric_limits<int16_t>::max() + 1),
-        std::make_tuple(AF_INET6, IPPROTO_TCP, TCP_KEEPCNT, -1),
-        std::make_tuple(AF_INET6, IPPROTO_TCP, TCP_KEEPCNT, 0),
-        std::make_tuple(AF_INET6, IPPROTO_TCP, TCP_KEEPCNT, std::numeric_limits<int8_t>::max() + 1),
-#endif
-        std::make_tuple(AF_INET6, IPPROTO_TCP, TCP_KEEPIDLE, -1),
-        std::make_tuple(AF_INET6, IPPROTO_TCP, TCP_KEEPIDLE,
-                        std::numeric_limits<int16_t>::max() + 1)));
+INSTANTIATE_TEST_CASE_P(keep_alive, tcp_setsockopt_negative,
+                        testing::Values(std::make_tuple(AF_INET, IPPROTO_TCP, TCP_KEEPINTVL, -1),
+                                        std::make_tuple(AF_INET, IPPROTO_TCP, TCP_KEEPINTVL, 0),
+                                        std::make_tuple(AF_INET, IPPROTO_TCP, TCP_KEEPINTVL,
+                                                        std::numeric_limits<int16_t>::max() + 1),
+                                        std::make_tuple(AF_INET, IPPROTO_TCP, TCP_KEEPCNT, -1),
+                                        std::make_tuple(AF_INET, IPPROTO_TCP, TCP_KEEPCNT, 0),
+                                        std::make_tuple(AF_INET, IPPROTO_TCP, TCP_KEEPCNT,
+                                                        std::numeric_limits<int8_t>::max() + 1),
+                                        std::make_tuple(AF_INET, IPPROTO_TCP, TCP_KEEPIDLE, -1),
+                                        std::make_tuple(AF_INET, IPPROTO_TCP, TCP_KEEPIDLE,
+                                                        std::numeric_limits<int16_t>::max() + 1),
+                                        std::make_tuple(AF_INET6, IPPROTO_TCP, TCP_KEEPINTVL, -1),
+                                        std::make_tuple(AF_INET6, IPPROTO_TCP, TCP_KEEPINTVL, 0),
+                                        std::make_tuple(AF_INET6, IPPROTO_TCP, TCP_KEEPINTVL,
+                                                        std::numeric_limits<int16_t>::max() + 1),
+                                        std::make_tuple(AF_INET6, IPPROTO_TCP, TCP_KEEPCNT, -1),
+                                        std::make_tuple(AF_INET6, IPPROTO_TCP, TCP_KEEPCNT, 0),
+                                        std::make_tuple(AF_INET6, IPPROTO_TCP, TCP_KEEPCNT,
+                                                        std::numeric_limits<int8_t>::max() + 1),
+                                        std::make_tuple(AF_INET6, IPPROTO_TCP, TCP_KEEPIDLE, -1),
+                                        std::make_tuple(AF_INET6, IPPROTO_TCP, TCP_KEEPIDLE,
+                                                        std::numeric_limits<int16_t>::max() + 1)));
 
 using getscokopt_params = std::tuple<int, int, int, const char *>;
 using tcp_sockopt_default = testing::TestWithParam<getscokopt_params>;
@@ -712,21 +704,18 @@ TEST_P(tcp_sockopt_default, matches_the_value_in_the_file)
 }
 
 INSTANTIATE_TEST_CASE_P(keep_alive, tcp_sockopt_default,
-                        testing::Values(
-#if LWIP_TCP_KEEPALIVE
-                            std::make_tuple(AF_INET, IPPROTO_TCP, TCP_KEEPINTVL,
-                                            "/proc/sys/net/ipv4/tcp_keepalive_intvl"),
-                            std::make_tuple(AF_INET, IPPROTO_TCP, TCP_KEEPCNT,
-                                            "/proc/sys/net/ipv4/tcp_keepalive_probes"),
-                            std::make_tuple(AF_INET6, IPPROTO_TCP, TCP_KEEPINTVL,
-                                            "/proc/sys/net/ipv4/tcp_keepalive_intvl"),
-                            std::make_tuple(AF_INET6, IPPROTO_TCP, TCP_KEEPCNT,
-                                            "/proc/sys/net/ipv4/tcp_keepalive_probes"),
-#endif
-                            std::make_tuple(AF_INET, IPPROTO_TCP, TCP_KEEPIDLE,
-                                            "/proc/sys/net/ipv4/tcp_keepalive_time"),
-                            std::make_tuple(AF_INET6, IPPROTO_TCP, TCP_KEEPIDLE,
-                                            "/proc/sys/net/ipv4/tcp_keepalive_time")));
+                        testing::Values(std::make_tuple(AF_INET, IPPROTO_TCP, TCP_KEEPINTVL,
+                                                        "/proc/sys/net/ipv4/tcp_keepalive_intvl"),
+                                        std::make_tuple(AF_INET, IPPROTO_TCP, TCP_KEEPCNT,
+                                                        "/proc/sys/net/ipv4/tcp_keepalive_probes"),
+                                        std::make_tuple(AF_INET6, IPPROTO_TCP, TCP_KEEPINTVL,
+                                                        "/proc/sys/net/ipv4/tcp_keepalive_intvl"),
+                                        std::make_tuple(AF_INET6, IPPROTO_TCP, TCP_KEEPCNT,
+                                                        "/proc/sys/net/ipv4/tcp_keepalive_probes"),
+                                        std::make_tuple(AF_INET, IPPROTO_TCP, TCP_KEEPIDLE,
+                                                        "/proc/sys/net/ipv4/tcp_keepalive_time"),
+                                        std::make_tuple(AF_INET6, IPPROTO_TCP, TCP_KEEPIDLE,
+                                                        "/proc/sys/net/ipv4/tcp_keepalive_time")));
 
 using setsockopt_param = std::tuple<int, int, int>;
 class tcp_with_fifo : public testing::TestWithParam<setsockopt_param> {
@@ -808,12 +797,10 @@ TEST_P(tcp_with_fifo, accepted_socket_inherits_the_setsockopt_param)
     }
 }
 
-INSTANTIATE_TEST_CASE_P(keep_alive, tcp_with_fifo,
-                        testing::Values(
-#if LWIP_TCP_KEEPALIVE
-                            std::make_tuple(static_cast<int>(IPPROTO_TCP), TCP_KEEPINTVL, 12345),
-                            std::make_tuple(static_cast<int>(IPPROTO_TCP), TCP_KEEPCNT, 123),
-#endif
-                            std::make_tuple(SOL_SOCKET, SO_KEEPALIVE, 0),
-                            std::make_tuple(SOL_SOCKET, SO_KEEPALIVE, 1),
-                            std::make_tuple(static_cast<int>(IPPROTO_TCP), TCP_KEEPIDLE, 1234)));
+INSTANTIATE_TEST_CASE_P(
+    keep_alive, tcp_with_fifo,
+    testing::Values(std::make_tuple(static_cast<int>(IPPROTO_TCP), TCP_KEEPINTVL, 12345),
+                    std::make_tuple(static_cast<int>(IPPROTO_TCP), TCP_KEEPCNT, 123),
+                    std::make_tuple(SOL_SOCKET, SO_KEEPALIVE, 0),
+                    std::make_tuple(SOL_SOCKET, SO_KEEPALIVE, 1),
+                    std::make_tuple(static_cast<int>(IPPROTO_TCP), TCP_KEEPIDLE, 1234)));


### PR DESCRIPTION
## Description
When TCP_USER_TIMEOUT is set on a keepalive connection, the abort decision should be based on elapsed time since last received data, not on the keepalive probe count (TCP_KEEPCNT). This matches the Linux tcp_keepalive_timer() behavior where TCP_USER_TIMEOUT overrides TCP_KEEPCNT.

Previously, the keepalive abort always used keep_cnt * keep_intvl, ignoring TCP_USER_TIMEOUT entirely. The separate tcp_user_timeout_ occured() check could eventually fire but measured from the wrong reference point (first probe sent, not last data received), making the effective timeout keep_idle + user_timeout instead of just user_timeout.

Enable LWIP_TCP_KEEPALIVE so that per-socket TCP_KEEPINTVL and TCP_KEEPCNT values are honored instead of using fixed defaults.

##### What
Fix keepalive abort to honor TCP_USER_TIMEOUT and enable per-socket TCP_KEEPINTVL/TCP_KEEPCNT.

##### Why ?
issue: 4043231 - When TCP_USER_TIMEOUT is set on a keepalive connection, XLIO aborts based on
probe count (TCP_KEEPCNT) instead of elapsed time. 

This differs from Linux, where
TCP_USER_TIMEOUT overrides TCP_KEEPCNT and the connection drops when elapsed time since last
received data exceeds the user timeout. 

Additionally, TCP_KEEPINTVL and TCP_KEEPCNT socket
options were silently ignored (LWIP_TCP_KEEPALIVE was compiled out).

##### How ?
Modify the keepalive abort block in tcp_slowtmr() to branch on user_timeout_ms:
- When set: abort when elapsed-since-last-rx >= user_timeout AND at least one probe was sent
  (matches Linux tcp_keepalive_timer() logic).
- When not set: abort when probe count exhausted (existing behavior, now using per-socket values).
Enable LWIP_TCP_KEEPALIVE=1 so per-socket keep_intvl and keep_cnt fields (already initialized
from /proc/sys/net/ipv4/tcp_keepalive_* in the constructor) are used by the timer and exposed
via setsockopt/getsockopt.

## Change type
What kind of change does this PR introduce?
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

