### PR TITLE
issue: 4938837 Fix fd_collection race in multi-worker socket cleanup

### DIFF
--- a/src/core/event/poll_group.cpp
+++ b/src/core/event/poll_group.cpp
@@ -244,7 +244,7 @@ void poll_group::close_socket(sockinfo_tcp *si, bool force /*=false*/)
 {
     int fd = si->get_fd();
     close_socket_helper(si, force);
-    g_p_fd_collection->clear_socket(fd);
+    g_p_fd_collection->clear_socket(fd, si);
 }
 
 void poll_group::close_socket_helper(sockinfo_tcp *si, bool force /*=false*/)

--- a/src/core/sock/fd_collection.cpp
+++ b/src/core/sock/fd_collection.cpp
@@ -50,8 +50,10 @@ fd_collection::fd_collection()
     }
     fdcoll_logdbg("using open files max limit of %d file descriptors", m_n_fd_map_size);
 
-    m_p_sockfd_map = new sockinfo *[m_n_fd_map_size];
-    memset(m_p_sockfd_map, 0, m_n_fd_map_size * sizeof(sockinfo *));
+    m_p_sockfd_map = new std::atomic<sockinfo *>[m_n_fd_map_size];
+    for (int i = 0; i < m_n_fd_map_size; ++i) {
+        m_p_sockfd_map[i].store(nullptr, std::memory_order_relaxed);
+    }
 
     m_p_epfd_map = new epfd_info *[m_n_fd_map_size];
     memset(m_p_epfd_map, 0, m_n_fd_map_size * sizeof(epfd_info *));
