### PR TITLE
issue: 4956979 Fix tcp_pcb::nrtx overflow and OOB array read

### DIFF
--- a/src/core/lwip/def.h
+++ b/src/core/lwip/def.h
@@ -45,6 +45,10 @@ extern "C" {
 #define NULL ((void *)0)
 #endif
 
+#ifndef ARRAY_SIZE
+#define ARRAY_SIZE(arr) (sizeof(arr) / sizeof(arr[0]))
+#endif /* ARRAY_SIZE */
+
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 /* These macros should be calculated by the preprocessor and are used
    with compile-time constants only (so that there is no little-endian

--- a/src/core/lwip/tcp.c
+++ b/src/core/lwip/tcp.c
@@ -46,6 +46,7 @@
 #include "core/lwip/tcp.h"
 #include "core/lwip/tcp_impl.h"
 
+#include <assert.h>
 #include <string.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -99,7 +100,9 @@ u32_t lwip_tcp_nodelay_treshold = 0;
 static u32_t slow_tmr_interval;
 /* Incremented every coarse grained timer shot (typically every slow_tmr_interval ms). */
 u32_t tcp_ticks = 0;
-const u8_t tcp_backoff[13] = {1, 2, 3, 4, 5, 6, 7, 7, 7, 7, 7, 7, 7};
+
+static_assert(TCP_SYNMAXRTX <= TCP_MAXRTX, "TCP_SYNMAXRTX must not exceed TCP_MAXRTX");
+const u8_t tcp_backoff[TCP_MAXRTX] = {1, 2, 3, 4, 5, 6, 7, 7, 7, 7, 7, 7};
 /* Times per slowtmr hits */
 const u8_t tcp_persist_backoff[7] = {3, 6, 12, 24, 48, 96, 120};
 
@@ -620,11 +623,11 @@ void tcp_slowtmr(struct tcp_pcb *pcb)
             err = ERR_TIMEOUT;
             pcb_reset += (pcb->so_options & SOF_KEEPALIVE);
             LWIP_DEBUGF(TCP_DEBUG, ("tcp_slowtmr: user timeout occurred\n"));
-        } else if (get_tcp_state(pcb) == SYN_SENT && pcb->nrtx == TCP_SYNMAXRTX) {
+        } else if (get_tcp_state(pcb) == SYN_SENT && pcb->nrtx >= TCP_SYNMAXRTX) {
             ++pcb_remove;
             err = ERR_TIMEOUT;
             LWIP_DEBUGF(TCP_DEBUG, ("tcp_slowtmr: max SYN retries reached\n"));
-        } else if (pcb->nrtx == TCP_MAXRTX) {
+        } else if (pcb->nrtx >= TCP_MAXRTX) {
             ++pcb_remove;
             err = ERR_ABRT;
             LWIP_DEBUGF(TCP_DEBUG, ("tcp_slowtmr: max DATA retries reached\n"));
@@ -635,7 +638,7 @@ void tcp_slowtmr(struct tcp_pcb *pcb)
                 pcb->persist_cnt++;
                 if (pcb->persist_cnt >= tcp_persist_backoff[pcb->persist_backoff - 1]) {
                     pcb->persist_cnt = 0;
-                    if (pcb->persist_backoff < sizeof(tcp_persist_backoff)) {
+                    if (pcb->persist_backoff < ARRAY_SIZE(tcp_persist_backoff)) {
                         pcb->persist_backoff++;
                     }
                     /* Use tcp_keepalive() instead of tcp_zero_window_probe() to probe for window

--- a/src/core/lwip/tcp.c
+++ b/src/core/lwip/tcp.c
@@ -46,6 +46,7 @@
 #include "core/lwip/tcp.h"
 #include "core/lwip/tcp_impl.h"
 
+#include <assert.h>
 #include <string.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -99,7 +100,11 @@ u32_t lwip_tcp_nodelay_treshold = 0;
 u32_t slow_tmr_interval;
 /* Incremented every coarse grained timer shot (typically every slow_tmr_interval ms). */
 u32_t tcp_ticks = 0;
-const u8_t tcp_backoff[13] = {1, 2, 3, 4, 5, 6, 7, 7, 7, 7, 7, 7, 7};
+
+const u8_t tcp_backoff[] = {1, 2, 3, 4, 5, 6, 7, 7, 7, 7, 7, 7};
+static_assert(TCP_MAXRTX <= ARRAY_SIZE(tcp_backoff),
+              "TCP_MAXRTX exceeds tcp_backoff table capacity");
+static_assert(TCP_SYNMAXRTX <= TCP_MAXRTX, "TCP_SYNMAXRTX must not exceed TCP_MAXRTX");
 /* Times per slowtmr hits */
 const u8_t tcp_persist_backoff[7] = {3, 6, 12, 24, 48, 96, 120};
 
@@ -620,11 +625,11 @@ void tcp_slowtmr(struct tcp_pcb *pcb)
             err = ERR_TIMEOUT;
             pcb_reset += (pcb->so_options & SOF_KEEPALIVE);
             LWIP_DEBUGF(TCP_DEBUG, ("tcp_slowtmr: user timeout occurred\n"));
-        } else if (get_tcp_state(pcb) == SYN_SENT && pcb->nrtx == TCP_SYNMAXRTX) {
+        } else if (get_tcp_state(pcb) == SYN_SENT && pcb->nrtx >= TCP_SYNMAXRTX) {
             ++pcb_remove;
             err = ERR_TIMEOUT;
             LWIP_DEBUGF(TCP_DEBUG, ("tcp_slowtmr: max SYN retries reached\n"));
-        } else if (pcb->nrtx == TCP_MAXRTX) {
+        } else if (pcb->nrtx >= TCP_MAXRTX) {
             ++pcb_remove;
             err = ERR_ABRT;
             LWIP_DEBUGF(TCP_DEBUG, ("tcp_slowtmr: max DATA retries reached\n"));
@@ -635,7 +640,7 @@ void tcp_slowtmr(struct tcp_pcb *pcb)
                 pcb->persist_cnt++;
                 if (pcb->persist_cnt >= tcp_persist_backoff[pcb->persist_backoff - 1]) {
                     pcb->persist_cnt = 0;
-                    if (pcb->persist_backoff < sizeof(tcp_persist_backoff)) {
+                    if (pcb->persist_backoff < ARRAY_SIZE(tcp_persist_backoff)) {
                         pcb->persist_backoff++;
                     }
                     /* Use tcp_keepalive() instead of tcp_zero_window_probe() to probe for window

--- a/src/core/lwip/tcp_out.c
+++ b/src/core/lwip/tcp_out.c
@@ -1660,7 +1660,9 @@ void tcp_rexmit(struct tcp_pcb *pcb)
         pcb->last_unsent = seg;
     }
 
-    ++pcb->nrtx;
+    if (pcb->nrtx < TCP_MAXRTX) {
+        ++pcb->nrtx;
+    }
 
     /* Don't take any rtt measurements after retransmitting. */
     pcb->rttest = 0;

--- a/src/core/lwip/tcp_out.c
+++ b/src/core/lwip/tcp_out.c
@@ -1664,7 +1664,9 @@ void tcp_rexmit(struct tcp_pcb *pcb)
         pcb->last_unsent = seg;
     }
 
-    ++pcb->nrtx;
+    if (pcb->nrtx < TCP_MAXRTX) {
+        ++pcb->nrtx;
+    }
 
     /* Don't take any rtt measurements after retransmitting. */
     pcb->rttest = 0;


### PR DESCRIPTION
## Description
The retransmission counter (nrtx) can be incremented from both the RTO slow timer path (tcp_rexmit_rto) and the fast retransmit path (tcp_rexmit) without bounds checking. If nrtx skips past the exact TCP_MAXRTX or TCP_SYNMAXRTX threshold between two slow timer ticks, the equality check (==) never matches: the connection is never terminated and subsequent access to tcp_backoff[nrtx] reads out of bounds.

* Change the checks to >= so overshooting the threshold is handled correctly.
* Size tcp_backoff using TCP_MAXRTX instead of a hardcoded literal, so any changes to the TCP_MAXRTX constant force to adjust the backoff array and avoid OOB reads.
* Don't overflow nrtx in tcp_rexmit() which can be called from tcp_in.c between timer ticks.

Note, current fix still allows to retransmit a segment more than TCP_MAXRTX times if the extra retransmissions happen between the TCP timer ticks.

##### What
Fix tcp_pcb::nrtx overflow, OOB array read and endless RTO.

##### Why ?
Bugfixes.

## Change type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved TCP retry logic to prevent counter overflow and enhance connection stability.
  * Fixed retry exhaustion handling in connection establishment to trigger at the correct threshold.

* **Chores**
  * Added compile-time safety checks for TCP configuration parameters to catch invalid settings early.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mellanox/libxlio/pull/600)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->