### PR TITLE
issue: 4923648 Fix segfault: Ultra API sockets coexist w/ worker threads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ src/stats/xlio_stats
 src/vlogger/vlogger_test
 src/state_machine/state_machine_test
 tests/gtest/gtest
+tests/gtest/ultra_api_connect_worker_threads_helper
 
 # build products
 build/libxlio.spec

--- a/src/core/sock/sockinfo.h
+++ b/src/core/sock/sockinfo.h
@@ -305,6 +305,10 @@ public:
     inline void sock_pop_descs_rx_ready(descq_t *cache);
 
     entity_context *get_entity_context() const { return m_entity_context; }
+    bool should_use_threads_mode() const
+    {
+        return safe_mce_sys().is_threads_mode() && !m_is_xlio_socket;
+    }
     uint32_t get_epoll_event_flags() { return m_epoll_event_flags; }
     uint32_t get_epoll_event_flags_thread() const { return m_epoll_event_flags_thread; }
     void set_epoll_event_flags(uint32_t events) { m_epoll_event_flags = events; }

--- a/src/core/sock/sockinfo_tcp.cpp
+++ b/src/core/sock/sockinfo_tcp.cpp
@@ -2771,7 +2771,7 @@ int sockinfo_tcp::connect(const sockaddr *__to, socklen_t __tolen)
         return -1;
     }
 
