### PR TITLE
issue: 4896482 Switch epfd lock from mutex to spinlock

### DIFF
--- a/src/core/iomux/epfd_info.cpp
+++ b/src/core/iomux/epfd_info.cpp
@@ -30,7 +30,7 @@ int epfd_info::remove_fd_from_epoll_os(int fd)
 }
 
 epfd_info::epfd_info(int epfd, int size)
-    : lock_mutex_recursive("epfd_info")
+    : lock_spin_recursive("epfd_info")
     , m_epfd(epfd)
     , m_size(size)
     , m_ring_map_lock("epfd_ring_map_lock")

--- a/src/core/iomux/epfd_info.h
+++ b/src/core/iomux/epfd_info.h
@@ -40,7 +40,7 @@ enum class epoll_poll_type_t {
     POLL_BOTH // Poll both RX and TX rings (default epoll_wait behavior)
 };
 
-class epfd_info : public lock_mutex_recursive, public cleanable_obj, public wakeup_pipe {
+class epfd_info : public lock_spin_recursive, public cleanable_obj, public wakeup_pipe {
 public:
     epfd_info(int epfd, int size);
     ~epfd_info();


### PR DESCRIPTION
The epfd_info lock protects brief critical sections during epoll operations. When multiple threads contend on this lock (e.g., close() calling fd_closed() while another thread is in epoll_wait), spinlock performs better than mutex because:
1. Critical sections are short - spinning is cheaper than sleep/wake syscall overhead
2. Mutex contention causes futex_wait which involves kernel transitions

This improves performance in multi-threaded scenarios such as worker thread mode where the main epfd is frequently accessed by multiple I/O threads.

## Description
Please provide a summary of the change.

##### What
_Subject: what this PR is doing in one line._ 

##### Why ?
_Justification for the PR. If there is existing issue/bug please reference._

##### How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc._

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

