### PR TITLE
issue: 4923648 Reject Ultra API calls when worker threads are enabled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,9 @@ src/stats/xlio_stats
 src/vlogger/vlogger_test
 src/state_machine/state_machine_test
 tests/gtest/gtest
+tests/gtest/hash.c
+tests/gtest/poll_group_worker_threads_helper
+tests/gtest/xlio_init_ex_worker_threads_helper
 
 # build products
 build/libxlio.spec

--- a/src/core/sock/sock-extra.cpp
+++ b/src/core/sock/sock-extra.cpp
@@ -116,6 +116,15 @@ struct xlio_api_t *extra_api()
 
 extern "C" int xlio_init_ex(const struct xlio_init_attr *attr)
 {
+    if (safe_mce_sys().is_threads_mode()) {
+        vlog_printf(VLOG_ERROR,
+                    "Ultra API (xlio_init_ex) is incompatible with worker threads mode "
+                    "(performance.threading.worker_threads > 0). "
+                    "Disable worker threads or use standard socket API.\n");
+        errno = EINVAL;
+        return -1;
+    }
+
     if (g_init_global_ctors_done) {
         vlog_printf(VLOG_DEBUG, "XLIO is already initialized!!\n");
         // If XLIO global memory is already allocated, we can't
@@ -151,6 +160,15 @@ extern "C" int xlio_poll_group_create(const struct xlio_poll_group_attr *attr,
 {
     // Validate input arguments
     if (!group_out || !attr || !attr->socket_event_cb) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    if (safe_mce_sys().is_threads_mode()) {
+        vlog_printf(VLOG_ERROR,
+                    "Cannot create poll group: Ultra API is incompatible with worker threads mode "
+                    "(performance.threading.worker_threads > 0). "
+                    "Disable worker threads or use standard socket API.\n");
         errno = EINVAL;
         return -1;
     }

--- a/tests/gtest/Makefile.am
+++ b/tests/gtest/Makefile.am
@@ -1,4 +1,4 @@
-noinst_PROGRAMS = gtest
+noinst_PROGRAMS = gtest poll_group_worker_threads_helper xlio_init_ex_worker_threads_helper
 
 # google test shows some warnings that are suppressed
 AM_CXXFLAGS = \
@@ -58,7 +58,16 @@ EXTRA_DIST = \
 	googletest/include \
 	googletest/src \
 	googletest/README.md \
-	googletest/LICENSE
+	googletest/LICENSE \
+	\
+	output/config-cpu-affinity-default.json \
+	output/config-cpu-affinity-invalid.json \
+	output/config-negative-values.json \
+	output/config-sample-2rules.json \
+	output/config-sample-4rules.json \
+	output/config-sample-5rules.json \
+	output/config-sample.json \
+	output/config-ultra-api-worker-threads.json
 
 libgtest_la_SOURCES = \
 	googletest/src/gtest-all.cc \
@@ -171,4 +180,16 @@ CLEANFILES = hash.c
 
 hash.c:
 	@echo "#include \"$(top_builddir)/tools/daemon/$@\"" >$@
+
+# Helper binary for testing Ultra API / worker threads incompatibility
+poll_group_worker_threads_helper_SOURCES = output/poll_group_worker_threads_helper.c
+poll_group_worker_threads_helper_CPPFLAGS = -I$(top_srcdir)/src/core
+poll_group_worker_threads_helper_CFLAGS = -Wall
+poll_group_worker_threads_helper_LDFLAGS = -no-install
+
+# Helper binary for testing xlio_init_ex primary check with worker threads
+xlio_init_ex_worker_threads_helper_SOURCES = output/xlio_init_ex_worker_threads_helper.c
+xlio_init_ex_worker_threads_helper_CPPFLAGS = -I$(top_srcdir)/src/core
+xlio_init_ex_worker_threads_helper_CFLAGS = -Wall
+xlio_init_ex_worker_threads_helper_LDFLAGS = -no-install
 

--- a/tests/gtest/output/config-ultra-api-worker-threads.json
+++ b/tests/gtest/output/config-ultra-api-worker-threads.json
@@ -1,0 +1,7 @@
+{
+  "performance": {
+    "threading": {
+      "worker_threads": 1
+    }
+  }
+}

--- a/tests/gtest/output/config.cc
+++ b/tests/gtest/output/config.cc
@@ -441,3 +441,96 @@ TEST_F(output, config_pid_substitution_new_config)
     unlink(config_file.c_str());
     int unused __attribute__((unused)) = system(("rm -rf " + report_dir).c_str());
 }
+
+/**
+ * @test output.config_reject_worker_threads_with_poll_group
+ * @brief
+ *    XLIO rejects poll group creation when worker_threads is configured.
+ *
+ * @details
+ *    Setting performance.threading.worker_threads > 0 alongside Ultra API
+ *    poll groups is an invalid configuration combination.  XLIO must detect
+ *    this at xlio_poll_group_create() time and fail with EINVAL plus a clear
+ *    error message.
+ *
+ *    A compiled helper binary (inheriting LD_PRELOAD from the gtest runner)
+ *    retrieves the API via xlio_get_api() and attempts xlio_poll_group_create().
+ *    The config file sets worker_threads=1, causing the call to be rejected.
+ */
+TEST_F(output, config_reject_worker_threads_with_poll_group)
+{
+    std::string full_config = m_prefix + "/config-ultra-api-worker-threads.json";
+
+    // Locate the helper binary relative to the gtest binary.
+    std::string helper;
+    if (m_workspace) {
+        helper = std::string(m_workspace) + "/tests/gtest/poll_group_worker_threads_helper";
+    } else {
+        helper = "./poll_group_worker_threads_helper";
+    }
+
+    std::string cmd = "XLIO_USE_NEW_CONFIG=1 XLIO_CONFIG_FILE=" + full_config + " " + helper +
+        " > " + m_output_file + " 2>&1";
+
+    int rc = system(cmd.c_str());
+    ASSERT_NE(rc, 0) << "xlio_poll_group_create should have failed with worker threads configured";
+
+    std::ifstream ifs(m_output_file);
+    std::string text(std::istreambuf_iterator<char>(ifs), {});
+    ifs.close();
+
+    ASSERT_TRUE(text.find("Cannot create poll group") != std::string::npos)
+        << "Expected error about poll group incompatibility with worker threads in output:"
+        << std::endl
+        << text;
+    ASSERT_TRUE(text.find("incompatible with worker threads") != std::string::npos)
+        << "Expected specific incompatibility message in output:" << std::endl
+        << text;
+}
+
+/**
+ * @test output.config_reject_worker_threads_with_xlio_init_ex
+ * @brief
+ *    XLIO rejects xlio_init_ex() when worker_threads is configured.
+ *
+ * @details
+ *    When performance.threading.worker_threads > 0, xlio_init_ex() must
+ *    reject the call before any Ultra API initialization proceeds.  The
+ *    check runs before the g_init_global_ctors_done early-return gate,
+ *    ensuring it fires even when XLIO is already fully initialized via
+ *    LD_PRELOAD (as opposed to the defense-in-depth check in
+ *    xlio_poll_group_create tested above).
+ *
+ *    A compiled helper binary (inheriting LD_PRELOAD from the gtest runner)
+ *    retrieves the API via xlio_get_api() and calls xlio_init_ex() as the
+ *    very first XLIO Ultra API call.  The config file sets worker_threads=1,
+ *    causing xlio_init_ex() to detect the incompatibility and return an error.
+ */
+TEST_F(output, config_reject_worker_threads_with_xlio_init_ex)
+{
+    std::string full_config = m_prefix + "/config-ultra-api-worker-threads.json";
+
+    std::string helper;
+    if (m_workspace) {
+        helper = std::string(m_workspace) + "/tests/gtest/xlio_init_ex_worker_threads_helper";
+    } else {
+        helper = "./xlio_init_ex_worker_threads_helper";
+    }
+
+    std::string cmd = "XLIO_USE_NEW_CONFIG=1 XLIO_CONFIG_FILE=" + full_config + " " + helper +
+        " > " + m_output_file + " 2>&1";
+
+    int rc = system(cmd.c_str());
+    ASSERT_NE(rc, 0) << "xlio_init_ex should have failed with worker threads configured";
+
+    std::ifstream ifs(m_output_file);
+    std::string text(std::istreambuf_iterator<char>(ifs), {});
+    ifs.close();
+
+    ASSERT_TRUE(text.find("Ultra API (xlio_init_ex)") != std::string::npos)
+        << "Expected incompatibility error from xlio_init_ex in output:" << std::endl
+        << text;
+    ASSERT_TRUE(text.find("incompatible with worker threads") != std::string::npos)
+        << "Expected incompatibility message in output:" << std::endl
+        << text;
+}

--- a/tests/gtest/output/poll_group_worker_threads_helper.c
+++ b/tests/gtest/output/poll_group_worker_threads_helper.c
@@ -1,0 +1,43 @@
+/*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+ * Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: GPL-2.0-only or BSD-2-Clause
+ */
+
+#include <stdio.h>
+#include <errno.h>
+#include <string.h>
+#include "xlio_extra.h"
+
+static void dummy_event_cb(xlio_socket_t s, uintptr_t ud, int ev, int val)
+{
+    (void)s;
+    (void)ud;
+    (void)ev;
+    (void)val;
+}
+
+int main(void)
+{
+    struct xlio_api_t *api = xlio_get_api();
+    if (!api) {
+        fprintf(stderr, "XLIO_API_NOT_AVAILABLE\n");
+        return 2;
+    }
+
+    struct xlio_poll_group_attr attr;
+    memset(&attr, 0, sizeof(attr));
+    attr.socket_event_cb = dummy_event_cb;
+
+    xlio_poll_group_t group = 0;
+    int rc = api->xlio_poll_group_create(&attr, &group);
+
+    if (rc != 0) {
+        fprintf(stderr, "POLL_GROUP_CREATE_FAILED: errno=%d (%s)\n", errno, strerror(errno));
+        return 1;
+    }
+
+    fprintf(stderr, "POLL_GROUP_CREATE_OK\n");
+    api->xlio_poll_group_destroy(group);
+    return 0;
+}

--- a/tests/gtest/output/xlio_init_ex_worker_threads_helper.c
+++ b/tests/gtest/output/xlio_init_ex_worker_threads_helper.c
@@ -1,0 +1,32 @@
+/*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+ * Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: GPL-2.0-only or BSD-2-Clause
+ */
+
+#include <stdio.h>
+#include <errno.h>
+#include <string.h>
+#include "xlio_extra.h"
+
+int main(void)
+{
+    struct xlio_api_t *api = xlio_get_api();
+    if (!api) {
+        fprintf(stderr, "XLIO_API_NOT_AVAILABLE\n");
+        return 2;
+    }
+
+    struct xlio_init_attr attr;
+    memset(&attr, 0, sizeof(attr));
+
+    int rc = api->xlio_init_ex(&attr);
+    if (rc != 0) {
+        fprintf(stderr, "XLIO_INIT_EX_FAILED: rc=%d errno=%d (%s)\n", rc, errno, strerror(errno));
+        return 1;
+    }
+
+    fprintf(stderr, "XLIO_INIT_EX_OK\n");
+    api->xlio_exit();
+    return 0;
+}


### PR DESCRIPTION
## Description
Ultra API (xlio_init_ex, xlio_poll_group_create) and worker threads mode are incompatible runtime configurations. Add early guards that return EINVAL with a clear error message when
performance.threading.worker_threads > 0.

- Add is_threads_mode() check at the top of xlio_init_ex() (before the g_init_global_ctors_done gate) and inside xlio_poll_group_create() (after argument validation).
- Add two standalone C helper binaries that exercise each entry point under LD_PRELOAD so the gtest runner can verify the rejection.
- Add gtest cases in output/config.cc that launch the helpers with a worker_threads=1 config and assert on the expected error strings.
- Add test config JSON files to EXTRA_DIST for make distcheck.
- Add generated build artifacts to .gitignore.

##### What
Reject Ultra API calls (xlio_init_ex, xlio_poll_group_create) when worker threads mode is enabled.

##### Why ?
Ultra API and worker threads mode (performance.threading.worker_threads > 0) are incompatible runtime configurations. 

Without an explicit guard, combining them leads to undefined behavior. 
The check must fail early with a clear error message so users know exactly which configuration to change.

##### How ?
 - Add is_threads_mode() guards in sock-extra.cpp: at the top of xlio_init_ex() (before the g_init_global_ctors_done gate, so it fires even when XLIO is already initialized via LD_PRELOAD) and inside xlio_poll_group_create() (after argument validation). Both return -1 with errno = EINVAL and log a VLOG_ERROR message.
 - Add two minimal standalone C helper binaries (poll_group_worker_threads_helper, xlio_init_ex_worker_threads_helper) that exercise each Ultra API entry point under the inherited LD_PRELOAD. They are built as noinst_PROGRAMS and need no XLIO link dependency — xlio_get_api() resolves at runtime via the preloaded library.
 - Add gtest cases in output/config.cc that launch each helper with a worker_threads=1 JSON config and assert the process fails with the expected error strings in its output.
Fix pre-existing EXTRA_DIST gap by adding all test JSON config files so make distcheck includes them.

## Change type
What kind of change does this PR introduce?
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

