### PR TITLE
issue: 4950843 Deprecate XLIO_MEMORY_LIMIT_USER

### DIFF
--- a/src/core/config/config_registry.cpp
+++ b/src/core/config/config_registry.cpp
@@ -113,6 +113,16 @@ void config_registry::initialize_from_loaders(std::queue<std::unique_ptr<loader>
                 // Now, validate constraints on the canonical value.
                 param_desc.validate_constraints(canonical_value);
 
+                if (param_desc.is_deprecated()) {
+                    std::string warn =
+                        "In '" + loader->source() + "': Parameter '" + key + "' is deprecated.";
+                    const auto &msg = param_desc.get_deprecation_message();
+                    if (msg && !msg->empty()) {
+                        warn += " " + *msg;
+                    }
+                    m_deprecation_warnings.push_back(std::move(warn));
+                }
+
             } catch (const xlio_exception &e) {
                 // Check if this is a type mismatch for a parent object
                 if (m_config_descriptor.is_parent_of_parameter_keys(key)) {

--- a/src/core/config/config_registry.h
+++ b/src/core/config/config_registry.h
@@ -106,6 +106,15 @@ public:
 
     const config_descriptor &get_config_descriptor() const { return m_config_descriptor; }
 
+    /**
+     * @brief Returns deprecation warnings collected during loading
+     * @return Vector of human-readable deprecation warning strings
+     */
+    const std::vector<std::string> &get_deprecation_warnings() const
+    {
+        return m_deprecation_warnings;
+    }
+
 private:
     // Holds all values set by config file / inline config
     std::map<std::string, std::experimental::any> m_config_data;
@@ -114,6 +123,8 @@ private:
     config_descriptor m_config_descriptor;
     // Holds all sources that contributed to the configuration
     std::vector<std::string> m_sources;
+    // Deprecation warnings collected during loading
+    std::vector<std::string> m_deprecation_warnings;
 
     std::experimental::any get_default_value_as_any(const std::string &key) const;
     void initialize_from_loaders(std::queue<std::unique_ptr<loader>> &&value_loaders);

--- a/src/core/config/config_strings.cpp
+++ b/src/core/config/config_strings.cpp
@@ -42,6 +42,7 @@ const char *JSON_TYPE_ARRAY = "array";
 namespace schema_extensions {
 const char *JSON_EXTENSION_MEMORY_SIZE = "x-memory-size";
 const char *JSON_EXTENSION_POWER_OF_2_OR_ZERO = "x-power-of-2-or-zero";
+const char *JSON_EXTENSION_DEPRECATED = "x-deprecated";
 } // namespace schema_extensions
 
 // Error messages

--- a/src/core/config/config_strings.h
+++ b/src/core/config/config_strings.h
@@ -61,6 +61,7 @@ namespace schema_extensions {
 extern const char *JSON_EXTENSION_MEMORY_SIZE; /**< Memory size extension identifier */
 extern const char
     *JSON_EXTENSION_POWER_OF_2_OR_ZERO; /**< Power of 2 validation extension identifier */
+extern const char *JSON_EXTENSION_DEPRECATED; /**< Deprecation marker extension */
 } //namespace schema_extensions
 
 /**

--- a/src/core/config/descriptor_providers/json_descriptor_provider.cpp
+++ b/src/core/config/descriptor_providers/json_descriptor_provider.cpp
@@ -173,6 +173,10 @@ std::unique_ptr<parameter_descriptor> json_descriptor_provider::create_descripto
         apply_enum_mapping(descriptor.get(), analysis.enum_cfg);
     }
 
+    if (analysis.deprecation_info) {
+        descriptor->set_deprecation_message(analysis.deprecation_info);
+    }
+
     return descriptor;
 }
 

--- a/src/core/config/descriptor_providers/schema_analyzer.cpp
+++ b/src/core/config/descriptor_providers/schema_analyzer.cpp
@@ -445,6 +445,7 @@ schema_analyzer::analysis_result::analysis_result(schema_analyzer &analyzer)
     , memory_cfg(analyzer.analyze_memory_size_extension_config())
     , constraint_cfg(analyzer.analyze_constraint_config())
     , enum_cfg(analyzer.analyze_enum_mapping_config())
+    , deprecation_info(analyzer.determine_deprecated_info())
 {
 }
 
@@ -462,4 +463,28 @@ bool schema_analyzer::analysis_result::needs_constraint_validation() const
 bool schema_analyzer::analysis_result::needs_enum_mapping() const
 {
     return static_cast<bool>(enum_cfg);
+}
+
+std::experimental::optional<std::string> schema_analyzer::determine_deprecated_info()
+{
+    json_object *deprecated_field = json_utils::try_get_field(
+        m_property_obj, config_strings::schema_extensions::JSON_EXTENSION_DEPRECATED);
+    if (!deprecated_field) {
+        return std::experimental::nullopt;
+    }
+
+    json_type type = json_object_get_type(deprecated_field);
+    if (type == json_type_boolean) {
+        if (json_object_get_boolean(deprecated_field)) {
+            return std::string();
+        }
+        return std::experimental::nullopt;
+    }
+
+    if (type == json_type_string) {
+        const char *msg = json_object_get_string(deprecated_field);
+        return std::string(msg ? msg : "");
+    }
+
+    throw_xlio_exception("x-deprecated must be boolean or string for: " + m_path);
 }

--- a/src/core/config/descriptor_providers/schema_analyzer.h
+++ b/src/core/config/descriptor_providers/schema_analyzer.h
@@ -77,6 +77,9 @@ public:
         memory_size_extension_config_t memory_cfg; /**< Memory size transformation configuration */
         constraint_config constraint_cfg; /**< Constraint validation configuration */
         enum_mapping_config_t enum_cfg; /**< Enum mapping configuration */
+        std::experimental::optional<std::string>
+            deprecation_info; /**< nullopt = not deprecated, empty = deprecated without message,
+                                   non-empty = deprecated with message */
 
         /**
          * @brief Checks if value transformation is needed for this property
@@ -128,6 +131,7 @@ private:
     memory_size_extension_config_t analyze_memory_size_extension_config();
     constraint_config analyze_constraint_config();
     enum_mapping_config_t analyze_enum_mapping_config();
+    std::experimental::optional<std::string> determine_deprecated_info();
 
     // Helper methods
     bool has_memory_size_flag();

--- a/src/core/config/descriptor_providers/xlio_config_schema.json
+++ b/src/core/config/descriptor_providers/xlio_config_schema.json
@@ -75,7 +75,8 @@
                             ],
                             "title": "External memory limit (bytes)",
                             "description": "Maps to XLIO_MEMORY_LIMIT_USER environment variable.\nMaximum memory block size XLIO requests from a user-provided allocator.\n\n**Applies only** to applications using XLIO's Extra API (xlio_init_ex) with custom\nmemory_alloc and memory_free callbacks. No effect for standard POSIX applications.\n\n**Behavior:**\n- 0 (default): XLIO requests blocks sized by `core.resources.memory_limit`\n- Non-zero: XLIO requests blocks up to this size from the user allocator\n\nMemory blocks are registered with RDMA hardware for DMA operations (RX/TX buffer pools).\n\n**Sizing:** XLIO requests exactly one block of this size from your allocator. If your\nallocator cannot provide it, or if the block is too small for XLIO's buffer pools,\ninitialization fails with an exception. Set to your allocator's maximum available\ncontiguous block, ensuring it meets XLIO's memory requirements.\n\n**Profile override:** nvme_bf3 profile sets this to 2GB for optimal SPDK performance.\n\n**Example:** DPDK/SPDK integration with 1GB hugepage pools: set to 1GB to match pool size.\n\n**Supports suffixes:** B, KB, MB, GB.",
-                            "x-memory-size": true
+                            "x-memory-size": true,
+                            "x-deprecated": "Use core.resources.memory_limit instead."
                         },
                         "heap_metadata_block_size": {
                             "oneOf": [

--- a/src/core/config/descriptors/parameter_descriptor.cpp
+++ b/src/core/config/descriptors/parameter_descriptor.cpp
@@ -24,6 +24,23 @@ const std::experimental::optional<std::string> &parameter_descriptor::get_title(
     return m_title;
 }
 
+void parameter_descriptor::set_deprecation_message(
+    const std::experimental::optional<std::string> &msg)
+{
+    m_deprecation_message = msg;
+}
+
+bool parameter_descriptor::is_deprecated() const
+{
+    return static_cast<bool>(m_deprecation_message);
+}
+
+const std::experimental::optional<std::string> &parameter_descriptor::get_deprecation_message()
+    const
+{
+    return m_deprecation_message;
+}
+
 /**
  * @brief Parse memory size string with suffixes (e.g., "4GB", "512MB", "1024KB", "1024B", "5G")
  * @param str The string to parse. Must match "^[0-9]+[KMGkmg]?[B]?$" (case insensitive)
@@ -163,6 +180,7 @@ parameter_descriptor::parameter_descriptor(const parameter_descriptor &pd)
     , m_value_transformer(pd.m_value_transformer)
     , m_type(pd.m_type)
     , m_title(pd.m_title)
+    , m_deprecation_message(pd.m_deprecation_message)
 {
 }
 

--- a/src/core/config/descriptors/parameter_descriptor.h
+++ b/src/core/config/descriptors/parameter_descriptor.h
@@ -104,6 +104,25 @@ public:
     const std::experimental::optional<std::string> &get_title() const;
 
     /**
+     * @brief Marks this parameter as deprecated with an optional message
+     * @param msg nullopt = not deprecated, empty string = deprecated without message,
+     *            non-empty = deprecated with the given message
+     */
+    void set_deprecation_message(const std::experimental::optional<std::string> &msg);
+
+    /**
+     * @brief Checks whether this parameter is deprecated
+     * @return True if the parameter is deprecated
+     */
+    bool is_deprecated() const;
+
+    /**
+     * @brief Gets the deprecation message, if any
+     * @return nullopt if not deprecated, otherwise the deprecation message (may be empty)
+     */
+    const std::experimental::optional<std::string> &get_deprecation_message() const;
+
+    /**
      * @brief Validates a value against all constraints
      * @param value Value to validate
      */
@@ -194,6 +213,8 @@ private:
     std::type_index m_type;
     std::experimental::optional<std::string>
         m_title; /**< Title of the parameter as defined in schema */
+    std::experimental::optional<std::string>
+        m_deprecation_message; /**< nullopt = not deprecated; set = deprecated (may have message) */
 
     /**
      * @brief Parses a memory size string with suffixes (KB, MB, GB)

--- a/src/core/util/sys_vars.cpp
+++ b/src/core/util/sys_vars.cpp
@@ -1815,6 +1815,12 @@ void mce_sys_var::apply_config_from_registry()
     read_hypervisor_info();
 
     m_runtime_registry = runtime_registry();
+
+    for (const auto &warning :
+         m_runtime_registry->get_config_registry().get_deprecation_warnings()) {
+        vlog_printf(VLOG_WARNING, "%s\n", warning.c_str());
+    }
+
     sys_var_configurator configurator(*m_runtime_registry, *this);
     configurator.configure();
 }
@@ -1859,6 +1865,26 @@ void mce_sys_var::get_app_name()
     fclose(fp);
 }
 
+static void check_deprecated_env_vars()
+{
+    struct deprecated_env_var {
+        const char *name;
+        const char *message;
+    };
+
+    static const deprecated_env_var table[] = {
+        // Add entries here as env variables are deprecated, e.g.:
+        // {SYS_VAR_SOME_PARAM, "Use XLIO_NEW_PARAM instead."},
+    };
+
+    for (const auto &entry : table) {
+        if (std::getenv(entry.name)) {
+            vlog_printf(VLOG_WARNING, "Environment variable '%s' is deprecated. %s\n", entry.name,
+                        entry.message ? entry.message : "");
+        }
+    }
+}
+
 void mce_sys_var::get_params()
 {
     get_app_name();
@@ -1867,6 +1893,7 @@ void mce_sys_var::get_params()
     const char *use_new_config = std::getenv("XLIO_USE_NEW_CONFIG");
     if (!use_new_config || std::string(use_new_config) != "1") {
         get_env_params();
+        check_deprecated_env_vars();
         fixup_params();
     } else {
         g_use_new_config = true;

--- a/src/core/util/sys_vars.cpp
+++ b/src/core/util/sys_vars.cpp
@@ -1875,6 +1875,7 @@ static void check_deprecated_env_vars()
     static const deprecated_env_var table[] = {
         // Add entries here as env variables are deprecated, e.g.:
         // {SYS_VAR_SOME_PARAM, "Use XLIO_NEW_PARAM instead."},
+        {SYS_VAR_MEMORY_LIMIT_USER, "Use XLIO_MEMORY_LIMIT instead."},
     };
 
     for (const auto &entry : table) {

--- a/tests/unit_tests/config/config_registry.cpp
+++ b/tests/unit_tests/config/config_registry.cpp
@@ -766,6 +766,71 @@ TEST(config, config_registry_power_of_2_validation_zero_values)
     ASSERT_EQ(64LL, registry.get_value<int64_t>("hardware_features.striding_rq.stride_size"));
 }
 
+TEST(config, config_registry_deprecated_no_warning_when_not_set)
+{
+    const char *schema = R"({
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "Test",
+        "description": "Test",
+        "type": "object",
+        "properties": {
+            "old_param": {
+                "type": "integer",
+                "default": 10,
+                "title": "Old param",
+                "description": "Deprecated param.",
+                "x-deprecated": "Use 'new_param' instead."
+            },
+            "current_param": {
+                "type": "integer",
+                "default": 20,
+                "title": "Current param",
+                "description": "Current param."
+            }
+        }
+    })";
+
+    conf_file_writer empty_config(R"({})");
+    auto descriptor = load_descriptor(schema);
+    auto loader_queue = std::queue<std::unique_ptr<loader>>();
+    loader_queue.push(std::make_unique<json_loader>(empty_config.get()));
+    config_registry registry(std::move(loader_queue), std::move(descriptor));
+    ASSERT_TRUE(registry.get_deprecation_warnings().empty());
+}
+
+TEST(config, config_registry_deprecated_warning_on_explicit_set)
+{
+    const char *schema = R"({
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "Test",
+        "description": "Test",
+        "type": "object",
+        "properties": {
+            "old_param": {
+                "type": "integer",
+                "default": 10,
+                "title": "Old param",
+                "description": "Deprecated param.",
+                "x-deprecated": "Use 'new_param' instead."
+            }
+        }
+    })";
+
+    conf_file_writer json_config(R"({ "old_param": 99 })");
+    env_setter config_file_setter("XLIO_CONFIG_FILE", json_config.get());
+
+    auto descriptor = load_descriptor(schema);
+    auto loader_queue = std::queue<std::unique_ptr<loader>>();
+    loader_queue.push(std::make_unique<json_loader>(json_config.get()));
+    config_registry registry(std::move(loader_queue), std::move(descriptor));
+
+    ASSERT_EQ(registry.get_deprecation_warnings().size(), 1U);
+    EXPECT_NE(registry.get_deprecation_warnings()[0].find("old_param"), std::string::npos);
+    EXPECT_NE(registry.get_deprecation_warnings()[0].find("deprecated"), std::string::npos);
+    EXPECT_NE(registry.get_deprecation_warnings()[0].find("Use 'new_param' instead."),
+              std::string::npos);
+}
+
 TEST(config, config_registry_bad_enum_string)
 {
     conf_file_writer json_config(R"({

--- a/tests/unit_tests/config/json_descriptor_provider.cpp
+++ b/tests/unit_tests/config/json_descriptor_provider.cpp
@@ -716,3 +716,64 @@ TEST(config, parent_objects_return_correct_expected_type)
     EXPECT_THROW(descriptor.get_parent_expected_type("network.tcp.enable"), xlio_exception);
     EXPECT_THROW(descriptor.get_parent_expected_type("nonexistent"), xlio_exception);
 }
+
+TEST(config, json_descriptor_provider_deprecated_boolean)
+{
+    const char *schema = R"({
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "Test Schema",
+        "description": "Test",
+        "type": "object",
+        "properties": {
+            "old_param": {
+                "type": "integer",
+                "default": 100,
+                "title": "Old parameter",
+                "description": "This parameter is deprecated.",
+                "x-deprecated": true
+            },
+            "current_param": {
+                "type": "integer",
+                "default": 200,
+                "title": "Current parameter",
+                "description": "This parameter is current."
+            }
+        }
+    })";
+
+    json_descriptor_provider provider(schema);
+    config_descriptor descriptor = provider.load_descriptors();
+
+    auto old_desc = descriptor.get_parameter("old_param");
+    ASSERT_TRUE(old_desc.is_deprecated());
+    ASSERT_TRUE(old_desc.get_deprecation_message()->empty());
+
+    auto current_desc = descriptor.get_parameter("current_param");
+    ASSERT_FALSE(current_desc.is_deprecated());
+}
+
+TEST(config, json_descriptor_provider_deprecated_with_message)
+{
+    const char *schema = R"({
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "Test Schema",
+        "description": "Test",
+        "type": "object",
+        "properties": {
+            "old_toggle": {
+                "type": "boolean",
+                "default": false,
+                "title": "Old toggle",
+                "description": "Deprecated toggle.",
+                "x-deprecated": "Use 'new_toggle' instead."
+            }
+        }
+    })";
+
+    json_descriptor_provider provider(schema);
+    config_descriptor descriptor = provider.load_descriptors();
+
+    auto desc = descriptor.get_parameter("old_toggle");
+    ASSERT_TRUE(desc.is_deprecated());
+    ASSERT_EQ(*desc.get_deprecation_message(), "Use 'new_toggle' instead.");
+}

--- a/tests/unit_tests/config/parameter_descriptor.cpp
+++ b/tests/unit_tests/config/parameter_descriptor.cpp
@@ -593,3 +593,45 @@ TEST_F(power_of_2_or_zero_constraint_test, edge_cases_and_boundaries)
     // Test maximum power of 2 that fits in int64_t
     test_valid_power_of_2(static_cast<int64_t>(1LL << 62)); // 2^62
 }
+
+TEST(config, parameter_descriptor_not_deprecated_by_default)
+{
+    parameter_descriptor desc(std::experimental::any(int64_t(42)));
+    ASSERT_FALSE(desc.is_deprecated());
+    ASSERT_FALSE(static_cast<bool>(desc.get_deprecation_message()));
+}
+
+TEST(config, parameter_descriptor_deprecated_without_message)
+{
+    parameter_descriptor desc(std::experimental::any(int64_t(42)));
+    desc.set_deprecation_message(std::string(""));
+    ASSERT_TRUE(desc.is_deprecated());
+    ASSERT_TRUE(static_cast<bool>(desc.get_deprecation_message()));
+    ASSERT_TRUE(desc.get_deprecation_message()->empty());
+}
+
+TEST(config, parameter_descriptor_deprecated_with_message)
+{
+    parameter_descriptor desc(std::experimental::any(bool(true)));
+    desc.set_deprecation_message(std::string("Use 'new_param' instead."));
+    ASSERT_TRUE(desc.is_deprecated());
+    ASSERT_EQ(*desc.get_deprecation_message(), "Use 'new_param' instead.");
+}
+
+TEST(config, parameter_descriptor_deprecated_cleared_by_nullopt)
+{
+    parameter_descriptor desc(std::experimental::any(int64_t(10)));
+    desc.set_deprecation_message(std::string("old message"));
+    ASSERT_TRUE(desc.is_deprecated());
+    desc.set_deprecation_message(std::experimental::nullopt);
+    ASSERT_FALSE(desc.is_deprecated());
+}
+
+TEST(config, parameter_descriptor_deprecated_survives_copy)
+{
+    parameter_descriptor desc(std::experimental::any(int64_t(5)));
+    desc.set_deprecation_message(std::string("Copied msg"));
+    parameter_descriptor copy(desc);
+    ASSERT_TRUE(copy.is_deprecated());
+    ASSERT_EQ(*copy.get_deprecation_message(), "Copied msg");
+}

--- a/tests/unit_tests/config/schema_analyzer.cpp
+++ b/tests/unit_tests/config/schema_analyzer.cpp
@@ -212,3 +212,67 @@ TEST_F(schema_analyzer_test, analyze_property_with_constraints)
     ASSERT_EQ(std::experimental::any_cast<int64_t>(*analysis.default_value), 50);
     json_object_put(constrained_property);
 }
+
+TEST_F(schema_analyzer_test, not_deprecated_by_default)
+{
+    auto analysis = schema_analyzer::analyze(simple_property, "test.simple");
+    ASSERT_FALSE(static_cast<bool>(analysis.deprecation_info));
+}
+
+TEST_F(schema_analyzer_test, deprecated_boolean_true)
+{
+    json_object *prop = json_object_new_object();
+    json_object_object_add(prop, "type", json_object_new_string("integer"));
+    json_object_object_add(prop, "default", json_object_new_int(10));
+    json_object_object_add(prop, "title", json_object_new_string("Deprecated Param"));
+    json_object_object_add(prop, "description", json_object_new_string("A deprecated param"));
+    json_object_object_add(prop, "x-deprecated", json_object_new_boolean(true));
+
+    auto analysis = schema_analyzer::analyze(prop, "test.deprecated_bool");
+    ASSERT_TRUE(static_cast<bool>(analysis.deprecation_info));
+    ASSERT_TRUE(analysis.deprecation_info->empty());
+    json_object_put(prop);
+}
+
+TEST_F(schema_analyzer_test, deprecated_boolean_false_means_not_deprecated)
+{
+    json_object *prop = json_object_new_object();
+    json_object_object_add(prop, "type", json_object_new_string("integer"));
+    json_object_object_add(prop, "default", json_object_new_int(10));
+    json_object_object_add(prop, "title", json_object_new_string("Not Deprecated"));
+    json_object_object_add(prop, "description", json_object_new_string("Not deprecated"));
+    json_object_object_add(prop, "x-deprecated", json_object_new_boolean(false));
+
+    auto analysis = schema_analyzer::analyze(prop, "test.not_deprecated_false");
+    ASSERT_FALSE(static_cast<bool>(analysis.deprecation_info));
+    json_object_put(prop);
+}
+
+TEST_F(schema_analyzer_test, deprecated_with_string_message)
+{
+    json_object *prop = json_object_new_object();
+    json_object_object_add(prop, "type", json_object_new_string("boolean"));
+    json_object_object_add(prop, "default", json_object_new_boolean(true));
+    json_object_object_add(prop, "title", json_object_new_string("Old Toggle"));
+    json_object_object_add(prop, "description", json_object_new_string("An old toggle"));
+    json_object_object_add(prop, "x-deprecated",
+                           json_object_new_string("Use 'new_toggle' instead."));
+
+    auto analysis = schema_analyzer::analyze(prop, "test.deprecated_msg");
+    ASSERT_TRUE(static_cast<bool>(analysis.deprecation_info));
+    ASSERT_EQ(*analysis.deprecation_info, "Use 'new_toggle' instead.");
+    json_object_put(prop);
+}
+
+TEST_F(schema_analyzer_test, deprecated_invalid_type_throws)
+{
+    json_object *prop = json_object_new_object();
+    json_object_object_add(prop, "type", json_object_new_string("integer"));
+    json_object_object_add(prop, "default", json_object_new_int(1));
+    json_object_object_add(prop, "title", json_object_new_string("Bad Deprecated"));
+    json_object_object_add(prop, "description", json_object_new_string("Bad deprecated type"));
+    json_object_object_add(prop, "x-deprecated", json_object_new_int(42));
+
+    ASSERT_THROW(schema_analyzer::analyze(prop, "test.bad_deprecated"), xlio_exception);
+    json_object_put(prop);
+}


### PR DESCRIPTION
## Description
Introduce a general mechanism to deprecate config parameters before removal,
warning users when deprecated parameters are explicitly set.

JSON config subsystem (schema-driven):
- Add "x-deprecated" schema extension (boolean or string with message)
- Propagate deprecation metadata through schema_analyzer ->
  parameter_descriptor pipeline
- Collect deprecation warnings in config_registry during loading
- Emit VLOG_WARNING from sys_vars when registry is constructed

Legacy env variables subsystem:
- Add static deprecated_env_vars[] table with getenv()-based checking
  in the legacy get_env_params() path

Deprecate XLIO_MEMORY_LIMIT_USER using the framework.

##### What
Add config parameter deprecation framework.
Deprecate XLIO_MEMORY_LIMIT_USER.

##### Why ?
XLIO_MEMORY_LIMIT_USER is legacy after xlio_heap implementation.

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