-    if (safe_mce_sys().is_threads_mode()) {
+    if (should_use_threads_mode()) {
         // For Threads mode need to do partial preparation and the rest will be done by the Thread.
         connect_threads_mode();
         return -1; // Currently no blocking socket support.
@@ -3210,8 +3210,7 @@ int sockinfo_tcp::listen(int backlog)
     tcp_accepted_pcb(&m_pcb, sockinfo_tcp::accepted_pcb_cb);
 
     bool success = false;
-    // Check if XLIO threads are enforced (> 0) for entity context distribution
-    if (safe_mce_sys().worker_threads > 0) {
+    if (should_use_threads_mode()) {
         create_listen_context();
         start_sockinfo_tcp_listen_objects();
         success = wait_for_listen_rss_children_ready();
@@ -3342,8 +3341,8 @@ int sockinfo_tcp::accept_helper(struct sockaddr *__addr, socklen_t *__addrlen,
             }
         }
 
-        int tmp_ret = safe_mce_sys().worker_threads > 0 ? harvest_sockinfo_tcp_listen_objects()
-                                                        : rx_wait(poll_count, m_b_blocking);
+        int tmp_ret = should_use_threads_mode() ? harvest_sockinfo_tcp_listen_objects()
+                                                : rx_wait(poll_count, m_b_blocking);
         if (tmp_ret < 0) {
             si_tcp_logdbg("interrupted accept");
             unlock_tcp_con();
@@ -3370,7 +3369,7 @@ int sockinfo_tcp::accept_helper(struct sockaddr *__addr, socklen_t *__addrlen,
     m_ready_conn_cnt--;
     IF_STATS(m_p_socket_stats->listen_counters.n_conn_backlog--);
 
-    safe_mce_sys().worker_threads ? assert(m_syn_received.empty()) : remove_received_syn_socket(ns);
+    should_use_threads_mode() ? assert(m_syn_received.empty()) : remove_received_syn_socket(ns);
 
     unlock_tcp_con();
 

--- a/tests/gtest/Makefile.am
+++ b/tests/gtest/Makefile.am
@@ -1,4 +1,4 @@
-noinst_PROGRAMS = gtest
+noinst_PROGRAMS = gtest ultra_api_connect_worker_threads_helper
 
 # google test shows some warnings that are suppressed
 AM_CXXFLAGS = \
@@ -73,6 +73,7 @@ gtest_CPPFLAGS = \
 	-I$(top_srcdir)/src/core \
 	-I$(top_srcdir)/tests/gtest \
 	-I$(top_srcdir)/tests/gtest/googletest/include \
+	-DGTEST_BUILDDIR=\"$(abs_builddir)\" \
 	$(AM_CPPFLAGS)
 
 gtest_LDFLAGS = -no-install
@@ -131,7 +132,8 @@ gtest_SOURCES = \
 	xlio_ultra_api/xlio_socket_migrate_2.cc \
 	xlio_ultra_api/xlio_socket_send_receive.cc \
 	xlio_ultra_api/xlio_socket_send_receive_2.cc \
-	xlio_ultra_api/xlio_socket_send_receive_full_sq.cc
+	xlio_ultra_api/xlio_socket_send_receive_full_sq.cc \
+	xlio_ultra_api/xlio_socket_worker_threads.cc
 
 noinst_HEADERS = \
 	common/tap.h \
@@ -139,6 +141,7 @@ noinst_HEADERS = \
 	common/sys.h \
 	common/log.h \
 	common/cmn.h \
+	common/subprocess_test.h \
 	\
 	common/base.h \
 	\
@@ -155,3 +158,8 @@ noinst_HEADERS = \
 gtest_DEPENDENCIES = \
 	libgtest.la
 
+# Helper binary for Ultra API + worker_threads smoke test
+ultra_api_connect_worker_threads_helper_SOURCES = xlio_ultra_api/ultra_api_connect_worker_threads_helper.c
+ultra_api_connect_worker_threads_helper_CPPFLAGS = -I$(top_srcdir)/src/core
+ultra_api_connect_worker_threads_helper_CFLAGS = -Wall
+ultra_api_connect_worker_threads_helper_LDFLAGS = -no-install

--- a/tests/gtest/common/subprocess_test.h
+++ b/tests/gtest/common/subprocess_test.h
@@ -1,0 +1,110 @@
+/*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+ * Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: GPL-2.0-only or BSD-2-Clause
+ */
+
+#ifndef TESTS_GTEST_COMMON_SUBPROCESS_TEST_H_
+#define TESTS_GTEST_COMMON_SUBPROCESS_TEST_H_
+
+#include <cstdlib>
+#include <fstream>
+#include <string>
+#include <unistd.h>
+
+#include "common/def.h"
+
+/**
+ * Base class for tests that launch helper binaries and inspect their
+ * captured output.  Provides workspace detection, command execution
+ * with output capture, and automatic cleanup.
+ */
+class subprocess_test : virtual public testing::Test {
+public:
+    void SetUp() override
+    {
+        m_workspace = std::getenv("WORKSPACE");
+        if (m_workspace) {
+            std::cout << "WORKSPACE: '" << m_workspace << "'" << std::endl;
+        } else {
+            std::cout << "WORKSPACE is not set" << std::endl;
+        }
+        // Default capture file; derived fixtures may override with a more
+        // specific name. Kept here so the base fully owns the field it cleans
+        // up in TearDown().
+        m_output_file = "/tmp/xlio_gtest_" + std::to_string(getpid()) + ".txt";
+    }
+
+    void TearDown() override
+    {
+        if (!m_output_file.empty()) {
+            unlink(m_output_file.c_str());
+        }
+    }
+
+protected:
+    /**
+     * Resolve a path relative to the workspace root (tests/gtest/...).
+     * Falls back to a path relative to CWD when WORKSPACE is not set.
+     */
+    std::string workspace_path(const std::string &relative) const
+    {
+        if (m_workspace) {
+            return std::string(m_workspace) + "/" + relative;
+        }
+        return relative;
+    }
+
+    /**
+     * Return the full path to a helper binary built alongside the gtest.
+     * Uses GTEST_BUILDDIR (set by Makefile.am) so the lookup works with
+     * out-of-tree builds where the build dir differs from the source tree.
+     */
+    std::string helper_path(const char *name) const
+    {
+        return std::string(GTEST_BUILDDIR) + "/" + name;
+    }
+
+    /**
+     * Run @p cmd, redirecting stdout+stderr to @p output_file.
+     * Throws std::runtime_error on non-zero exit to fail the test with
+     * diagnostic output.
+     */
+    void exec_cmd_to_file(const std::string &cmd, const std::string &output_file)
+    {
+        std::string command = cmd + " > " + output_file + " 2>&1";
+        int rc = system(command.c_str());
+        if (rc != 0) {
+            std::cout << "system('" << command << "') failed!" << std::endl;
+            try {
+                std::ifstream ifs(output_file);
+                std::string text(std::istreambuf_iterator<char>(ifs), {});
+                ifs.close();
+                std::cout << "Content of '" << output_file << "':\n" << text << std::endl;
+            } catch (const std::exception &e) {
+                std::cout << "Failed to read file '" << output_file << "': " << e.what()
+                          << std::endl;
+            }
+            throw std::runtime_error("Aborting test due to system command failure");
+        }
+    }
+
+    /**
+     * Read the full contents of a text file into a string.
+     */
+    std::string read_file(const std::string &path) const
+    {
+        std::ifstream ifs(path);
+        if (!ifs.is_open()) {
+            throw std::runtime_error("Failed to open file: " + path);
+        }
+        std::string text(std::istreambuf_iterator<char>(ifs), {});
+        ifs.close();
+        return text;
+    }
+
+    char *m_workspace {nullptr};
+    std::string m_output_file;
+};
+
+#endif /* TESTS_GTEST_COMMON_SUBPROCESS_TEST_H_ */

--- a/tests/gtest/output/config.cc
+++ b/tests/gtest/output/config.cc
@@ -10,51 +10,24 @@
 #include <fstream>
 #include <unistd.h>
 
-#include "common/def.h"
+#include "common/subprocess_test.h"
 
 /**
- * Base class for output tests
+ * Base class for output/config tests.
+ * Extends subprocess_test with config-file helpers.
  */
-class output : virtual public testing::Test {
+class output : public subprocess_test {
 public:
     void SetUp() override
     {
-        m_workspace = std::getenv("WORKSPACE");
-        if (m_workspace) {
-            std::cout << "WORKSPACE: '" << m_workspace << "'" << std::endl;
-            m_prefix = std::string(m_workspace) + "/tests/gtest/output";
-        } else {
-            std::cout << "WORKSPACE is not set" << std::endl;
-            m_prefix = "output";
-        }
-        m_output_file = m_prefix + "/output.txt";
+        subprocess_test::SetUp();
+        m_prefix = workspace_path("tests/gtest/output");
+        m_output_file = "/tmp/xlio_gtest_config_" + std::to_string(getpid()) + ".txt";
     }
-
-    void TearDown() override { unlink(m_output_file.c_str()); }
 
 protected:
     static constexpr const char *SOCKET_CMD =
         "python3 -c 'import socket; s=socket.socket(); s.close()'";
-    void exec_cmd_to_file(const std::string &cmd, const std::string &file_to_quote)
-    {
-        // The syntax '[command] > [file] 2>&1' works for both bash and dash
-        std::string command = cmd + " > " + file_to_quote + " 2>&1";
-        int rc = system(command.c_str());
-        if (rc != 0) {
-            std::cout << "system('" << command << "') failed!" << std::endl;
-            // Show content of the file to quote
-            try {
-                std::ifstream ifs(file_to_quote);
-                std::string text(std::istreambuf_iterator<char>(ifs), {});
-                ifs.close();
-                std::cout << "Content of '" << file_to_quote << "':\n" << text << std::endl;
-            } catch (const std::exception &e) {
-                std::cout << "Failed to read file '" << file_to_quote << "': " << e.what()
-                          << std::endl;
-            }
-            throw std::runtime_error("Aborting test due to system command failure");
-        }
-    }
 
     void check_file(const std::string &filename, const std::vector<const char *> &expected_strings,
                     const std::vector<const char *> &unexpected_strings = {})
@@ -66,10 +39,7 @@ protected:
         std::string cmd = "XLIO_USE_NEW_CONFIG=1 XLIO_CONFIG_FILE=" + full_filename + " ls";
         exec_cmd_to_file(cmd, m_output_file);
 
-        // Read the output file
-        std::ifstream ifs(m_output_file);
-        std::string text(std::istreambuf_iterator<char>(ifs), {});
-        ifs.close();
+        std::string text = read_file(m_output_file);
 
         for (const auto &expected : expected_strings) {
             // ASSERT and not EXPECT because if there are multiple failures the test output
@@ -91,9 +61,7 @@ protected:
         }
     }
 
-    char *m_workspace {nullptr};
     std::string m_prefix;
-    std::string m_output_file;
 };
 
 /**

--- a/tests/gtest/xlio_ultra_api/config-ultra-api-worker-threads.json
+++ b/tests/gtest/xlio_ultra_api/config-ultra-api-worker-threads.json
@@ -1,0 +1,12 @@
+{
+  "monitor": {
+    "log": {
+      "level": 5
+    }
+  },
+  "performance": {
+    "threading": {
+      "worker_threads": 1
+    }
+  }
+}

--- a/tests/gtest/xlio_ultra_api/ultra_api_connect_worker_threads_helper.c
+++ b/tests/gtest/xlio_ultra_api/ultra_api_connect_worker_threads_helper.c
@@ -1,0 +1,170 @@
+/*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+ * Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: GPL-2.0-only or BSD-2-Clause
+ */
+
+/*
+ * Smoke-test helper for verifying Ultra API sockets are NOT dispatched
+ * to XLIO worker threads.  Exercises the xlio_socket_connect() path with
+ * worker_threads=1 configured.  The gtest wrapper asserts that worker-
+ * thread dispatch messages (connect_socket_job / "New TCP socket added")
+ * are absent from the debug output.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <arpa/inet.h>
+#include <ifaddrs.h>
+#include <net/if.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include "xlio_extra.h"
+
+/* Arbitrary unused TCP port -- the connect() is only used to drive the
+ * XLIO connect code path, not to actually communicate. */
+#define PEER_PORT 1
+
+/* Iterations of xlio_poll_group_poll() to drain pending socket events
+ * between connect() and teardown. */
+#define POLL_ITERATIONS 100
+
+/* inet_pton() returns 1 for a successful parse, 0 for malformed input,
+ * -1 for an unsupported family. */
+#define INET_PTON_OK 1
+
+static void dummy_event_cb(xlio_socket_t s, uintptr_t ud, int ev, int val)
+{
+    (void)s;
+    (void)ud;
+    (void)ev;
+    (void)val;
+}
+
+/*
+ * Find a non-loopback IPv4 address on this machine.  Returns 0 on success.
+ * On RDMA-capable hosts this will typically be an offload-eligible address.
+ */
+static int find_local_ipv4(struct in_addr *out)
+{
+    struct ifaddrs *ifa_list, *ifa;
+
+    if (getifaddrs(&ifa_list) != 0) {
+        return -1;
+    }
+
+    for (ifa = ifa_list; ifa; ifa = ifa->ifa_next) {
+        if (!ifa->ifa_addr || ifa->ifa_addr->sa_family != AF_INET) {
+            continue;
+        }
+        if (ifa->ifa_flags & IFF_LOOPBACK) {
+            continue;
+        }
+        *out = ((struct sockaddr_in *)ifa->ifa_addr)->sin_addr;
+        freeifaddrs(ifa_list);
+        return 0;
+    }
+
+    freeifaddrs(ifa_list);
+    return -1;
+}
+
+int main(int argc, char **argv)
+{
+    /* Parse the peer address up-front so that sattr.domain can be set
+     * correctly, and so a malformed literal short-circuits to SKIP before
+     * we touch any XLIO resources.  Three independent cases:
+     *   - no argument supplied  -> default to a local IPv4 address;
+     *   - argument contains ':' -> parse as IPv6;
+     *   - otherwise             -> parse as IPv4.
+     */
+    const char *arg = (argc > 1) ? argv[1] : NULL;
+    struct sockaddr_storage peer;
+    socklen_t peer_len;
+    sa_family_t family;
+
+    memset(&peer, 0, sizeof(peer));
+
+    if (!arg) {
+        struct sockaddr_in *s4 = (struct sockaddr_in *)&peer;
+        s4->sin_family = AF_INET;
+        s4->sin_port = htons(PEER_PORT);
+        if (find_local_ipv4(&s4->sin_addr) != 0) {
+            s4->sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+        }
+        family = AF_INET;
+        peer_len = sizeof(*s4);
+    } else if (strchr(arg, ':')) {
+        struct sockaddr_in6 *s6 = (struct sockaddr_in6 *)&peer;
+        s6->sin6_family = AF_INET6;
+        s6->sin6_port = htons(PEER_PORT);
+        if (inet_pton(AF_INET6, arg, &s6->sin6_addr) != INET_PTON_OK) {
+            fprintf(stderr, "SKIP: failed to parse peer address '%s'\n", arg);
+            return EXIT_SUCCESS;
+        }
+        family = AF_INET6;
+        peer_len = sizeof(*s6);
+    } else {
+        struct sockaddr_in *s4 = (struct sockaddr_in *)&peer;
+        s4->sin_family = AF_INET;
+        s4->sin_port = htons(PEER_PORT);
+        if (inet_pton(AF_INET, arg, &s4->sin_addr) != INET_PTON_OK) {
+            fprintf(stderr, "SKIP: failed to parse peer address '%s'\n", arg);
+            return EXIT_SUCCESS;
+        }
+        family = AF_INET;
+        peer_len = sizeof(*s4);
+    }
+
+    struct xlio_api_t *api = xlio_get_api();
+    if (!api) {
+        fprintf(stderr, "SKIP: XLIO API not available\n");
+        return EXIT_SUCCESS;
+    }
+
+    struct xlio_init_attr iattr;
+    memset(&iattr, 0, sizeof(iattr));
+    if (api->xlio_init_ex(&iattr) != 0) {
+        fprintf(stderr, "SKIP: xlio_init_ex failed: %s\n", strerror(errno));
+        return EXIT_SUCCESS;
+    }
+
+    xlio_poll_group_t group = 0;
+    struct xlio_poll_group_attr gattr;
+    memset(&gattr, 0, sizeof(gattr));
+    gattr.socket_event_cb = dummy_event_cb;
+    if (api->xlio_poll_group_create(&gattr, &group) != 0) {
+        fprintf(stderr, "FAIL: xlio_poll_group_create: %s\n", strerror(errno));
+        api->xlio_exit();
+        return EXIT_FAILURE;
+    }
+
+    xlio_socket_t sock = 0;
+    struct xlio_socket_attr sattr;
+    memset(&sattr, 0, sizeof(sattr));
+    sattr.domain = family;
+    sattr.group = group;
+    if (api->xlio_socket_create(&sattr, &sock) != 0) {
+        fprintf(stderr, "SKIP: xlio_socket_create failed: %s\n", strerror(errno));
+        api->xlio_poll_group_destroy(group);
+        api->xlio_exit();
+        return EXIT_SUCCESS;
+    }
+
+    /* Connect will likely fail (ECONNREFUSED / timeout) but that is fine.
+     * The goal is to exercise the connect code path inside XLIO. */
+    api->xlio_socket_connect(sock, (struct sockaddr *)&peer, peer_len);
+
+    for (int i = 0; i < POLL_ITERATIONS; i++) {
+        api->xlio_poll_group_poll(group);
+    }
+
+    api->xlio_socket_destroy(sock);
+    api->xlio_poll_group_destroy(group);
+    api->xlio_exit();
+
+    fprintf(stderr, "PASS\n");
+    return EXIT_SUCCESS;
+}

--- a/tests/gtest/xlio_ultra_api/xlio_socket_worker_threads.cc
+++ b/tests/gtest/xlio_ultra_api/xlio_socket_worker_threads.cc
@@ -1,0 +1,100 @@
+/*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+ * Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: GPL-2.0-only or BSD-2-Clause
+ */
+
+#include "common/subprocess_test.h"
+#include "common/log.h"
+#include "common/sys.h"
+
+/**
+ * Tests for Ultra API + worker threads coexistence.
+ *
+ * These tests launch a helper binary (with LD_PRELOAD inherited from the
+ * gtest runner) that exercises Ultra API operations while worker_threads
+ * is configured.  The tests inspect the captured debug output for signs
+ * of incorrect worker-thread dispatch.
+ */
+class ultra_api_worker_threads : public subprocess_test {
+public:
+    void SetUp() override
+    {
+        subprocess_test::SetUp();
+        m_output_file = "/tmp/xlio_gtest_wt_" + std::to_string(getpid()) + ".txt";
+    }
+};
+
+/**
+ * @test ultra_api_worker_threads.no_distribute_on_connect
+ * @brief
+ *    Ultra API sockets must not be dispatched to XLIO worker threads.
+ *
+ * @details
+ *    When performance.threading.worker_threads > 0, POSIX sockets are handed
+ *    off to worker threads for processing.  Ultra API sockets manage their own
+ *    poll groups and rings, so they must bypass this dispatch entirely.
+ *
+ *    A compiled helper binary retrieves the API via xlio_get_api(), creates a
+ *    poll group and socket, and calls xlio_socket_connect() targeting the
+ *    server address provided by the gtest runner (a real RDMA-routable address
+ *    in CI).  The config sets worker_threads=1 and log level=debug so that any
+ *    worker-thread dispatch is visible in the output.
+ *
+ *    The test asserts the ABSENCE of worker-thread dispatch messages:
+ *    - "connect_socket_job" / "New TCP socket added" from entity_context
+ *    - "already a member in a list" from vlist (symptom of the original crash)
+ *
+ *    It also positively asserts that either the XLIO offload path was exercised
+ *    ("MATCH TCP CLIENT" from __xlio_match_tcp_client) or the helper explicitly
+ *    skipped (printed "SKIP"), to prevent vacuous passes.
+ */
+TEST_F(ultra_api_worker_threads, no_distribute_on_connect)
+{
+    std::string config =
+        workspace_path("tests/gtest/xlio_ultra_api/config-ultra-api-worker-threads.json");
+    std::string helper = helper_path("ultra_api_connect_worker_threads_helper");
+
+    std::string cmd = "XLIO_USE_NEW_CONFIG=1 XLIO_CONFIG_FILE=" + config + " " + helper;
+
+    // Pass the real server address so the connect reaches the XLIO offload
+    // path on RDMA-capable CI machines.
+    const struct sockaddr *sa = (const struct sockaddr *)&gtest_conf.server_addr;
+    if (sa->sa_family == AF_INET || sa->sa_family == AF_INET6) {
+        std::string addr_str = sys_addr2str(sa, false);
+        if (!addr_str.empty() && addr_str != "0.0.0.0") {
+            cmd += " " + addr_str;
+        }
+    }
+
+    exec_cmd_to_file(cmd, m_output_file);
+
+    std::string text = read_file(m_output_file);
+
+    ASSERT_TRUE(text.find("connect_socket_job") == std::string::npos)
+        << "Worker thread incorrectly dispatched Ultra API socket connect." << std::endl
+        << "START OF TEXT:" << std::endl
+        << text << std::endl
+        << "END OF TEXT";
+
+    ASSERT_TRUE(text.find("New TCP socket added") == std::string::npos)
+        << "Worker thread incorrectly dispatched Ultra API socket (New TCP socket added)."
+        << std::endl
+        << "START OF TEXT:" << std::endl
+        << text << std::endl
+        << "END OF TEXT";
+
+    ASSERT_TRUE(text.find("already a member in a list") == std::string::npos)
+        << "Buffer corruption detected during Ultra API + worker threads coexistence." << std::endl
+        << "START OF TEXT:" << std::endl
+        << text << std::endl
+        << "END OF TEXT";
+
+    ASSERT_TRUE(text.find("MATCH TCP CLIENT") != std::string::npos ||
+                text.find("SKIP") != std::string::npos)
+        << "Neither XLIO offload path nor explicit SKIP was detected -- test is vacuous."
+        << std::endl
+        << "START OF TEXT:" << std::endl
+        << text << std::endl
+        << "END OF TEXT";
+}


### PR DESCRIPTION
## Description
When worker_threads > 0, XLIO unconditionally dispatches any socket's connect/listen/accept operations to worker threads via distribute_socket(). Ultra API sockets manage their own poll groups and rings, so this dispatch causes double-ownership: the application thread drives the socket through its poll_group while the worker thread also tries to manage it. This leads to "Buff is already a member in a list!" errors and a SIGSEGV in TCP_EVENT_ERR when the worker thread invokes a NULL callback.

Add sockinfo::should_use_threads_mode() which returns true only when worker threads are configured AND the socket is not an Ultra API socket (m_is_xlio_socket == false). Replace the three bare is_threads_mode() / worker_threads > 0 checks in sockinfo_tcp.cpp (connect, listen, accept paths) with this new method, allowing POSIX and Ultra API sockets to coexist safely when worker threads are enabled.

Add a regression test -ultra_api_worker_threads.no_distribute_on_connect that exercises xlio_socket_connect() with worker_threads=1 at debug log level and asserts that worker-thread dispatch messages are absent from the output. Extract subprocess test infrastructure from output/config.cc into common/subprocess_test.h for reuse.

##### What
Skip worker-thread dispatch for Ultra API sockets, preventing SIGSEGV when Ultra API and worker threads coexist.

##### Why ?
When worker_threads > 0, XLIO unconditionally dispatches any socket's connect/listen/accept to worker threads via distribute_socket(). Ultra API sockets manage their own poll groups and rings, so this dispatch causes double-ownership: the application thread drives the socket through its poll_group while a worker thread also tries to manage it. This leads to "Buff is already a member in a list!" errors and a SIGSEGV in TCP_EVENT_ERR when the worker thread invokes a NULL callback. See Redmine #4923648.

##### How ?
Add sockinfo::should_use_threads_mode() which returns true only when worker threads are configured and the socket is not an Ultra API socket (!m_is_xlio_socket). Replace the three bare is_threads_mode() / worker_threads > 0 checks in sockinfo_tcp.cpp (connect, listen, accept paths) with this method. POSIX sockets continue to be dispatched to worker threads as before; Ultra API sockets bypass the dispatch entirely.

A regression test (ultra_api_worker_threads.no_distribute_on_connect) launches a helper binary that calls xlio_socket_connect() with worker_threads=1 at debug log level, then asserts that worker-thread dispatch messages (connect_socket_job) are absent from the output. The test runs automatically in CI under the ultra_api* filter with real RDMA addresses and root privileges. Subprocess test infrastructure is extracted from output/config.cc into common/subprocess_test.h for reuse.

## Change type
What kind of change does this PR introduce?
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection and accept handling when worker-thread mode is enabled, making behavior more consistent across socket types.

* **Tests**
  * Added new end-to-end coverage for worker-thread connection scenarios.
  * Introduced shared test support for running helper programs and capturing their output.
  * Updated test configuration and build setup to include the new scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->