@@ -87,13 +89,9 @@ void fd_collection::prepare_to_close()
 {
     lock();
     for (int fd = 0; fd < m_n_fd_map_size; ++fd) {
-        if (m_p_sockfd_map[fd]) {
-            if (!g_is_forked_child) {
-                sockinfo *p_sfd_api = get_sockfd(fd);
-                if (p_sfd_api) {
-                    p_sfd_api->prepare_to_close(true);
-                }
-            }
+        sockinfo *p_sfd_api = m_p_sockfd_map[fd].load(std::memory_order_relaxed);
+        if (p_sfd_api && !g_is_forked_child) {
+            p_sfd_api->prepare_to_close(true);
         }
     }
     unlock();
@@ -125,16 +123,14 @@ void fd_collection::clear()
     /* Clean up all left overs sockinfo
      */
     for (fd = 0; fd < m_n_fd_map_size; ++fd) {
-        if (m_p_sockfd_map[fd]) {
+        sockinfo *p_sfd_api = m_p_sockfd_map[fd].load(std::memory_order_relaxed);
+        if (p_sfd_api) {
             if (!g_is_forked_child) {
-                sockinfo *p_sfd_api = get_sockfd(fd);
-                if (p_sfd_api) {
-                    p_sfd_api->statistics_print();
-                    p_sfd_api->clean_socket_obj();
-                }
+                p_sfd_api->statistics_print();
+                p_sfd_api->clean_socket_obj();
             }
 
-            m_p_sockfd_map[fd] = nullptr;
+            m_p_sockfd_map[fd].store(nullptr, std::memory_order_relaxed);
             fdcoll_logdbg("destroyed fd=%d", fd);
         }
 
@@ -235,7 +231,7 @@ int fd_collection::addsocket(int fd, int domain, int type, bool check_offload /*
 
     assert(!get_sockfd(fd));
     assert(!get_epfd(fd));
-    m_p_sockfd_map[fd] = p_sfd_api_obj;
+    m_p_sockfd_map[fd].store(p_sfd_api_obj, std::memory_order_release);
 
     unlock();
 
@@ -428,7 +424,7 @@ int fd_collection::del_sockfd(int fd, bool is_for_udp_pool /*=false*/)
             // the socket is already closable
             // This may register the socket to be erased by internal thread,
             // However, a timer may tick on this socket before it is deleted.
-            ret_val = del_socket(fd, m_p_sockfd_map);
+            ret_val = del_socket(fd);
         } else {
             lock();
             // The socket is not ready for close.
@@ -437,11 +433,11 @@ int fd_collection::del_sockfd(int fd, bool is_for_udp_pool /*=false*/)
             // This will be done from fd_col timer handler.
             // Used for UDP socket pool as well
             // so closed UDP sockets will be deleted at the end of the world
-            if (m_p_sockfd_map[fd] == p_sfd_api) {
+            if (m_p_sockfd_map[fd].load(std::memory_order_relaxed) == p_sfd_api) {
                 if (!is_for_udp_pool) {
                     ++g_global_stat_static.n_pending_sockets;
                 }
-                m_p_sockfd_map[fd] = nullptr;
+                m_p_sockfd_map[fd].store(nullptr, std::memory_order_release);
                 m_pending_to_remove_lst.push_front(p_sfd_api);
             }
 
@@ -460,7 +456,7 @@ bool fd_collection::handle_worker_threads_mode_close(int fd, sockinfo *p_sfd_api
         if (tcp_si->get_entity_context()) {
             // Incoming/outgoing sockets - delegate to entity context and return
             // Clear the socket from the fd_collection before delegating
-            clear_socket(fd);
+            clear_socket(fd, p_sfd_api);
             handle_socket_close_job_worker_threads_mode(tcp_si);
             return true; // Should return from del_sockfd
         } else if (tcp_si->get_listen_context()) {
@@ -540,7 +536,7 @@ template <typename cls> int fd_collection::del(int fd, bool b_cleanup, cls **map
     return -1;
 }
 
-int fd_collection::del_socket(int fd, sockinfo **map_type)
+int fd_collection::del_socket(int fd)
 {
     fdcoll_logfunc("fd=%d", fd);
 
@@ -549,9 +545,9 @@ int fd_collection::del_socket(int fd, sockinfo **map_type)
     }
 
     lock();
-    sockinfo *p_obj = map_type[fd];
+    sockinfo *p_obj = m_p_sockfd_map[fd].load(std::memory_order_relaxed);
     if (p_obj) {
-        map_type[fd] = nullptr;
+        m_p_sockfd_map[fd].store(nullptr, std::memory_order_release);
         unlock();
         p_obj->clean_socket_obj();
         return 0;
@@ -599,8 +595,8 @@ bool fd_collection::pop_socket_pool(int &fd, bool &add_to_udp_pool, int type)
         // use fd from pool - will skip creation of new fd by os
         sockinfo *sockfd = m_socket_pool.top();
         fd = sockfd->get_fd();
-        if (!m_p_sockfd_map[fd]) {
-            m_p_sockfd_map[fd] = sockfd;
+        if (!m_p_sockfd_map[fd].load(std::memory_order_relaxed)) {
+            m_p_sockfd_map[fd].store(sockfd, std::memory_order_release);
             m_pending_to_remove_lst.erase(sockfd);
         }
         sockfd->prepare_to_close_socket_pool(false);

--- a/src/core/sock/fd_collection.h
+++ b/src/core/sock/fd_collection.h
@@ -7,6 +7,7 @@
 #ifndef FD_COLLECTION_H
 #define FD_COLLECTION_H
 
+#include <atomic>
 #include <stack>
 #include <unordered_map>
 
@@ -109,8 +110,17 @@ public:
      */
     int del_cq_channel_fd(int fd, bool b_cleanup = false);
 
-    void set_socket(int fd, sockinfo *si) { m_p_sockfd_map[fd] = si; }
-    void clear_socket(int fd) { m_p_sockfd_map[fd] = nullptr; }
+    void set_socket(int fd, sockinfo *si)
+    {
+        m_p_sockfd_map[fd].store(si, std::memory_order_release);
+    }
+
+    // Only clears the entry if it still points to `expected`, preventing a stale
+    // clear from wiping a new socket that reused the same fd on another thread.
+    void clear_socket(int fd, sockinfo *expected)
+    {
+        m_p_sockfd_map[fd].compare_exchange_strong(expected, nullptr, std::memory_order_acq_rel);
+    }
 
     /**
      * Call set_immediate_os_sample of the input fd.
@@ -165,7 +175,7 @@ public:
 private:
     template <typename cls> int del(int fd, bool b_cleanup, cls **map_type);
     template <typename cls> inline cls *get(int fd, cls **map_type);
-    int del_socket(int fd, sockinfo **map_type);
+    int del_socket(int fd);
     inline bool is_valid_fd(int fd);
 
     inline bool create_offloaded_sockets();
@@ -181,7 +191,7 @@ private:
 
 private:
     int m_n_fd_map_size;
-    sockinfo **m_p_sockfd_map;
+    std::atomic<sockinfo *> *m_p_sockfd_map;
     epfd_info **m_p_epfd_map;
     cq_channel_info **m_p_cq_channel_map;
 
@@ -225,7 +235,7 @@ inline void fd_collection::reuse_sockfd(int fd, sockinfo *p_sfd_api_obj)
 {
     lock();
     m_pending_to_remove_lst.erase(p_sfd_api_obj);
-    m_p_sockfd_map[fd] = p_sfd_api_obj;
+    m_p_sockfd_map[fd].store(p_sfd_api_obj, std::memory_order_release);
     --g_global_stat_static.n_pending_sockets;
     unlock();
 }
@@ -241,7 +251,13 @@ inline void fd_collection::destroy_sockfd(sockinfo *p_sfd_api_obj)
 
 inline sockinfo *fd_collection::get_sockfd(int fd)
 {
-    return get(fd, m_p_sockfd_map);
+    if (!is_valid_fd(fd)) {
+        return nullptr;
+    }
+    // acquire pairs with the release in set_socket/addsocket to guarantee
+    // cross-thread visibility (e.g. ring packet-processing calling get_sockfd
+    // for a socket registered on a different worker thread).
+    return m_p_sockfd_map[fd].load(std::memory_order_acquire);
 }
 
 inline epfd_info *fd_collection::get_epfd(int fd)

--- a/src/core/sock/sock-extra.cpp
+++ b/src/core/sock/sock-extra.cpp
@@ -234,7 +234,7 @@ extern "C" int xlio_socket_destroy(xlio_socket_t sock)
         grp->mark_socket_to_close(si);
     } else {
         // Detached socket flow.
-        g_p_fd_collection->clear_socket(si->get_fd());
+        g_p_fd_collection->clear_socket(si->get_fd(), si);
         si->prepare_to_close(true);
         si->clean_socket_obj();
     }


### PR DESCRIPTION
## Description
With multiple poll_group workers sharing the global fd_collection, clear_socket() can wipe a freshly-added entry that belongs to a different socket on another thread. The race occurs when an fd is reused by the OS after destruction:

  Worker A: close_socket(si_old) → clear_socket(fd) [unconditional]
  Worker B: addsocket() stores si_new at same fd (reused by OS)
  Worker A: clear_socket(fd) wipes si_new → accept_clone() fails

This manifests as "Can not get accept socket from FD collection" warnings and dropped SYN packets under high connection churn.

Replace the raw sockinfo pointer array with std::atomic<sockinfo *> to eliminate undefined behavior from concurrent access. Change clear_socket() from an unconditional store to a compare-and-swap that only clears the entry if it still points to the expected socket, preventing a stale clear from clobbering a new socket that reused the same fd.

##### What
Fix fd_collection race where clear_socket() wipes a freshly-added socket entry on another worker thread.

##### Why ?
With multiple poll_group workers sharing the global fd_collection, an unconditional clear_socket(fd) can race with addsocket() on another thread when the OS reuses a file descriptor. Worker A's stale clear wipes Worker B's new entry, causing accept_clone() to fail with "Can not get accept socket from FD collection" and dropping SYN packets. Under high connection churn (8 workers, 8192 connections) with SYN storm and RSTs, this amplifies connection establishment failures and worker initialization timeouts.

##### How ?
Replace sockinfo **m_p_sockfd_map with std::atomic<sockinfo *> * to eliminate undefined behavior from concurrent lockless access. Change clear_socket(fd) from an unconditional store(nullptr) to a compare_exchange_strong that only clears the entry if it still points to the expected socket. All callers now pass the socket pointer they intend to clean up. If another thread has already replaced the entry with a new socket, the CAS fails silently and the new entry is preserved. Stores use memory_order_release and the CAS uses memory_order_acq_rel to ensure correct cross-thread visibility. Reads use memory_order_relaxed since they are either same-thread (accept_clone hot path) or protected by the fd_collection mutex. del_socket() is changed from a generic template parameter to directly access the now-atomic m_p_sockfd_map.

## Change type
What kind of change does this PR introduce?
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

