### PR TITLE
issue: 4962651 Fix "use xlio" keyword rejected by rules parser

### DIFF
--- a/src/core/util/config_parser.y
+++ b/src/core/util/config_parser.y
@@ -51,7 +51,7 @@ int __xlio_config_empty(void)
 /* define the address by 4 integers */
 static void __xlio_set_ipv4_addr(short a0, short a1, short a2, short a3)
 {
-	char buf[16];
+	char buf[32];
 	struct in_addr *p_ipv4 = NULL;
   
 	p_ipv4 = &(__xlio_address_port_rule->ipv4);
@@ -497,12 +497,12 @@ int __xlio_parse_config_file (const char *fileName) {
 	return(parse_err);
 }
 
-int __xlio_parse_config_line (char *line) {
+int __xlio_parse_config_line (const char *line) {
 	extern FILE * libxlio_yyin;
 	
 	__xlio_rule_push_head = 1;
 	
-	libxlio_yyin = fmemopen(line, strlen(line), "r");
+	libxlio_yyin = fmemopen((void *)line, strlen(line), "r");
 	
 	if (!libxlio_yyin) {
 		printf("libxlio Error: Fail to parse line:%s\n", line);

--- a/third_party/legacy_config_parser/config_parser.c
+++ b/third_party/legacy_config_parser/config_parser.c
@@ -1,21 +1,22 @@
-/* A Bison parser, made by GNU Bison 2.7.  */
+/* A Bison parser, made by GNU Bison 3.8.2.  */
 
 /* Bison implementation for Yacc-like parsers in C
-   
-      Copyright (C) 1984, 1989-1990, 2000-2012 Free Software Foundation, Inc.
-   
+
+   Copyright (C) 1984, 1989-1990, 2000-2015, 2018-2021 Free Software Foundation,
+   Inc.
+
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation, either version 3 of the License, or
    (at your option) any later version.
-   
+
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
    GNU General Public License for more details.
-   
+
    You should have received a copy of the GNU General Public License
-   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.  */
 
 /* As a special exception, you may create a larger work that contains
    part or all of the Bison parser skeleton and distribute that work
@@ -26,12 +27,16 @@
    special exception, which will cause the skeleton and the resulting
    Bison output files to be licensed under the GNU General Public
    License without this special exception.
-   
+
    This special exception was added by the Free Software Foundation in
    version 2.2 of Bison.  */
 
 /* C LALR(1) parser skeleton written by Richard Stallman, by
    simplifying the original so-called "semantic" parser.  */
+
+/* DO NOT RELY ON FEATURES THAT ARE NOT DOCUMENTED in the manual,
+   especially those whose name start with YY_ or yy_.  They are
+   private implementation details that can be changed or removed.  */
 
 /* All symbols defined below should begin with yy or YY, to avoid
    infringing on user name space.  This should be done even for local
@@ -40,11 +45,11 @@
    define necessary library symbols; they are noted "INFRINGES ON
    USER NAME SPACE" below.  */
 
-/* Identify Bison output.  */
-#define YYBISON 1
+/* Identify Bison output, and Bison version.  */
+#define YYBISON 30802
 
-/* Bison version.  */
-#define YYBISON_VERSION "2.7"
+/* Bison version string.  */
+#define YYBISON_VERSION "3.8.2"
 
 /* Skeleton name.  */
 #define YYSKELETON_NAME "yacc.c"
@@ -63,14 +68,13 @@
 #define yyparse         libxlio_yyparse
 #define yylex           libxlio_yylex
 #define yyerror         libxlio_yyerror
-#define yylval          libxlio_yylval
-#define yychar          libxlio_yychar
 #define yydebug         libxlio_yydebug
 #define yynerrs         libxlio_yynerrs
+#define yylval          libxlio_yylval
+#define yychar          libxlio_yychar
 
-/* Copy the first part of user declarations.  */
-/* Line 371 of yacc.c  */
-/* Line 39 of config_parser.y */
+/* First part of user prologue.  */
+#line 13 "src/core/util/config_parser.y"
 
 
 /* header section */
@@ -112,12 +116,12 @@ int __xlio_config_empty(void)
 /* define the address by 4 integers */
 static void __xlio_set_ipv4_addr(short a0, short a1, short a2, short a3)
 {
-	char buf[16];
+	char buf[32];
 	struct in_addr *p_ipv4 = NULL;
   
 	p_ipv4 = &(__xlio_address_port_rule->ipv4);
   
-	snprintf(buf, sizeof(buf), "%hd.%hd.%hd.%hd", a0, a1, a2, a3);
+	sprintf(buf,"%d.%d.%d.%d", a0, a1, a2, a3);
 	if (1 != inet_pton(AF_INET, (const char*)buf, p_ipv4)) {
 		parse_err = 1;
 		yyerror("provided address is not legal");
@@ -160,7 +164,7 @@ void __xlio_dump_address_port_rule_config_state(char *buf) {
 }
 
 /* dump the current state in readable format */
-static void  __xlio_dump_rule_config_state(void) {
+static void  __xlio_dump_rule_config_state() {
 	char buf[1024];
 	sprintf(buf, "\tACCESS CONFIG: use %s %s %s ", 
 			__xlio_get_transport_str(__xlio_rule.target_transport), 
@@ -177,7 +181,7 @@ static void  __xlio_dump_rule_config_state(void) {
 }
 
 /* dump configuration properites of new instance */
-static void  __xlio_dump_instance(void) {
+static void  __xlio_dump_instance() {
 	char buf[1024];
 	
 	if (curr_instance) {
@@ -220,7 +224,7 @@ static void __xlio_add_dbl_lst_node(struct dbl_lst *lst, struct dbl_lst_node *no
 	}
 }
 
-static struct dbl_lst_node* __xlio_allocate_dbl_lst_node(void)
+static struct dbl_lst_node* __xlio_allocate_dbl_lst_node()
 {
 	struct dbl_lst_node *ret_val = NULL;
 	
@@ -255,9 +259,9 @@ static void __xlio_add_instance(char *prog_name_expr, char *user_defined_id) {
 	
 	new_instance = (struct instance*) malloc(sizeof(struct instance));
 	if (!new_instance) {
+		free(new_node);
 		yyerror("fail to allocate new instance");
 		parse_err = 1;
-		free(new_node);
 		return;
 	}
 
@@ -272,7 +276,6 @@ static void __xlio_add_instance(char *prog_name_expr, char *user_defined_id) {
 			free(new_instance->id.prog_name_expr);
 		if (new_instance->id.user_defined_id)
 			free(new_instance->id.user_defined_id);
-		free(new_node);
 		free(new_instance);
 		return;
 	}
@@ -289,13 +292,13 @@ static void __xlio_add_inst_with_int_uid(char *prog_name_expr, int user_defined_
 }
 
 /* use the above state for making a new rule */
-static void __xlio_add_rule(void) {
+static void __xlio_add_rule() {
 	struct dbl_lst *p_lst;
 	struct use_family_rule *rule;
 	struct dbl_lst_node *new_node;
 
 	if (!curr_instance)
-		__xlio_add_instance((char *)"*", (char *)"*");
+		__xlio_add_instance("*", "*");
   	if (!curr_instance)
 		return;
   
@@ -328,9 +331,9 @@ static void __xlio_add_rule(void) {
 	
 	rule = (struct use_family_rule *)malloc(sizeof(*rule));
 	if (!rule) {
+		free(new_node);
 		yyerror("fail to allocate new rule");
 		parse_err = 1;
-		free(new_node);
 		return;
 	}
 	memset(rule, 0, sizeof(*rule));
@@ -343,171 +346,189 @@ static void __xlio_add_rule(void) {
 }
 
 
-/* Line 371 of yacc.c  */
-/* Line 341 of config_parser.c  */
+#line 350 "third_party/legacy_config_parser/config_parser.c"
 
-# ifndef YY_NULL
-#  if defined __cplusplus && 201103L <= __cplusplus
-#   define YY_NULL nullptr
+# ifndef YY_CAST
+#  ifdef __cplusplus
+#   define YY_CAST(Type, Val) static_cast<Type> (Val)
+#   define YY_REINTERPRET_CAST(Type, Val) reinterpret_cast<Type> (Val)
 #  else
-#   define YY_NULL 0
+#   define YY_CAST(Type, Val) ((Type) (Val))
+#   define YY_REINTERPRET_CAST(Type, Val) ((Type) (Val))
+#  endif
+# endif
+# ifndef YY_NULLPTR
+#  if defined __cplusplus
+#   if 201103L <= __cplusplus
+#    define YY_NULLPTR nullptr
+#   else
+#    define YY_NULLPTR 0
+#   endif
+#  else
+#   define YY_NULLPTR ((void*)0)
 #  endif
 # endif
 
-/* Enabling verbose error messages.  */
-#ifdef YYERROR_VERBOSE
-# undef YYERROR_VERBOSE
-# define YYERROR_VERBOSE 1
-#else
-# define YYERROR_VERBOSE 0
-#endif
-
-/* In a future release of Bison, this section will be replaced
-   by #include "y.tab.h".  */
-#ifndef YY_Y_TAB_H_INCLUDED
-# define YY_Y_TAB_H_INCLUDED
-/* Enabling traces.  */
-#ifndef YYDEBUG
-# define YYDEBUG 0
-#endif
-#if YYDEBUG
-extern int libxlio_yydebug;
-#endif
-
-/* Tokens.  */
-#ifndef YYTOKENTYPE
-# define YYTOKENTYPE
-   /* Put the tokens into the symbol table, so that GDB and other debuggers
-      know about them.  */
-   enum yytokentype {
-     USE = 258,
-     TCP_CLIENT = 259,
-     TCP_SERVER = 260,
-     UDP_SENDER = 261,
-     UDP_RECEIVER = 262,
-     UDP_CONNECT = 263,
-     TCP = 264,
-     UDP = 265,
-     OS = 266,
-     XLIO = 267,
-     SDP = 268,
-     SA = 269,
-     INT = 270,
-     APP_ID = 271,
-     PROGRAM = 272,
-     USER_DEFINED_ID_STR = 273,
-     LOG = 274,
-     DEST = 275,
-     STDERR = 276,
-     SYSLOG = 277,
-     FILENAME = 278,
-     NAME = 279,
-     LEVEL = 280,
-     LINE = 281
-   };
-#endif
-/* Tokens.  */
-#define USE 258
-#define TCP_CLIENT 259
-#define TCP_SERVER 260
-#define UDP_SENDER 261
-#define UDP_RECEIVER 262
-#define UDP_CONNECT 263
-#define TCP 264
-#define UDP 265
-#define OS 266
-#define XLIO 267
-#define SDP 268
-#define SA 269
-#define INT 270
-#define APP_ID 271
-#define PROGRAM 272
-#define USER_DEFINED_ID_STR 273
-#define LOG 274
-#define DEST 275
-#define STDERR 276
-#define SYSLOG 277
-#define FILENAME 278
-#define NAME 279
-#define LEVEL 280
-#define LINE 281
-
-
-
-#if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
-typedef union YYSTYPE
+#include "config_parser.h"
+/* Symbol kind.  */
+enum yysymbol_kind_t
 {
-/* Line 387 of yacc.c  */
-/* Line 306 of config_parser.y */
+  YYSYMBOL_YYEMPTY = -2,
+  YYSYMBOL_YYEOF = 0,                      /* "end of file"  */
+  YYSYMBOL_YYerror = 1,                    /* error  */
+  YYSYMBOL_YYUNDEF = 2,                    /* "invalid token"  */
+  YYSYMBOL_USE = 3,                        /* "use"  */
+  YYSYMBOL_TCP_CLIENT = 4,                 /* "tcp client"  */
+  YYSYMBOL_TCP_SERVER = 5,                 /* "tcp server"  */
+  YYSYMBOL_UDP_SENDER = 6,                 /* "udp sender"  */
+  YYSYMBOL_UDP_RECEIVER = 7,               /* "udp receiver"  */
+  YYSYMBOL_UDP_CONNECT = 8,                /* "udp connect"  */
+  YYSYMBOL_TCP = 9,                        /* "tcp"  */
+  YYSYMBOL_UDP = 10,                       /* "udp"  */
+  YYSYMBOL_OS = 11,                        /* "os"  */
+  YYSYMBOL_XLIO = 12,                      /* "xlio"  */
+  YYSYMBOL_SDP = 13,                       /* "sdp"  */
+  YYSYMBOL_SA = 14,                        /* "sa"  */
+  YYSYMBOL_INT = 15,                       /* "integer value"  */
+  YYSYMBOL_APP_ID = 16,                    /* "application id"  */
+  YYSYMBOL_PROGRAM = 17,                   /* "program name"  */
+  YYSYMBOL_USER_DEFINED_ID_STR = 18,       /* "userdefined id str"  */
+  YYSYMBOL_LOG = 19,                       /* "log statement"  */
+  YYSYMBOL_DEST = 20,                      /* "destination"  */
+  YYSYMBOL_STDERR = 21,                    /* "ystderr"  */
+  YYSYMBOL_SYSLOG = 22,                    /* "syslog"  */
+  YYSYMBOL_FILENAME = 23,                  /* "yfile"  */
+  YYSYMBOL_NAME = 24,                      /* "a name"  */
+  YYSYMBOL_LEVEL = 25,                     /* "min-level"  */
+  YYSYMBOL_LINE = 26,                      /* "new line"  */
+  YYSYMBOL_27_ = 27,                       /* '*'  */
+  YYSYMBOL_28_ = 28,                       /* ':'  */
+  YYSYMBOL_29_ = 29,                       /* '/'  */
+  YYSYMBOL_30_ = 30,                       /* '.'  */
+  YYSYMBOL_31_ = 31,                       /* '-'  */
+  YYSYMBOL_YYACCEPT = 32,                  /* $accept  */
+  YYSYMBOL_NL = 33,                        /* NL  */
+  YYSYMBOL_ONL = 34,                       /* ONL  */
+  YYSYMBOL_config = 35,                    /* config  */
+  YYSYMBOL_statements = 36,                /* statements  */
+  YYSYMBOL_statement = 37,                 /* statement  */
+  YYSYMBOL_log_statement = 38,             /* log_statement  */
+  YYSYMBOL_log_opts = 39,                  /* log_opts  */
+  YYSYMBOL_log_dest = 40,                  /* log_dest  */
+  YYSYMBOL_verbosity = 41,                 /* verbosity  */
+  YYSYMBOL_app_id_statement = 42,          /* app_id_statement  */
+  YYSYMBOL_app_id = 43,                    /* app_id  */
+  YYSYMBOL_socket_statement = 44,          /* socket_statement  */
+  YYSYMBOL_use = 45,                       /* use  */
+  YYSYMBOL_transport = 46,                 /* transport  */
+  YYSYMBOL_role = 47,                      /* role  */
+  YYSYMBOL_tuple = 48,                     /* tuple  */
+  YYSYMBOL_three_tuple = 49,               /* three_tuple  */
+  YYSYMBOL_five_tuple = 50,                /* five_tuple  */
+  YYSYMBOL_address_first = 51,             /* address_first  */
+  YYSYMBOL_52_1 = 52,                      /* $@1  */
+  YYSYMBOL_address_second = 53,            /* address_second  */
+  YYSYMBOL_54_2 = 54,                      /* $@2  */
+  YYSYMBOL_address = 55,                   /* address  */
+  YYSYMBOL_ipv4 = 56,                      /* ipv4  */
+  YYSYMBOL_ports = 57                      /* ports  */
+};
+typedef enum yysymbol_kind_t yysymbol_kind_t;
 
-  int        ival;
-  char      *sval;
 
-
-/* Line 387 of yacc.c  */
-/* Line 442 of config_parser.c */
-} YYSTYPE;
-# define YYSTYPE_IS_TRIVIAL 1
-# define yystype YYSTYPE /* obsolescent; will be withdrawn */
-# define YYSTYPE_IS_DECLARED 1
-#endif
-
-extern YYSTYPE libxlio_yylval;
-
-#ifdef YYPARSE_PARAM
-#if defined __STDC__ || defined __cplusplus
-int libxlio_yyparse (void *YYPARSE_PARAM);
-#else
-int libxlio_yyparse ();
-#endif
-#else /* ! YYPARSE_PARAM */
-#if defined __STDC__ || defined __cplusplus
-int libxlio_yyparse (void);
-#else
-int libxlio_yyparse ();
-#endif
-#endif /* ! YYPARSE_PARAM */
-
-#endif /* !YY_Y_TAB_H_INCLUDED  */
-
-/* Copy the second part of user declarations.  */
-/* Line 390 of yacc.c  */
-/* Line 339 of config_parser.y */
+/* Second part of user prologue.  */
+#line 319 "src/core/util/config_parser.y"
 
   long __xlio_config_line_num;
 
-/* Line 390 of yacc.c  */
-/* Line 474 of config_parser.c */
+#line 445 "third_party/legacy_config_parser/config_parser.c"
+
 
 #ifdef short
 # undef short
 #endif
 
-#ifdef YYTYPE_UINT8
-typedef YYTYPE_UINT8 yytype_uint8;
-#else
-typedef unsigned char yytype_uint8;
+/* On compilers that do not define __PTRDIFF_MAX__ etc., make sure
+   <limits.h> and (if available) <stdint.h> are included
+   so that the code can choose integer types of a good width.  */
+
+#ifndef __PTRDIFF_MAX__
+# include <limits.h> /* INFRINGES ON USER NAME SPACE */
+# if defined __STDC_VERSION__ && 199901 <= __STDC_VERSION__
+#  include <stdint.h> /* INFRINGES ON USER NAME SPACE */
+#  define YY_STDINT_H
+# endif
 #endif
 
-#ifdef YYTYPE_INT8
-typedef YYTYPE_INT8 yytype_int8;
-#elif (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
+/* Narrow types that promote to a signed type and that can represent a
+   signed or unsigned integer of at least N bits.  In tables they can
+   save space and decrease cache pressure.  Promoting to a signed type
+   helps avoid bugs in integer arithmetic.  */
+
+#ifdef __INT_LEAST8_MAX__
+typedef __INT_LEAST8_TYPE__ yytype_int8;
+#elif defined YY_STDINT_H
+typedef int_least8_t yytype_int8;
+#else
 typedef signed char yytype_int8;
-#else
-typedef short int yytype_int8;
 #endif
 
-#ifdef YYTYPE_UINT16
-typedef YYTYPE_UINT16 yytype_uint16;
+#ifdef __INT_LEAST16_MAX__
+typedef __INT_LEAST16_TYPE__ yytype_int16;
+#elif defined YY_STDINT_H
+typedef int_least16_t yytype_int16;
 #else
-typedef unsigned short int yytype_uint16;
+typedef short yytype_int16;
 #endif
 
-#ifdef YYTYPE_INT16
-typedef YYTYPE_INT16 yytype_int16;
+/* Work around bug in HP-UX 11.23, which defines these macros
+   incorrectly for preprocessor constants.  This workaround can likely
+   be removed in 2023, as HPE has promised support for HP-UX 11.23
+   (aka HP-UX 11i v2) only through the end of 2022; see Table 2 of
+   <https://h20195.www2.hpe.com/V2/getpdf.aspx/4AA4-7673ENW.pdf>.  */
+#ifdef __hpux
+# undef UINT_LEAST8_MAX
+# undef UINT_LEAST16_MAX
+# define UINT_LEAST8_MAX 255
+# define UINT_LEAST16_MAX 65535
+#endif
+
+#if defined __UINT_LEAST8_MAX__ && __UINT_LEAST8_MAX__ <= __INT_MAX__
+typedef __UINT_LEAST8_TYPE__ yytype_uint8;
+#elif (!defined __UINT_LEAST8_MAX__ && defined YY_STDINT_H \
+       && UINT_LEAST8_MAX <= INT_MAX)
+typedef uint_least8_t yytype_uint8;
+#elif !defined __UINT_LEAST8_MAX__ && UCHAR_MAX <= INT_MAX
+typedef unsigned char yytype_uint8;
 #else
-typedef short int yytype_int16;
+typedef short yytype_uint8;
+#endif
+
+#if defined __UINT_LEAST16_MAX__ && __UINT_LEAST16_MAX__ <= __INT_MAX__
+typedef __UINT_LEAST16_TYPE__ yytype_uint16;
+#elif (!defined __UINT_LEAST16_MAX__ && defined YY_STDINT_H \
+       && UINT_LEAST16_MAX <= INT_MAX)
+typedef uint_least16_t yytype_uint16;
+#elif !defined __UINT_LEAST16_MAX__ && USHRT_MAX <= INT_MAX
+typedef unsigned short yytype_uint16;
+#else
+typedef int yytype_uint16;
+#endif
+
+#ifndef YYPTRDIFF_T
+# if defined __PTRDIFF_TYPE__ && defined __PTRDIFF_MAX__
+#  define YYPTRDIFF_T __PTRDIFF_TYPE__
+#  define YYPTRDIFF_MAXIMUM __PTRDIFF_MAX__
+# elif defined PTRDIFF_MAX
+#  ifndef ptrdiff_t
+#   include <stddef.h> /* INFRINGES ON USER NAME SPACE */
+#  endif
+#  define YYPTRDIFF_T ptrdiff_t
+#  define YYPTRDIFF_MAXIMUM PTRDIFF_MAX
+# else
+#  define YYPTRDIFF_T long
+#  define YYPTRDIFF_MAXIMUM LONG_MAX
+# endif
 #endif
 
 #ifndef YYSIZE_T
@@ -515,16 +536,28 @@ typedef short int yytype_int16;
 #  define YYSIZE_T __SIZE_TYPE__
 # elif defined size_t
 #  define YYSIZE_T size_t
-# elif ! defined YYSIZE_T && (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
+# elif defined __STDC_VERSION__ && 199901 <= __STDC_VERSION__
 #  include <stddef.h> /* INFRINGES ON USER NAME SPACE */
 #  define YYSIZE_T size_t
 # else
-#  define YYSIZE_T unsigned int
+#  define YYSIZE_T unsigned
 # endif
 #endif
 
-#define YYSIZE_MAXIMUM ((YYSIZE_T) -1)
+#define YYSIZE_MAXIMUM                                  \
+  YY_CAST (YYPTRDIFF_T,                                 \
+           (YYPTRDIFF_MAXIMUM < YY_CAST (YYSIZE_T, -1)  \
+            ? YYPTRDIFF_MAXIMUM                         \
+            : YY_CAST (YYSIZE_T, -1)))
+
+#define YYSIZEOF(X) YY_CAST (YYPTRDIFF_T, sizeof (X))
+
+
+/* Stored state numbers (used for stacks). */
+typedef yytype_int8 yy_state_t;
+
+/* State numbers in computations.  */
+typedef int yy_state_fast_t;
 
 #ifndef YY_
 # if defined YYENABLE_NLS && YYENABLE_NLS
@@ -538,32 +571,71 @@ typedef short int yytype_int16;
 # endif
 #endif
 
+
+#ifndef YY_ATTRIBUTE_PURE
+# if defined __GNUC__ && 2 < __GNUC__ + (96 <= __GNUC_MINOR__)
+#  define YY_ATTRIBUTE_PURE __attribute__ ((__pure__))
+# else
+#  define YY_ATTRIBUTE_PURE
+# endif
+#endif
+
+#ifndef YY_ATTRIBUTE_UNUSED
+# if defined __GNUC__ && 2 < __GNUC__ + (7 <= __GNUC_MINOR__)
+#  define YY_ATTRIBUTE_UNUSED __attribute__ ((__unused__))
+# else
+#  define YY_ATTRIBUTE_UNUSED
+# endif
+#endif
+
 /* Suppress unused-variable warnings by "using" E.  */
 #if ! defined lint || defined __GNUC__
-# define YYUSE(E) ((void) (E))
+# define YY_USE(E) ((void) (E))
 #else
-# define YYUSE(E) /* empty */
+# define YY_USE(E) /* empty */
 #endif
 
-/* Identity function, used to suppress warnings about constant conditions.  */
-#ifndef lint
-# define YYID(N) (N)
+/* Suppress an incorrect diagnostic about yylval being uninitialized.  */
+#if defined __GNUC__ && ! defined __ICC && 406 <= __GNUC__ * 100 + __GNUC_MINOR__
+# if __GNUC__ * 100 + __GNUC_MINOR__ < 407
+#  define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN                           \
+    _Pragma ("GCC diagnostic push")                                     \
+    _Pragma ("GCC diagnostic ignored \"-Wuninitialized\"")
+# else
+#  define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN                           \
+    _Pragma ("GCC diagnostic push")                                     \
+    _Pragma ("GCC diagnostic ignored \"-Wuninitialized\"")              \
+    _Pragma ("GCC diagnostic ignored \"-Wmaybe-uninitialized\"")
+# endif
+# define YY_IGNORE_MAYBE_UNINITIALIZED_END      \
+    _Pragma ("GCC diagnostic pop")
 #else
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
-static int
-YYID (int yyi)
-#else
-static int
-YYID (yyi)
-    int yyi;
+# define YY_INITIAL_VALUE(Value) Value
 #endif
-{
-  return yyi;
-}
+#ifndef YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
+# define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
+# define YY_IGNORE_MAYBE_UNINITIALIZED_END
+#endif
+#ifndef YY_INITIAL_VALUE
+# define YY_INITIAL_VALUE(Value) /* Nothing. */
 #endif
 
-#if ! defined yyoverflow || YYERROR_VERBOSE
+#if defined __cplusplus && defined __GNUC__ && ! defined __ICC && 6 <= __GNUC__
+# define YY_IGNORE_USELESS_CAST_BEGIN                          \
+    _Pragma ("GCC diagnostic push")                            \
+    _Pragma ("GCC diagnostic ignored \"-Wuseless-cast\"")
+# define YY_IGNORE_USELESS_CAST_END            \
+    _Pragma ("GCC diagnostic pop")
+#endif
+#ifndef YY_IGNORE_USELESS_CAST_BEGIN
+# define YY_IGNORE_USELESS_CAST_BEGIN
+# define YY_IGNORE_USELESS_CAST_END
+#endif
+
+
+#define YY_ASSERT(E) ((void) (0 && (E)))
+
+#if !defined yyoverflow
 
 /* The parser invokes alloca or malloc; define the necessary symbols.  */
 
@@ -580,8 +652,7 @@ YYID (yyi)
 #    define alloca _alloca
 #   else
 #    define YYSTACK_ALLOC alloca
-#    if ! defined _ALLOCA_H && ! defined EXIT_SUCCESS && (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
+#    if ! defined _ALLOCA_H && ! defined EXIT_SUCCESS
 #     include <stdlib.h> /* INFRINGES ON USER NAME SPACE */
       /* Use EXIT_SUCCESS as a witness for stdlib.h.  */
 #     ifndef EXIT_SUCCESS
@@ -593,8 +664,8 @@ YYID (yyi)
 # endif
 
 # ifdef YYSTACK_ALLOC
-   /* Pacify GCC's `empty if-body' warning.  */
-#  define YYSTACK_FREE(Ptr) do { /* empty */; } while (YYID (0))
+   /* Pacify GCC's 'empty if-body' warning.  */
+#  define YYSTACK_FREE(Ptr) do { /* empty */; } while (0)
 #  ifndef YYSTACK_ALLOC_MAXIMUM
     /* The OS might guarantee only one guard page at the bottom of the stack,
        and a page size can be as small as 4096 bytes.  So we cannot safely
@@ -610,7 +681,7 @@ YYID (yyi)
 #  endif
 #  if (defined __cplusplus && ! defined EXIT_SUCCESS \
        && ! ((defined YYMALLOC || defined malloc) \
-	     && (defined YYFREE || defined free)))
+             && (defined YYFREE || defined free)))
 #   include <stdlib.h> /* INFRINGES ON USER NAME SPACE */
 #   ifndef EXIT_SUCCESS
 #    define EXIT_SUCCESS 0
@@ -618,40 +689,37 @@ YYID (yyi)
 #  endif
 #  ifndef YYMALLOC
 #   define YYMALLOC malloc
-#   if ! defined malloc && ! defined EXIT_SUCCESS && (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
+#   if ! defined malloc && ! defined EXIT_SUCCESS
 void *malloc (YYSIZE_T); /* INFRINGES ON USER NAME SPACE */
 #   endif
 #  endif
 #  ifndef YYFREE
 #   define YYFREE free
-#   if ! defined free && ! defined EXIT_SUCCESS && (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
+#   if ! defined free && ! defined EXIT_SUCCESS
 void free (void *); /* INFRINGES ON USER NAME SPACE */
 #   endif
 #  endif
 # endif
-#endif /* ! defined yyoverflow || YYERROR_VERBOSE */
-
+#endif /* !defined yyoverflow */
 
 #if (! defined yyoverflow \
      && (! defined __cplusplus \
-	 || (defined YYSTYPE_IS_TRIVIAL && YYSTYPE_IS_TRIVIAL)))
+         || (defined YYSTYPE_IS_TRIVIAL && YYSTYPE_IS_TRIVIAL)))
 
 /* A type that is properly aligned for any stack member.  */
 union yyalloc
 {
-  yytype_int16 yyss_alloc;
+  yy_state_t yyss_alloc;
   YYSTYPE yyvs_alloc;
 };
 
 /* The size of the maximum gap between one aligned stack and the next.  */
-# define YYSTACK_GAP_MAXIMUM (sizeof (union yyalloc) - 1)
+# define YYSTACK_GAP_MAXIMUM (YYSIZEOF (union yyalloc) - 1)
 
 /* The size of an array large to enough to hold all stacks, each with
    N elements.  */
 # define YYSTACK_BYTES(N) \
-     ((N) * (sizeof (yytype_int16) + sizeof (YYSTYPE)) \
+     ((N) * (YYSIZEOF (yy_state_t) + YYSIZEOF (YYSTYPE)) \
       + YYSTACK_GAP_MAXIMUM)
 
 # define YYCOPY_NEEDED 1
@@ -661,16 +729,16 @@ union yyalloc
    elements in the stack, and YYPTR gives the new location of the
    stack.  Advance YYPTR to a properly aligned location for the next
    stack.  */
-# define YYSTACK_RELOCATE(Stack_alloc, Stack)				\
-    do									\
-      {									\
-	YYSIZE_T yynewbytes;						\
-	YYCOPY (&yyptr->Stack_alloc, Stack, yysize);			\
-	Stack = &yyptr->Stack_alloc;					\
-	yynewbytes = yystacksize * sizeof (*Stack) + YYSTACK_GAP_MAXIMUM; \
-	yyptr += yynewbytes / sizeof (*yyptr);				\
-      }									\
-    while (YYID (0))
+# define YYSTACK_RELOCATE(Stack_alloc, Stack)                           \
+    do                                                                  \
+      {                                                                 \
+        YYPTRDIFF_T yynewbytes;                                         \
+        YYCOPY (&yyptr->Stack_alloc, Stack, yysize);                    \
+        Stack = &yyptr->Stack_alloc;                                    \
+        yynewbytes = yystacksize * YYSIZEOF (*Stack) + YYSTACK_GAP_MAXIMUM; \
+        yyptr += yynewbytes / YYSIZEOF (*yyptr);                        \
+      }                                                                 \
+    while (0)
 
 #endif
 
@@ -680,16 +748,16 @@ union yyalloc
 # ifndef YYCOPY
 #  if defined __GNUC__ && 1 < __GNUC__
 #   define YYCOPY(Dst, Src, Count) \
-      __builtin_memcpy (Dst, Src, (Count) * sizeof (*(Src)))
+      __builtin_memcpy (Dst, Src, YY_CAST (YYSIZE_T, (Count)) * sizeof (*(Src)))
 #  else
 #   define YYCOPY(Dst, Src, Count)              \
       do                                        \
         {                                       \
-          YYSIZE_T yyi;                         \
+          YYPTRDIFF_T yyi;                      \
           for (yyi = 0; yyi < (Count); yyi++)   \
             (Dst)[yyi] = (Src)[yyi];            \
         }                                       \
-      while (YYID (0))
+      while (0)
 #  endif
 # endif
 #endif /* !YYCOPY_NEEDED */
@@ -705,18 +773,23 @@ union yyalloc
 #define YYNNTS  26
 /* YYNRULES -- Number of rules.  */
 #define YYNRULES  50
-/* YYNRULES -- Number of states.  */
+/* YYNSTATES -- Number of states.  */
 #define YYNSTATES  74
 
-/* YYTRANSLATE(YYLEX) -- Bison symbol number corresponding to YYLEX.  */
-#define YYUNDEFTOK  2
+/* YYMAXUTOK -- Last valid token kind.  */
 #define YYMAXUTOK   281
 
-#define YYTRANSLATE(YYX)						\
-  ((unsigned int) (YYX) <= YYMAXUTOK ? yytranslate[YYX] : YYUNDEFTOK)
 
-/* YYTRANSLATE[YYLEX] -- Bison symbol number corresponding to YYLEX.  */
-static const yytype_uint8 yytranslate[] =
+/* YYTRANSLATE(TOKEN-NUM) -- Symbol number corresponding to TOKEN-NUM
+   as returned by yylex, with out-of-bounds checking.  */
+#define YYTRANSLATE(YYX)                                \
+  (0 <= (YYX) && (YYX) <= YYMAXUTOK                     \
+   ? YY_CAST (yysymbol_kind_t, yytranslate[YYX])        \
+   : YYSYMBOL_YYUNDEF)
+
+/* YYTRANSLATE[TOKEN-NUM] -- Symbol number corresponding to TOKEN-NUM
+   as returned by yylex.  */
+static const yytype_int8 yytranslate[] =
 {
        0,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
@@ -750,56 +823,32 @@ static const yytype_uint8 yytranslate[] =
 };
 
 #if YYDEBUG
-/* YYPRHS[YYN] -- Index of the first RHS symbol of rule number YYN in
-   YYRHS.  */
-static const yytype_uint8 yyprhs[] =
+/* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
+static const yytype_int16 yyrline[] =
 {
-       0,     0,     3,     5,     8,     9,    10,    12,    15,    16,
-      19,    21,    23,    25,    29,    30,    33,    36,    39,    42,
-      46,    49,    52,    56,    60,    66,    68,    70,    72,    74,
-      76,    78,    80,    82,    84,    86,    88,    90,    92,    96,
-     104,   105,   108,   109,   112,   114,   118,   120,   128,   130,
-     134
-};
-
-/* YYRHS -- A `-1'-separated list of the rules' RHS.  */
-static const yytype_int8 yyrhs[] =
-{
-      35,     0,    -1,    26,    -1,    33,    26,    -1,    -1,    -1,
-      33,    -1,    34,    36,    -1,    -1,    36,    37,    -1,    38,
-      -1,    42,    -1,    44,    -1,    19,    39,    33,    -1,    -1,
-      39,    40,    -1,    39,    41,    -1,    20,    21,    -1,    20,
-      22,    -1,    20,    23,    24,    -1,    25,    15,    -1,    43,
-      33,    -1,    16,    17,    18,    -1,    16,    17,    15,    -1,
-      45,    46,    47,    48,    33,    -1,     3,    -1,    11,    -1,
-      12,    -1,    13,    -1,    14,    -1,    27,    -1,     5,    -1,
-       4,    -1,     7,    -1,     6,    -1,     8,    -1,    49,    -1,
-      50,    -1,    51,    28,    57,    -1,    51,    28,    57,    28,
-      53,    28,    57,    -1,    -1,    52,    55,    -1,    -1,    54,
-      55,    -1,    56,    -1,    56,    29,    15,    -1,    27,    -1,
-      15,    30,    15,    30,    15,    30,    15,    -1,    15,    -1,
-      15,    31,    15,    -1,    27,    -1
-};
-
-/* YYRLINE[YYN] -- source line where rule number YYN was defined.  */
-static const yytype_uint16 yyrline[] =
-{
-       0,   345,   345,   346,   347,   349,   350,   353,   356,   357,
-     361,   362,   363,   367,   370,   371,   372,   376,   377,   378,
-     382,   386,   390,   391,   396,   400,   404,   405,   406,   407,
-     408,   413,   414,   415,   416,   417,   421,   422,   426,   430,
-     434,   434,   438,   438,   442,   443,   444,   448,   452,   453,
-     454
+       0,   325,   325,   326,   327,   329,   330,   333,   336,   337,
+     341,   342,   343,   347,   350,   351,   352,   356,   357,   358,
+     362,   366,   370,   371,   376,   380,   384,   385,   386,   387,
+     388,   393,   394,   395,   396,   397,   401,   402,   406,   410,
+     414,   414,   418,   418,   422,   423,   424,   428,   432,   433,
+     434
 };
 #endif
 
-#if YYDEBUG || YYERROR_VERBOSE || 0
+/** Accessing symbol of state STATE.  */
+#define YY_ACCESSING_SYMBOL(State) YY_CAST (yysymbol_kind_t, yystos[State])
+
+#if YYDEBUG || 0
+/* The user-facing name of the symbol whose (internal) number is
+   YYSYMBOL.  No bounds checking.  */
+static const char *yysymbol_name (yysymbol_kind_t yysymbol) YY_ATTRIBUTE_UNUSED;
+
 /* YYTNAME[SYMBOL-NUM] -- String name of the symbol SYMBOL-NUM.
    First, the terminals, then, starting at YYNTOKENS, nonterminals.  */
 static const char *const yytname[] =
 {
-  "$end", "error", "$undefined", "\"use\"", "\"tcp client\"",
-  "\"tcp server\"", "\"udp sender\"", "\"udp receiver\"",
+  "\"end of file\"", "error", "\"invalid token\"", "\"use\"",
+  "\"tcp client\"", "\"tcp server\"", "\"udp sender\"", "\"udp receiver\"",
   "\"udp connect\"", "\"tcp\"", "\"udp\"", "\"os\"", "\"xlio\"", "\"sdp\"",
   "\"sa\"", "\"integer value\"", "\"application id\"", "\"program name\"",
   "\"userdefined id str\"", "\"log statement\"", "\"destination\"",
@@ -809,70 +858,28 @@ static const char *const yytname[] =
   "log_dest", "verbosity", "app_id_statement", "app_id",
   "socket_statement", "use", "transport", "role", "tuple", "three_tuple",
   "five_tuple", "address_first", "$@1", "address_second", "$@2", "address",
-  "ipv4", "ports", YY_NULL
+  "ipv4", "ports", YY_NULLPTR
 };
+
+static const char *
+yysymbol_name (yysymbol_kind_t yysymbol)
+{
+  return yytname[yysymbol];
+}
 #endif
 
-# ifdef YYPRINT
-/* YYTOKNUM[YYLEX-NUM] -- Internal token number corresponding to
-   token YYLEX-NUM.  */
-static const yytype_uint16 yytoknum[] =
-{
-       0,   256,   257,   258,   259,   260,   261,   262,   263,   264,
-     265,   266,   267,   268,   269,   270,   271,   272,   273,   274,
-     275,   276,   277,   278,   279,   280,   281,    42,    58,    47,
-      46,    45
-};
-# endif
+#define YYPACT_NINF (-25)
 
-/* YYR1[YYN] -- Symbol number of symbol that rule YYN derives.  */
-static const yytype_uint8 yyr1[] =
-{
-       0,    32,    33,    33,    33,    34,    34,    35,    36,    36,
-      37,    37,    37,    38,    39,    39,    39,    40,    40,    40,
-      41,    42,    43,    43,    44,    45,    46,    46,    46,    46,
-      46,    47,    47,    47,    47,    47,    48,    48,    49,    50,
-      52,    51,    54,    53,    55,    55,    55,    56,    57,    57,
-      57
-};
+#define yypact_value_is_default(Yyn) \
+  ((Yyn) == YYPACT_NINF)
 
-/* YYR2[YYN] -- Number of symbols composing right hand side of rule YYN.  */
-static const yytype_uint8 yyr2[] =
-{
-       0,     2,     1,     2,     0,     0,     1,     2,     0,     2,
-       1,     1,     1,     3,     0,     2,     2,     2,     2,     3,
-       2,     2,     3,     3,     5,     1,     1,     1,     1,     1,
-       1,     1,     1,     1,     1,     1,     1,     1,     3,     7,
-       0,     2,     0,     2,     1,     3,     1,     7,     1,     3,
-       1
-};
+#define YYTABLE_NINF (-1)
 
-/* YYDEFACT[STATE-NAME] -- Default reduction number in state STATE-NUM.
-   Performed when YYTABLE doesn't specify something else to do.  Zero
-   means the default is an error.  */
-static const yytype_uint8 yydefact[] =
-{
-       4,     2,     6,     8,     0,     3,     7,     1,    25,     0,
-      14,     9,    10,    11,     4,    12,     0,     0,     4,    21,
-      26,    27,    28,    29,    30,     0,    23,    22,     0,     0,
-      13,    15,    16,    32,    31,    34,    33,    35,    40,    17,
-      18,     0,    20,     4,    36,    37,     0,     0,    19,    24,
-       0,     0,    46,    41,    44,    48,    50,    38,     0,     0,
-       0,    42,     0,    45,    49,     0,     0,     0,     0,    43,
-       0,    39,     0,    47
-};
-
-/* YYDEFGOTO[NTERM-NUM].  */
-static const yytype_int8 yydefgoto[] =
-{
-      -1,     2,     3,     4,     6,    11,    12,    18,    31,    32,
-      13,    14,    15,    16,    25,    38,    43,    44,    45,    46,
-      47,    65,    66,    53,    54,    57
-};
+#define yytable_value_is_error(Yyn) \
+  0
 
 /* YYPACT[STATE-NUM] -- Index in YYTABLE of the portion describing
    STATE-NUM.  */
-#define YYPACT_NINF -25
 static const yytype_int8 yypact[] =
 {
      -24,   -25,   -17,   -25,    12,   -25,    -2,   -25,   -25,    -1,
@@ -885,6 +892,21 @@ static const yytype_int8 yypact[] =
       16,   -25,    30,   -25
 };
 
+/* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
+   Performed when YYTABLE does not specify something else to do.  Zero
+   means the default is an error.  */
+static const yytype_int8 yydefact[] =
+{
+       4,     2,     6,     8,     0,     3,     7,     1,    25,     0,
+      14,     9,    10,    11,     4,    12,     0,     0,     4,    21,
+      26,    27,    28,    29,    30,     0,    23,    22,     0,     0,
+      13,    15,    16,    32,    31,    34,    33,    35,    40,    17,
+      18,     0,    20,     4,    36,    37,     0,     0,    19,    24,
+       0,     0,    46,    41,    44,    48,    50,    38,     0,     0,
+       0,    42,     0,    45,    49,     0,     0,     0,     0,    43,
+       0,    39,     0,    47
+};
+
 /* YYPGOTO[NTERM-NUM].  */
 static const yytype_int8 yypgoto[] =
 {
@@ -893,11 +915,18 @@ static const yytype_int8 yypgoto[] =
      -25,   -25,   -25,   -19,   -25,   -20
 };
 
-/* YYTABLE[YYPACT[STATE-NUM]].  What to do in state STATE-NUM.  If
-   positive, shift that token.  If negative, reduce the rule which
+/* YYDEFGOTO[NTERM-NUM].  */
+static const yytype_int8 yydefgoto[] =
+{
+       0,     2,     3,     4,     6,    11,    12,    18,    31,    32,
+      13,    14,    15,    16,    25,    38,    43,    44,    45,    46,
+      47,    65,    66,    53,    54,    57
+};
+
+/* YYTABLE[YYPACT[STATE-NUM]] -- What to do in state STATE-NUM.  If
+   positive, shift that token.  If negative, reduce the rule whose
    number is the opposite.  If YYTABLE_NINF, syntax error.  */
-#define YYTABLE_NINF -1
-static const yytype_uint8 yytable[] =
+static const yytype_int8 yytable[] =
 {
       19,     8,     1,    51,    30,    20,    21,    22,    23,     5,
       55,    42,     7,    28,     9,    52,    17,    10,    29,     1,
@@ -906,13 +935,7 @@ static const yytype_uint8 yytable[] =
       63,    64,    70,    68,    67,    73,    72,    69,    71
 };
 
-#define yypact_value_is_default(Yystate) \
-  (!!((Yystate) == (-25)))
-
-#define yytable_value_is_error(Yytable_value) \
-  YYID (0)
-
-static const yytype_uint8 yycheck[] =
+static const yytype_int8 yycheck[] =
 {
       14,     3,    26,    15,    18,    11,    12,    13,    14,    26,
       15,    15,     0,    20,    16,    27,    17,    19,    25,    26,
@@ -921,9 +944,9 @@ static const yytype_uint8 yycheck[] =
       15,    15,    15,    28,    30,    15,    30,    66,    68
 };
 
-/* YYSTOS[STATE-NUM] -- The (internal number of the) accessing
-   symbol of state STATE-NUM.  */
-static const yytype_uint8 yystos[] =
+/* YYSTOS[STATE-NUM] -- The symbol kind of the accessing symbol of
+   state STATE-NUM.  */
+static const yytype_int8 yystos[] =
 {
        0,    26,    33,    34,    35,    26,    36,     0,     3,    16,
       19,    37,    38,    42,    43,    44,    45,    17,    39,    33,
@@ -935,67 +958,63 @@ static const yytype_uint8 yystos[] =
       15,    57,    30,    15
 };
 
-#define yyerrok		(yyerrstatus = 0)
-#define yyclearin	(yychar = YYEMPTY)
-#define YYEMPTY		(-2)
-#define YYEOF		0
+/* YYR1[RULE-NUM] -- Symbol kind of the left-hand side of rule RULE-NUM.  */
+static const yytype_int8 yyr1[] =
+{
+       0,    32,    33,    33,    33,    34,    34,    35,    36,    36,
+      37,    37,    37,    38,    39,    39,    39,    40,    40,    40,
+      41,    42,    43,    43,    44,    45,    46,    46,    46,    46,
+      46,    47,    47,    47,    47,    47,    48,    48,    49,    50,
+      52,    51,    54,    53,    55,    55,    55,    56,    57,    57,
+      57
+};
 
-#define YYACCEPT	goto yyacceptlab
-#define YYABORT		goto yyabortlab
-#define YYERROR		goto yyerrorlab
+/* YYR2[RULE-NUM] -- Number of symbols on the right-hand side of rule RULE-NUM.  */
+static const yytype_int8 yyr2[] =
+{
+       0,     2,     1,     2,     0,     0,     1,     2,     0,     2,
+       1,     1,     1,     3,     0,     2,     2,     2,     2,     3,
+       2,     2,     3,     3,     5,     1,     1,     1,     1,     1,
+       1,     1,     1,     1,     1,     1,     1,     1,     3,     7,
+       0,     2,     0,     2,     1,     3,     1,     7,     1,     3,
+       1
+};
 
 
-/* Like YYERROR except do call yyerror.  This remains here temporarily
-   to ease the transition to the new meaning of YYERROR, for GCC.
-   Once GCC version 2 has supplanted version 1, this can go.  However,
-   YYFAIL appears to be in use.  Nevertheless, it is formally deprecated
-   in Bison 2.4.2's NEWS entry, where a plan to phase it out is
-   discussed.  */
+enum { YYENOMEM = -2 };
 
-#define YYFAIL		goto yyerrlab
-#if defined YYFAIL
-  /* This is here to suppress warnings from the GCC cpp's
-     -Wunused-macros.  Normally we don't worry about that warning, but
-     some users do, and we want to make it easy for users to remove
-     YYFAIL uses, which will produce warnings from Bison 2.5.  */
-#endif
+#define yyerrok         (yyerrstatus = 0)
+#define yyclearin       (yychar = YYEMPTY)
+
+#define YYACCEPT        goto yyacceptlab
+#define YYABORT         goto yyabortlab
+#define YYERROR         goto yyerrorlab
+#define YYNOMEM         goto yyexhaustedlab
+
 
 #define YYRECOVERING()  (!!yyerrstatus)
 
-#define YYBACKUP(Token, Value)                                  \
-do                                                              \
-  if (yychar == YYEMPTY)                                        \
-    {                                                           \
-      yychar = (Token);                                         \
-      yylval = (Value);                                         \
-      YYPOPSTACK (yylen);                                       \
-      yystate = *yyssp;                                         \
-      goto yybackup;                                            \
-    }                                                           \
-  else                                                          \
-    {                                                           \
-      yyerror (YY_("syntax error: cannot back up")); \
-      YYERROR;							\
-    }								\
-while (YYID (0))
+#define YYBACKUP(Token, Value)                                    \
+  do                                                              \
+    if (yychar == YYEMPTY)                                        \
+      {                                                           \
+        yychar = (Token);                                         \
+        yylval = (Value);                                         \
+        YYPOPSTACK (yylen);                                       \
+        yystate = *yyssp;                                         \
+        goto yybackup;                                            \
+      }                                                           \
+    else                                                          \
+      {                                                           \
+        yyerror (YY_("syntax error: cannot back up")); \
+        YYERROR;                                                  \
+      }                                                           \
+  while (0)
 
-/* Error token number */
-#define YYTERROR	1
-#define YYERRCODE	256
+/* Backward compatibility with an undocumented macro.
+   Use YYerror or YYUNDEF. */
+#define YYERRCODE YYUNDEF
 
-
-/* This macro is provided for backward compatibility. */
-#ifndef YY_LOCATION_PRINT
-# define YY_LOCATION_PRINT(File, Loc) ((void) 0)
-#endif
-
-
-/* YYLEX -- calling `yylex' with the right arguments.  */
-#ifdef YYLEX_PARAM
-# define YYLEX yylex (YYLEX_PARAM)
-#else
-# define YYLEX yylex ()
-#endif
 
 /* Enable debugging if requested.  */
 #if YYDEBUG
@@ -1005,82 +1024,58 @@ while (YYID (0))
 #  define YYFPRINTF fprintf
 # endif
 
-# define YYDPRINTF(Args)			\
-do {						\
-  if (yydebug)					\
-    YYFPRINTF Args;				\
-} while (YYID (0))
-
-# define YY_SYMBOL_PRINT(Title, Type, Value, Location)			  \
-do {									  \
-  if (yydebug)								  \
-    {									  \
-      YYFPRINTF (stderr, "%s ", Title);					  \
-      yy_symbol_print (stderr,						  \
-		  Type, Value); \
-      YYFPRINTF (stderr, "\n");						  \
-    }									  \
-} while (YYID (0))
+# define YYDPRINTF(Args)                        \
+do {                                            \
+  if (yydebug)                                  \
+    YYFPRINTF Args;                             \
+} while (0)
 
 
-/*--------------------------------.
-| Print this symbol on YYOUTPUT.  |
-`--------------------------------*/
 
-/*ARGSUSED*/
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
+
+# define YY_SYMBOL_PRINT(Title, Kind, Value, Location)                    \
+do {                                                                      \
+  if (yydebug)                                                            \
+    {                                                                     \
+      YYFPRINTF (stderr, "%s ", Title);                                   \
+      yy_symbol_print (stderr,                                            \
+                  Kind, Value); \
+      YYFPRINTF (stderr, "\n");                                           \
+    }                                                                     \
+} while (0)
+
+
+/*-----------------------------------.
+| Print this symbol's value on YYO.  |
+`-----------------------------------*/
+
 static void
-yy_symbol_value_print (FILE *yyoutput, int yytype, YYSTYPE const * const yyvaluep)
-#else
-static void
-yy_symbol_value_print (yyoutput, yytype, yyvaluep)
-    FILE *yyoutput;
-    int yytype;
-    YYSTYPE const * const yyvaluep;
-#endif
+yy_symbol_value_print (FILE *yyo,
+                       yysymbol_kind_t yykind, YYSTYPE const * const yyvaluep)
 {
-  FILE *yyo = yyoutput;
-  YYUSE (yyo);
+  FILE *yyoutput = yyo;
+  YY_USE (yyoutput);
   if (!yyvaluep)
     return;
-# ifdef YYPRINT
-  if (yytype < YYNTOKENS)
-    YYPRINT (yyoutput, yytoknum[yytype], *yyvaluep);
-# else
-  YYUSE (yyoutput);
-# endif
-  switch (yytype)
-    {
-      default:
-        break;
-    }
+  YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
+  YY_USE (yykind);
+  YY_IGNORE_MAYBE_UNINITIALIZED_END
 }
 
 
-/*--------------------------------.
-| Print this symbol on YYOUTPUT.  |
-`--------------------------------*/
+/*---------------------------.
+| Print this symbol on YYO.  |
+`---------------------------*/
 
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
 static void
-yy_symbol_print (FILE *yyoutput, int yytype, YYSTYPE const * const yyvaluep)
-#else
-static void
-yy_symbol_print (yyoutput, yytype, yyvaluep)
-    FILE *yyoutput;
-    int yytype;
-    YYSTYPE const * const yyvaluep;
-#endif
+yy_symbol_print (FILE *yyo,
+                 yysymbol_kind_t yykind, YYSTYPE const * const yyvaluep)
 {
-  if (yytype < YYNTOKENS)
-    YYFPRINTF (yyoutput, "token %s (", yytname[yytype]);
-  else
-    YYFPRINTF (yyoutput, "nterm %s (", yytname[yytype]);
+  YYFPRINTF (yyo, "%s %s (",
+             yykind < YYNTOKENS ? "token" : "nterm", yysymbol_name (yykind));
 
-  yy_symbol_value_print (yyoutput, yytype, yyvaluep);
-  YYFPRINTF (yyoutput, ")");
+  yy_symbol_value_print (yyo, yykind, yyvaluep);
+  YYFPRINTF (yyo, ")");
 }
 
 /*------------------------------------------------------------------.
@@ -1088,16 +1083,8 @@ yy_symbol_print (yyoutput, yytype, yyvaluep)
 | TOP (included).                                                   |
 `------------------------------------------------------------------*/
 
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
 static void
-yy_stack_print (yytype_int16 *yybottom, yytype_int16 *yytop)
-#else
-static void
-yy_stack_print (yybottom, yytop)
-    yytype_int16 *yybottom;
-    yytype_int16 *yytop;
-#endif
+yy_stack_print (yy_state_t *yybottom, yy_state_t *yytop)
 {
   YYFPRINTF (stderr, "Stack now");
   for (; yybottom <= yytop; yybottom++)
@@ -1108,63 +1095,56 @@ yy_stack_print (yybottom, yytop)
   YYFPRINTF (stderr, "\n");
 }
 
-# define YY_STACK_PRINT(Bottom, Top)				\
-do {								\
-  if (yydebug)							\
-    yy_stack_print ((Bottom), (Top));				\
-} while (YYID (0))
+# define YY_STACK_PRINT(Bottom, Top)                            \
+do {                                                            \
+  if (yydebug)                                                  \
+    yy_stack_print ((Bottom), (Top));                           \
+} while (0)
 
 
 /*------------------------------------------------.
 | Report that the YYRULE is going to be reduced.  |
 `------------------------------------------------*/
 
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
 static void
-yy_reduce_print (YYSTYPE *yyvsp, int yyrule)
-#else
-static void
-yy_reduce_print (yyvsp, yyrule)
-    YYSTYPE *yyvsp;
-    int yyrule;
-#endif
+yy_reduce_print (yy_state_t *yyssp, YYSTYPE *yyvsp,
+                 int yyrule)
 {
+  int yylno = yyrline[yyrule];
   int yynrhs = yyr2[yyrule];
   int yyi;
-  unsigned long int yylno = yyrline[yyrule];
-  YYFPRINTF (stderr, "Reducing stack by rule %d (line %lu):\n",
-	     yyrule - 1, yylno);
+  YYFPRINTF (stderr, "Reducing stack by rule %d (line %d):\n",
+             yyrule - 1, yylno);
   /* The symbols being reduced.  */
   for (yyi = 0; yyi < yynrhs; yyi++)
     {
       YYFPRINTF (stderr, "   $%d = ", yyi + 1);
-      yy_symbol_print (stderr, yyrhs[yyprhs[yyrule] + yyi],
-		       &(yyvsp[(yyi + 1) - (yynrhs)])
-		       		       );
+      yy_symbol_print (stderr,
+                       YY_ACCESSING_SYMBOL (+yyssp[yyi + 1 - yynrhs]),
+                       &yyvsp[(yyi + 1) - (yynrhs)]);
       YYFPRINTF (stderr, "\n");
     }
 }
 
-# define YY_REDUCE_PRINT(Rule)		\
-do {					\
-  if (yydebug)				\
-    yy_reduce_print (yyvsp, Rule); \
-} while (YYID (0))
+# define YY_REDUCE_PRINT(Rule)          \
+do {                                    \
+  if (yydebug)                          \
+    yy_reduce_print (yyssp, yyvsp, Rule); \
+} while (0)
 
 /* Nonzero means print parse trace.  It is left uninitialized so that
    multiple parsers can coexist.  */
 int yydebug;
 #else /* !YYDEBUG */
-# define YYDPRINTF(Args)
-# define YY_SYMBOL_PRINT(Title, Type, Value, Location)
+# define YYDPRINTF(Args) ((void) 0)
+# define YY_SYMBOL_PRINT(Title, Kind, Value, Location)
 # define YY_STACK_PRINT(Bottom, Top)
 # define YY_REDUCE_PRINT(Rule)
 #endif /* !YYDEBUG */
 
 
 /* YYINITDEPTH -- initial size of the parser's stacks.  */
-#ifndef	YYINITDEPTH
+#ifndef YYINITDEPTH
 # define YYINITDEPTH 200
 #endif
 
@@ -1180,370 +1160,77 @@ int yydebug;
 #endif
 
 
-#if YYERROR_VERBOSE
 
-# ifndef yystrlen
-#  if defined __GLIBC__ && defined _STRING_H
-#   define yystrlen strlen
-#  else
-/* Return the length of YYSTR.  */
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
-static YYSIZE_T
-yystrlen (const char *yystr)
-#else
-static YYSIZE_T
-yystrlen (yystr)
-    const char *yystr;
-#endif
-{
-  YYSIZE_T yylen;
-  for (yylen = 0; yystr[yylen]; yylen++)
-    continue;
-  return yylen;
-}
-#  endif
-# endif
 
-# ifndef yystpcpy
-#  if defined __GLIBC__ && defined _STRING_H && defined _GNU_SOURCE
-#   define yystpcpy stpcpy
-#  else
-/* Copy YYSRC to YYDEST, returning the address of the terminating '\0' in
-   YYDEST.  */
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
-static char *
-yystpcpy (char *yydest, const char *yysrc)
-#else
-static char *
-yystpcpy (yydest, yysrc)
-    char *yydest;
-    const char *yysrc;
-#endif
-{
-  char *yyd = yydest;
-  const char *yys = yysrc;
 
-  while ((*yyd++ = *yys++) != '\0')
-    continue;
-
-  return yyd - 1;
-}
-#  endif
-# endif
-
-# ifndef yytnamerr
-/* Copy to YYRES the contents of YYSTR after stripping away unnecessary
-   quotes and backslashes, so that it's suitable for yyerror.  The
-   heuristic is that double-quoting is unnecessary unless the string
-   contains an apostrophe, a comma, or backslash (other than
-   backslash-backslash).  YYSTR is taken from yytname.  If YYRES is
-   null, do not copy; instead, return the length of what the result
-   would have been.  */
-static YYSIZE_T
-yytnamerr (char *yyres, const char *yystr)
-{
-  if (*yystr == '"')
-    {
-      YYSIZE_T yyn = 0;
-      char const *yyp = yystr;
-
-      for (;;)
-	switch (*++yyp)
-	  {
-	  case '\'':
-	  case ',':
-	    goto do_not_strip_quotes;
-
-	  /* coverity[unterminated_case] */
-	  case '\\':
-	    if (*++yyp != '\\')
-	      goto do_not_strip_quotes;
-	    /* Fall through.  */
-	  default:
-	    if (yyres)
-	      yyres[yyn] = *yyp;
-	    yyn++;
-	    break;
-
-	  case '"':
-	    if (yyres)
-	      yyres[yyn] = '\0';
-	    return yyn;
-	  }
-    do_not_strip_quotes: ;
-    }
-
-  if (! yyres)
-    return yystrlen (yystr);
-
-  return yystpcpy (yyres, yystr) - yyres;
-}
-# endif
-
-/* Copy into *YYMSG, which is of size *YYMSG_ALLOC, an error message
-   about the unexpected token YYTOKEN for the state stack whose top is
-   YYSSP.
-
-   Return 0 if *YYMSG was successfully written.  Return 1 if *YYMSG is
-   not large enough to hold the message.  In that case, also set
-   *YYMSG_ALLOC to the required number of bytes.  Return 2 if the
-   required number of bytes is too large to store.  */
-static int
-yysyntax_error (YYSIZE_T *yymsg_alloc, char **yymsg,
-                yytype_int16 *yyssp, int yytoken)
-{
-  YYSIZE_T yysize0 = 0;
-  YYSIZE_T yysize = yysize0;
-  enum { YYERROR_VERBOSE_ARGS_MAXIMUM = 5 };
-  /* Internationalized format string. */
-  const char *yyformat = YY_NULL;
-  /* Arguments of yyformat. */
-  char const *yyarg[YYERROR_VERBOSE_ARGS_MAXIMUM];
-  /* Number of reported tokens (one for the "unexpected", one per
-     "expected"). */
-  int yycount = 0;
-
-  if (yytoken < 0) return 1;
-  yysize0 = yytnamerr (YY_NULL, yytname[yytoken]);
-  yysize = yysize0;
-
-  /* There are many possibilities here to consider:
-     - Assume YYFAIL is not used.  It's too flawed to consider.  See
-       <http://lists.gnu.org/archive/html/bison-patches/2009-12/msg00024.html>
-       for details.  YYERROR is fine as it does not invoke this
-       function.
-     - If this state is a consistent state with a default action, then
-       the only way this function was invoked is if the default action
-       is an error action.  In that case, don't check for expected
-       tokens because there are none.
-     - The only way there can be no lookahead present (in yychar) is if
-       this state is a consistent state with a default action.  Thus,
-       detecting the absence of a lookahead is sufficient to determine
-       that there is no unexpected or expected token to report.  In that
-       case, just report a simple "syntax error".
-     - Don't assume there isn't a lookahead just because this state is a
-       consistent state with a default action.  There might have been a
-       previous inconsistent state, consistent state with a non-default
-       action, or user semantic action that manipulated yychar.
-     - Of course, the expected token list depends on states to have
-       correct lookahead information, and it depends on the parser not
-       to perform extra reductions after fetching a lookahead from the
-       scanner and before detecting a syntax error.  Thus, state merging
-       (from LALR or IELR) and default reductions corrupt the expected
-       token list.  However, the list is correct for canonical LR with
-       one exception: it will still contain any token that will not be
-       accepted due to an error action in a later state.
-  */
-  if (yytoken != YYEMPTY)
-    {
-      int yyn = yypact[*yyssp];
-      yyarg[yycount++] = yytname[yytoken];
-      if (!yypact_value_is_default (yyn))
-        {
-          /* Start YYX at -YYN if negative to avoid negative indexes in
-             YYCHECK.  In other words, skip the first -YYN actions for
-             this state because they are default actions.  */
-          int yyxbegin = yyn < 0 ? -yyn : 0;
-          /* Stay within bounds of both yycheck and yytname.  */
-          int yychecklim = YYLAST - yyn + 1;
-          int yyxend = yychecklim < YYNTOKENS ? yychecklim : YYNTOKENS;
-          int yyx;
-
-          for (yyx = yyxbegin; yyx < yyxend; ++yyx)
-            if (yycheck[yyx + yyn] == yyx && yyx != YYTERROR
-                && !yytable_value_is_error (yytable[yyx + yyn]))
-              {
-                if (yycount == YYERROR_VERBOSE_ARGS_MAXIMUM)
-                  {
-                    yycount = 1;
-                    yysize = yysize0;
-                    break;
-                  }
-                yyarg[yycount++] = yytname[yyx];
-                {
-                  YYSIZE_T yysize1 = yysize + yytnamerr (YY_NULL, yytname[yyx]);
-                  if (! (yysize <= yysize1
-                         && yysize1 <= YYSTACK_ALLOC_MAXIMUM))
-                    return 2;
-                  yysize = yysize1;
-                }
-              }
-        }
-    }
-
-  switch (yycount)
-    {
-# define YYCASE_(N, S)                      \
-      case N:                               \
-        yyformat = S;                       \
-      break
-      YYCASE_(0, YY_("syntax error"));
-      YYCASE_(1, YY_("syntax error, unexpected %s"));
-      YYCASE_(2, YY_("syntax error, unexpected %s, expecting %s"));
-      YYCASE_(3, YY_("syntax error, unexpected %s, expecting %s or %s"));
-      YYCASE_(4, YY_("syntax error, unexpected %s, expecting %s or %s or %s"));
-      YYCASE_(5, YY_("syntax error, unexpected %s, expecting %s or %s or %s or %s"));
-# undef YYCASE_
-    }
-
-  {
-    YYSIZE_T yysize1 = yysize + (yyformat ? yystrlen (yyformat) : 0);
-    if (! (yysize <= yysize1 && yysize1 <= YYSTACK_ALLOC_MAXIMUM))
-      return 2;
-    yysize = yysize1;
-  }
-
-  if (*yymsg_alloc < yysize)
-    {
-      *yymsg_alloc = 2 * yysize;
-      if (! (yysize <= *yymsg_alloc
-             && *yymsg_alloc <= YYSTACK_ALLOC_MAXIMUM))
-        *yymsg_alloc = YYSTACK_ALLOC_MAXIMUM;
-      return 1;
-    }
-
-  /* Avoid sprintf, as that infringes on the user's name space.
-     Don't have undefined behavior even if the translation
-     produced a string with the wrong number of "%s"s.  */
-  {
-    char *yyp = *yymsg;
-    int yyi = 0;
-    /* coverity[var_deref_op] */
-    while ((*yyp = *yyformat) != '\0')
-      if (*yyp == '%' && yyformat[1] == 's' && yyi < yycount)
-        {
-          yyp += yytnamerr (yyp, yyarg[yyi++]);
-          yyformat += 2;
-        }
-      else
-        {
-          yyp++;
-          yyformat++;
-        }
-  }
-  return 0;
-}
-#endif /* YYERROR_VERBOSE */
 
 /*-----------------------------------------------.
 | Release the memory associated to this symbol.  |
 `-----------------------------------------------*/
 
-/*ARGSUSED*/
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
 static void
-yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep)
-#else
-static void
-yydestruct (yymsg, yytype, yyvaluep)
-    const char *yymsg;
-    int yytype;
-    YYSTYPE *yyvaluep;
-#endif
+yydestruct (const char *yymsg,
+            yysymbol_kind_t yykind, YYSTYPE *yyvaluep)
 {
-  YYUSE (yyvaluep);
-
+  YY_USE (yyvaluep);
   if (!yymsg)
     yymsg = "Deleting";
-  (void)yymsg;
-  YY_SYMBOL_PRINT (yymsg, yytype, yyvaluep, yylocationp);
+  YY_SYMBOL_PRINT (yymsg, yykind, yyvaluep, yylocationp);
 
-  switch (yytype)
-    {
-
-      default:
-        break;
-    }
+  YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
+  YY_USE (yykind);
+  YY_IGNORE_MAYBE_UNINITIALIZED_END
 }
 
 
-
-
-/* The lookahead symbol.  */
+/* Lookahead token kind.  */
 int yychar;
 
-
-#ifndef YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
-# define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
-# define YY_IGNORE_MAYBE_UNINITIALIZED_END
-#endif
-#ifndef YY_INITIAL_VALUE
-# define YY_INITIAL_VALUE(Value) /* Nothing. */
-#endif
-
 /* The semantic value of the lookahead symbol.  */
-YYSTYPE yylval YY_INITIAL_VALUE(yyval_default);
-
+YYSTYPE yylval;
 /* Number of syntax errors so far.  */
 int yynerrs;
+
+
 
 
 /*----------.
 | yyparse.  |
 `----------*/
 
-#ifdef YYPARSE_PARAM
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
-int
-yyparse (void *YYPARSE_PARAM)
-#else
-int
-yyparse (YYPARSE_PARAM)
-    void *YYPARSE_PARAM;
-#endif
-#else /* ! YYPARSE_PARAM */
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
 int
 yyparse (void)
-#else
-int
-yyparse ()
-
-#endif
-#endif
 {
-    int yystate;
+    yy_state_fast_t yystate = 0;
     /* Number of tokens to shift before error messages enabled.  */
-    int yyerrstatus;
+    int yyerrstatus = 0;
 
-    /* The stacks and their tools:
-       `yyss': related to states.
-       `yyvs': related to semantic values.
-
-       Refer to the stacks through separate pointers, to allow yyoverflow
+    /* Refer to the stacks through separate pointers, to allow yyoverflow
        to reallocate them elsewhere.  */
 
-    /* The state stack.  */
-    yytype_int16 yyssa[YYINITDEPTH];
-    yytype_int16 *yyss;
-    yytype_int16 *yyssp;
+    /* Their size.  */
+    YYPTRDIFF_T yystacksize = YYINITDEPTH;
 
-    /* The semantic value stack.  */
+    /* The state stack: array, bottom, top.  */
+    yy_state_t yyssa[YYINITDEPTH];
+    yy_state_t *yyss = yyssa;
+    yy_state_t *yyssp = yyss;
+
+    /* The semantic value stack: array, bottom, top.  */
     YYSTYPE yyvsa[YYINITDEPTH];
-    YYSTYPE *yyvs;
-    YYSTYPE *yyvsp;
-
-    YYSIZE_T yystacksize;
+    YYSTYPE *yyvs = yyvsa;
+    YYSTYPE *yyvsp = yyvs;
 
   int yyn;
+  /* The return value of yyparse.  */
   int yyresult;
-  /* Lookahead token as an internal (translated) token number.  */
-  int yytoken = 0;
+  /* Lookahead symbol kind.  */
+  yysymbol_kind_t yytoken = YYSYMBOL_YYEMPTY;
   /* The variables used to return semantic value and location from the
      action routines.  */
   YYSTYPE yyval;
 
-#if YYERROR_VERBOSE
-  /* Buffer for error messages, and its allocated size.  */
-  char yymsgbuf[128];
-  char *yymsg = yymsgbuf;
-  YYSIZE_T yymsg_alloc = sizeof yymsgbuf;
-#endif
+
 
 #define YYPOPSTACK(N)   (yyvsp -= (N), yyssp -= (N))
 
@@ -1551,105 +1238,107 @@ yyparse ()
      Keep to zero when no symbol should be popped.  */
   int yylen = 0;
 
-  yyssp = yyss = yyssa;
-  yyvsp = yyvs = yyvsa;
-  yystacksize = YYINITDEPTH;
-
   YYDPRINTF ((stderr, "Starting parse\n"));
 
-  yystate = 0;
-  yyerrstatus = 0;
-  yynerrs = 0;
   yychar = YYEMPTY; /* Cause a token to be read.  */
+
   goto yysetstate;
 
+
 /*------------------------------------------------------------.
-| yynewstate -- Push a new state, which is found in yystate.  |
+| yynewstate -- push a new state, which is found in yystate.  |
 `------------------------------------------------------------*/
- yynewstate:
+yynewstate:
   /* In all cases, when you get here, the value and location stacks
      have just been pushed.  So pushing a state here evens the stacks.  */
   yyssp++;
 
- yysetstate:
-  *yyssp = yystate;
+
+/*--------------------------------------------------------------------.
+| yysetstate -- set current state (the top of the stack) to yystate.  |
+`--------------------------------------------------------------------*/
+yysetstate:
+  YYDPRINTF ((stderr, "Entering state %d\n", yystate));
+  YY_ASSERT (0 <= yystate && yystate < YYNSTATES);
+  YY_IGNORE_USELESS_CAST_BEGIN
+  *yyssp = YY_CAST (yy_state_t, yystate);
+  YY_IGNORE_USELESS_CAST_END
+  YY_STACK_PRINT (yyss, yyssp);
 
   if (yyss + yystacksize - 1 <= yyssp)
+#if !defined yyoverflow && !defined YYSTACK_RELOCATE
+    YYNOMEM;
+#else
     {
       /* Get the current used size of the three stacks, in elements.  */
-      YYSIZE_T yysize = yyssp - yyss + 1;
+      YYPTRDIFF_T yysize = yyssp - yyss + 1;
 
-#ifdef yyoverflow
+# if defined yyoverflow
       {
-	/* Give user a chance to reallocate the stack.  Use copies of
-	   these so that the &'s don't force the real ones into
-	   memory.  */
-	YYSTYPE *yyvs1 = yyvs;
-	yytype_int16 *yyss1 = yyss;
+        /* Give user a chance to reallocate the stack.  Use copies of
+           these so that the &'s don't force the real ones into
+           memory.  */
+        yy_state_t *yyss1 = yyss;
+        YYSTYPE *yyvs1 = yyvs;
 
-	/* Each stack pointer address is followed by the size of the
-	   data in use in that stack, in bytes.  This used to be a
-	   conditional around just the two extra args, but that might
-	   be undefined if yyoverflow is a macro.  */
-	yyoverflow (YY_("memory exhausted"),
-		    &yyss1, yysize * sizeof (*yyssp),
-		    &yyvs1, yysize * sizeof (*yyvsp),
-		    &yystacksize);
-
-	yyss = yyss1;
-	yyvs = yyvs1;
+        /* Each stack pointer address is followed by the size of the
+           data in use in that stack, in bytes.  This used to be a
+           conditional around just the two extra args, but that might
+           be undefined if yyoverflow is a macro.  */
+        yyoverflow (YY_("memory exhausted"),
+                    &yyss1, yysize * YYSIZEOF (*yyssp),
+                    &yyvs1, yysize * YYSIZEOF (*yyvsp),
+                    &yystacksize);
+        yyss = yyss1;
+        yyvs = yyvs1;
       }
-#else /* no yyoverflow */
-# ifndef YYSTACK_RELOCATE
-      goto yyexhaustedlab;
-# else
+# else /* defined YYSTACK_RELOCATE */
       /* Extend the stack our own way.  */
       if (YYMAXDEPTH <= yystacksize)
-	goto yyexhaustedlab;
+        YYNOMEM;
       yystacksize *= 2;
       if (YYMAXDEPTH < yystacksize)
-	yystacksize = YYMAXDEPTH;
+        yystacksize = YYMAXDEPTH;
 
       {
-	yytype_int16 *yyss1 = yyss;
-	/* coverity[leaked_storage] */
-	union yyalloc *yyptr =
-	  (union yyalloc *) YYSTACK_ALLOC (YYSTACK_BYTES (yystacksize));
-	if (! yyptr)
-	  goto yyexhaustedlab;
-	YYSTACK_RELOCATE (yyss_alloc, yyss);
-	YYSTACK_RELOCATE (yyvs_alloc, yyvs);
+        yy_state_t *yyss1 = yyss;
+        union yyalloc *yyptr =
+          YY_CAST (union yyalloc *,
+                   YYSTACK_ALLOC (YY_CAST (YYSIZE_T, YYSTACK_BYTES (yystacksize))));
+        if (! yyptr)
+          YYNOMEM;
+        YYSTACK_RELOCATE (yyss_alloc, yyss);
+        YYSTACK_RELOCATE (yyvs_alloc, yyvs);
 #  undef YYSTACK_RELOCATE
-	if (yyss1 != yyssa)
-	  YYSTACK_FREE (yyss1);
-	/* coverity[leaked_storage] */
+        if (yyss1 != yyssa)
+          YYSTACK_FREE (yyss1);
       }
 # endif
-#endif /* no yyoverflow */
 
-      /* coverity[ptr_arith] */
       yyssp = yyss + yysize - 1;
       yyvsp = yyvs + yysize - 1;
 
-      YYDPRINTF ((stderr, "Stack size increased to %lu\n",
-		  (unsigned long int) yystacksize));
-      /* coverity[illegal_address] */
-      if (yyss + yystacksize - 1 <= yyssp)
-	YYABORT;
-    }
+      YY_IGNORE_USELESS_CAST_BEGIN
+      YYDPRINTF ((stderr, "Stack size increased to %ld\n",
+                  YY_CAST (long, yystacksize)));
+      YY_IGNORE_USELESS_CAST_END
 
-  YYDPRINTF ((stderr, "Entering state %d\n", yystate));
+      if (yyss + yystacksize - 1 <= yyssp)
+        YYABORT;
+    }
+#endif /* !defined yyoverflow && !defined YYSTACK_RELOCATE */
+
 
   if (yystate == YYFINAL)
     YYACCEPT;
 
   goto yybackup;
 
+
 /*-----------.
 | yybackup.  |
 `-----------*/
 yybackup:
-
   /* Do appropriate processing given the current state.  Read a
      lookahead token if we need one and don't already have one.  */
 
@@ -1660,17 +1349,28 @@ yybackup:
 
   /* Not known => get a lookahead token if don't already have one.  */
 
-  /* YYCHAR is either YYEMPTY or YYEOF or a valid lookahead symbol.  */
+  /* YYCHAR is either empty, or end-of-input, or a valid lookahead.  */
   if (yychar == YYEMPTY)
     {
-      YYDPRINTF ((stderr, "Reading a token: "));
-      yychar = YYLEX;
+      YYDPRINTF ((stderr, "Reading a token\n"));
+      yychar = yylex ();
     }
 
   if (yychar <= YYEOF)
     {
-      yychar = yytoken = YYEOF;
+      yychar = YYEOF;
+      yytoken = YYSYMBOL_YYEOF;
       YYDPRINTF ((stderr, "Now at end of input.\n"));
+    }
+  else if (yychar == YYerror)
+    {
+      /* The scanner already issued an error message, process directly
+         to error recovery.  But do not keep the error token as
+         lookahead, it is too special and may lead us to an endless
+         loop in error recovery. */
+      yychar = YYUNDEF;
+      yytoken = YYSYMBOL_YYerror;
+      goto yyerrlab1;
     }
   else
     {
@@ -1699,15 +1399,13 @@ yybackup:
 
   /* Shift the lookahead token.  */
   YY_SYMBOL_PRINT ("Shifting", yytoken, &yylval, &yylloc);
-
-  /* Discard the shifted token.  */
-  yychar = YYEMPTY;
-
   yystate = yyn;
   YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
   *++yyvsp = yylval;
   YY_IGNORE_MAYBE_UNINITIALIZED_END
 
+  /* Discard the shifted token.  */
+  yychar = YYEMPTY;
   goto yynewstate;
 
 
@@ -1722,192 +1420,191 @@ yydefault:
 
 
 /*-----------------------------.
-| yyreduce -- Do a reduction.  |
+| yyreduce -- do a reduction.  |
 `-----------------------------*/
 yyreduce:
   /* yyn is the number of a rule to reduce with.  */
   yylen = yyr2[yyn];
 
   /* If YYLEN is nonzero, implement the default value of the action:
-     `$$ = $1'.
+     '$$ = $1'.
 
      Otherwise, the following line sets YYVAL to garbage.
      This behavior is undocumented and Bison
      users should not rely upon it.  Assigning to YYVAL
      unconditionally makes the parser a bit smaller, and it avoids a
      GCC warning that YYVAL may be used uninitialized.  */
-  /* coverity[uninit_use] */
   yyval = yyvsp[1-yylen];
 
 
   YY_REDUCE_PRINT (yyn);
   switch (yyn)
     {
-        case 17:
-/* Line 1792 of yacc.c  */
-/* Line 376 of config_parser.y */
-    { __xlio_log_set_log_stderr(); }
+  case 17: /* log_dest: "destination" "ystderr"  */
+#line 356 "src/core/util/config_parser.y"
+                                        { __xlio_log_set_log_stderr(); }
+#line 1447 "third_party/legacy_config_parser/config_parser.c"
     break;
 
-  case 18:
-/* Line 1792 of yacc.c  */
-/* Line 377 of config_parser.y */
-    { __xlio_log_set_log_syslog(); }
+  case 18: /* log_dest: "destination" "syslog"  */
+#line 357 "src/core/util/config_parser.y"
+                                        { __xlio_log_set_log_syslog(); }
+#line 1453 "third_party/legacy_config_parser/config_parser.c"
     break;
 
-  case 19:
-/* Line 1792 of yacc.c  */
-/* Line 378 of config_parser.y */
-    { __xlio_log_set_log_file((yyvsp[(3) - (3)].sval)); }
+  case 19: /* log_dest: "destination" "yfile" "a name"  */
+#line 358 "src/core/util/config_parser.y"
+                                        { __xlio_log_set_log_file((yyvsp[0].sval)); }
+#line 1459 "third_party/legacy_config_parser/config_parser.c"
     break;
 
-  case 20:
-/* Line 1792 of yacc.c  */
-/* Line 382 of config_parser.y */
-    { __xlio_log_set_min_level((yyvsp[(2) - (2)].ival)); }
+  case 20: /* verbosity: "min-level" "integer value"  */
+#line 362 "src/core/util/config_parser.y"
+                  { __xlio_log_set_min_level((yyvsp[0].ival)); }
+#line 1465 "third_party/legacy_config_parser/config_parser.c"
     break;
 
-  case 22:
-/* Line 1792 of yacc.c  */
-/* Line 390 of config_parser.y */
-    {__xlio_add_instance((yyvsp[(2) - (3)].sval), (yyvsp[(3) - (3)].sval));	if ((yyvsp[(2) - (3)].sval)) free((yyvsp[(2) - (3)].sval)); if ((yyvsp[(3) - (3)].sval)) free((yyvsp[(3) - (3)].sval));	}
+  case 22: /* app_id: "application id" "program name" "userdefined id str"  */
+#line 370 "src/core/util/config_parser.y"
+                                                {__xlio_add_instance((yyvsp[-1].sval), (yyvsp[0].sval));	if ((yyvsp[-1].sval)) free((yyvsp[-1].sval)); if ((yyvsp[0].sval)) free((yyvsp[0].sval));	}
+#line 1471 "third_party/legacy_config_parser/config_parser.c"
     break;
 
-  case 23:
-/* Line 1792 of yacc.c  */
-/* Line 391 of config_parser.y */
-    {__xlio_add_inst_with_int_uid((yyvsp[(2) - (3)].sval), (yyvsp[(3) - (3)].ival));	if ((yyvsp[(2) - (3)].sval)) free((yyvsp[(2) - (3)].sval));		}
+  case 23: /* app_id: "application id" "program name" "integer value"  */
+#line 371 "src/core/util/config_parser.y"
+                                                {__xlio_add_inst_with_int_uid((yyvsp[-1].sval), (yyvsp[0].ival));	if ((yyvsp[-1].sval)) free((yyvsp[-1].sval));		}
+#line 1477 "third_party/legacy_config_parser/config_parser.c"
     break;
 
-  case 24:
-/* Line 1792 of yacc.c  */
-/* Line 396 of config_parser.y */
-    { __xlio_add_rule(); }
+  case 24: /* socket_statement: use transport role tuple NL  */
+#line 376 "src/core/util/config_parser.y"
+                                { __xlio_add_rule(); }
+#line 1483 "third_party/legacy_config_parser/config_parser.c"
     break;
 
-  case 25:
-/* Line 1792 of yacc.c  */
-/* Line 400 of config_parser.y */
-    { current_conf_type = CONF_RULE; }
+  case 25: /* use: "use"  */
+#line 380 "src/core/util/config_parser.y"
+            { current_conf_type = CONF_RULE; }
+#line 1489 "third_party/legacy_config_parser/config_parser.c"
     break;
 
-  case 26:
-/* Line 1792 of yacc.c  */
-/* Line 404 of config_parser.y */
-    { __xlio_rule.target_transport = TRANS_OS;	}
+  case 26: /* transport: "os"  */
+#line 384 "src/core/util/config_parser.y"
+                { __xlio_rule.target_transport = TRANS_OS;	}
+#line 1495 "third_party/legacy_config_parser/config_parser.c"
     break;
 
-  case 27:
-/* Line 1792 of yacc.c  */
-/* Line 405 of config_parser.y */
-    { __xlio_rule.target_transport = TRANS_XLIO;	}
+  case 27: /* transport: "xlio"  */
+#line 385 "src/core/util/config_parser.y"
+                { __xlio_rule.target_transport = TRANS_XLIO;	}
+#line 1501 "third_party/legacy_config_parser/config_parser.c"
     break;
 
-  case 28:
-/* Line 1792 of yacc.c  */
-/* Line 406 of config_parser.y */
-    { __xlio_rule.target_transport = TRANS_SDP;	}
+  case 28: /* transport: "sdp"  */
+#line 386 "src/core/util/config_parser.y"
+                { __xlio_rule.target_transport = TRANS_SDP;	}
+#line 1507 "third_party/legacy_config_parser/config_parser.c"
     break;
 
-  case 29:
-/* Line 1792 of yacc.c  */
-/* Line 407 of config_parser.y */
-    { __xlio_rule.target_transport = TRANS_SA;	}
+  case 29: /* transport: "sa"  */
+#line 387 "src/core/util/config_parser.y"
+                { __xlio_rule.target_transport = TRANS_SA;	}
+#line 1513 "third_party/legacy_config_parser/config_parser.c"
     break;
 
-  case 30:
-/* Line 1792 of yacc.c  */
-/* Line 408 of config_parser.y */
-    { __xlio_rule.target_transport = TRANS_ULP;	}
+  case 30: /* transport: '*'  */
+#line 388 "src/core/util/config_parser.y"
+                { __xlio_rule.target_transport = TRANS_ULP;	}
+#line 1519 "third_party/legacy_config_parser/config_parser.c"
     break;
 
-  case 31:
-/* Line 1792 of yacc.c  */
-/* Line 413 of config_parser.y */
-    { current_role = ROLE_TCP_SERVER; 	__xlio_rule.protocol = PROTO_TCP; }
+  case 31: /* role: "tcp server"  */
+#line 393 "src/core/util/config_parser.y"
+                        { current_role = ROLE_TCP_SERVER; 	__xlio_rule.protocol = PROTO_TCP; }
+#line 1525 "third_party/legacy_config_parser/config_parser.c"
     break;
 
-  case 32:
-/* Line 1792 of yacc.c  */
-/* Line 414 of config_parser.y */
-    { current_role = ROLE_TCP_CLIENT; 	__xlio_rule.protocol = PROTO_TCP; }
+  case 32: /* role: "tcp client"  */
+#line 394 "src/core/util/config_parser.y"
+                        { current_role = ROLE_TCP_CLIENT; 	__xlio_rule.protocol = PROTO_TCP; }
+#line 1531 "third_party/legacy_config_parser/config_parser.c"
     break;
 
-  case 33:
-/* Line 1792 of yacc.c  */
-/* Line 415 of config_parser.y */
-    { current_role = ROLE_UDP_RECEIVER; __xlio_rule.protocol = PROTO_UDP; }
+  case 33: /* role: "udp receiver"  */
+#line 395 "src/core/util/config_parser.y"
+                        { current_role = ROLE_UDP_RECEIVER; __xlio_rule.protocol = PROTO_UDP; }
+#line 1537 "third_party/legacy_config_parser/config_parser.c"
     break;
 
-  case 34:
-/* Line 1792 of yacc.c  */
-/* Line 416 of config_parser.y */
-    { current_role = ROLE_UDP_SENDER;	__xlio_rule.protocol = PROTO_UDP; }
+  case 34: /* role: "udp sender"  */
+#line 396 "src/core/util/config_parser.y"
+                        { current_role = ROLE_UDP_SENDER;	__xlio_rule.protocol = PROTO_UDP; }
+#line 1543 "third_party/legacy_config_parser/config_parser.c"
     break;
 
-  case 35:
-/* Line 1792 of yacc.c  */
-/* Line 417 of config_parser.y */
-    { current_role = ROLE_UDP_CONNECT;	__xlio_rule.protocol = PROTO_UDP; }
+  case 35: /* role: "udp connect"  */
+#line 397 "src/core/util/config_parser.y"
+                        { current_role = ROLE_UDP_CONNECT;	__xlio_rule.protocol = PROTO_UDP; }
+#line 1549 "third_party/legacy_config_parser/config_parser.c"
     break;
 
-  case 40:
-/* Line 1792 of yacc.c  */
-/* Line 434 of config_parser.y */
-    { __xlio_address_port_rule = &(__xlio_rule.first); __xlio_rule.use_second = 0; }
+  case 40: /* $@1: %empty  */
+#line 414 "src/core/util/config_parser.y"
+        { __xlio_address_port_rule = &(__xlio_rule.first); __xlio_rule.use_second = 0; }
+#line 1555 "third_party/legacy_config_parser/config_parser.c"
     break;
 
-  case 42:
-/* Line 1792 of yacc.c  */
-/* Line 438 of config_parser.y */
-    { __xlio_address_port_rule = &(__xlio_rule.second); __xlio_rule.use_second = 1; }
+  case 42: /* $@2: %empty  */
+#line 418 "src/core/util/config_parser.y"
+        { __xlio_address_port_rule = &(__xlio_rule.second); __xlio_rule.use_second = 1; }
+#line 1561 "third_party/legacy_config_parser/config_parser.c"
     break;
 
-  case 44:
-/* Line 1792 of yacc.c  */
-/* Line 442 of config_parser.y */
-    { if (current_conf_type == CONF_RULE) __xlio_address_port_rule->match_by_addr = 1; __xlio_set_inet_addr_prefix_len(32); }
+  case 44: /* address: ipv4  */
+#line 422 "src/core/util/config_parser.y"
+                       { if (current_conf_type == CONF_RULE) __xlio_address_port_rule->match_by_addr = 1; __xlio_set_inet_addr_prefix_len(32); }
+#line 1567 "third_party/legacy_config_parser/config_parser.c"
     break;
 
-  case 45:
-/* Line 1792 of yacc.c  */
-/* Line 443 of config_parser.y */
-    { if (current_conf_type == CONF_RULE) __xlio_address_port_rule->match_by_addr = 1; __xlio_set_inet_addr_prefix_len((yyvsp[(3) - (3)].ival)); }
+  case 45: /* address: ipv4 '/' "integer value"  */
+#line 423 "src/core/util/config_parser.y"
+                       { if (current_conf_type == CONF_RULE) __xlio_address_port_rule->match_by_addr = 1; __xlio_set_inet_addr_prefix_len((yyvsp[0].ival)); }
+#line 1573 "third_party/legacy_config_parser/config_parser.c"
     break;
 
-  case 46:
-/* Line 1792 of yacc.c  */
-/* Line 444 of config_parser.y */
-    { if (current_conf_type == CONF_RULE) __xlio_address_port_rule->match_by_addr = 0; __xlio_set_inet_addr_prefix_len(32); }
+  case 46: /* address: '*'  */
+#line 424 "src/core/util/config_parser.y"
+                       { if (current_conf_type == CONF_RULE) __xlio_address_port_rule->match_by_addr = 0; __xlio_set_inet_addr_prefix_len(32); }
+#line 1579 "third_party/legacy_config_parser/config_parser.c"
     break;
 
-  case 47:
-/* Line 1792 of yacc.c  */
-/* Line 448 of config_parser.y */
-    { __xlio_set_ipv4_addr((yyvsp[(1) - (7)].ival),(yyvsp[(3) - (7)].ival),(yyvsp[(5) - (7)].ival),(yyvsp[(7) - (7)].ival)); }
+  case 47: /* ipv4: "integer value" '.' "integer value" '.' "integer value" '.' "integer value"  */
+#line 428 "src/core/util/config_parser.y"
+                                    { __xlio_set_ipv4_addr((yyvsp[-6].ival),(yyvsp[-4].ival),(yyvsp[-2].ival),(yyvsp[0].ival)); }
+#line 1585 "third_party/legacy_config_parser/config_parser.c"
     break;
 
-  case 48:
-/* Line 1792 of yacc.c  */
-/* Line 452 of config_parser.y */
-    { __xlio_address_port_rule->match_by_port = 1; __xlio_address_port_rule->sport= (yyvsp[(1) - (1)].ival); __xlio_address_port_rule->eport= (yyvsp[(1) - (1)].ival); }
+  case 48: /* ports: "integer value"  */
+#line 432 "src/core/util/config_parser.y"
+                      { __xlio_address_port_rule->match_by_port = 1; __xlio_address_port_rule->sport= (yyvsp[0].ival); __xlio_address_port_rule->eport= (yyvsp[0].ival); }
+#line 1591 "third_party/legacy_config_parser/config_parser.c"
     break;
 
-  case 49:
-/* Line 1792 of yacc.c  */
-/* Line 453 of config_parser.y */
-    { __xlio_address_port_rule->match_by_port = 1; __xlio_address_port_rule->sport= (yyvsp[(1) - (3)].ival); __xlio_address_port_rule->eport= (yyvsp[(3) - (3)].ival); }
+  case 49: /* ports: "integer value" '-' "integer value"  */
+#line 433 "src/core/util/config_parser.y"
+                      { __xlio_address_port_rule->match_by_port = 1; __xlio_address_port_rule->sport= (yyvsp[-2].ival); __xlio_address_port_rule->eport= (yyvsp[0].ival); }
+#line 1597 "third_party/legacy_config_parser/config_parser.c"
     break;
 
-  case 50:
-/* Line 1792 of yacc.c  */
-/* Line 454 of config_parser.y */
-    { __xlio_address_port_rule->match_by_port = 0; __xlio_address_port_rule->sport= 0;  __xlio_address_port_rule->eport= 0;  }
+  case 50: /* ports: '*'  */
+#line 434 "src/core/util/config_parser.y"
+                      { __xlio_address_port_rule->match_by_port = 0; __xlio_address_port_rule->sport= 0;  __xlio_address_port_rule->eport= 0;  }
+#line 1603 "third_party/legacy_config_parser/config_parser.c"
     break;
 
 
-/* Line 1792 of yacc.c  */
-/* Line 1893 of config_parser.c */
+#line 1607 "third_party/legacy_config_parser/config_parser.c"
+
       default: break;
     }
   /* User semantic actions sometimes alter yychar, and that requires
@@ -1921,96 +1618,58 @@ yyreduce:
      case of YYERROR or YYBACKUP, subsequent parser actions might lead
      to an incorrect destructor call or verbose syntax error message
      before the lookahead is translated.  */
-  YY_SYMBOL_PRINT ("-> $$ =", yyr1[yyn], &yyval, &yyloc);
+  YY_SYMBOL_PRINT ("-> $$ =", YY_CAST (yysymbol_kind_t, yyr1[yyn]), &yyval, &yyloc);
 
   YYPOPSTACK (yylen);
   yylen = 0;
-  YY_STACK_PRINT (yyss, yyssp);
 
   *++yyvsp = yyval;
 
-  /* Now `shift' the result of the reduction.  Determine what state
+  /* Now 'shift' the result of the reduction.  Determine what state
      that goes to, based on the state we popped back to and the rule
      number reduced by.  */
-
-  yyn = yyr1[yyn];
-
-  yystate = yypgoto[yyn - YYNTOKENS] + *yyssp;
-  if (0 <= yystate && yystate <= YYLAST && yycheck[yystate] == *yyssp)
-    yystate = yytable[yystate];
-  else
-    yystate = yydefgoto[yyn - YYNTOKENS];
+  {
+    const int yylhs = yyr1[yyn] - YYNTOKENS;
+    const int yyi = yypgoto[yylhs] + *yyssp;
+    yystate = (0 <= yyi && yyi <= YYLAST && yycheck[yyi] == *yyssp
+               ? yytable[yyi]
+               : yydefgoto[yylhs]);
+  }
 
   goto yynewstate;
 
 
-/*------------------------------------.
-| yyerrlab -- here on detecting error |
-`------------------------------------*/
+/*--------------------------------------.
+| yyerrlab -- here on detecting error.  |
+`--------------------------------------*/
 yyerrlab:
   /* Make sure we have latest lookahead translation.  See comments at
      user semantic actions for why this is necessary.  */
-  yytoken = yychar == YYEMPTY ? YYEMPTY : YYTRANSLATE (yychar);
-
+  yytoken = yychar == YYEMPTY ? YYSYMBOL_YYEMPTY : YYTRANSLATE (yychar);
   /* If not already recovering from an error, report this error.  */
   if (!yyerrstatus)
     {
       ++yynerrs;
-#if ! YYERROR_VERBOSE
       yyerror (YY_("syntax error"));
-#else
-# define YYSYNTAX_ERROR yysyntax_error (&yymsg_alloc, &yymsg, \
-                                        yyssp, yytoken)
-      {
-        char const *yymsgp = YY_("syntax error");
-        int yysyntax_error_status;
-        yysyntax_error_status = YYSYNTAX_ERROR;
-        if (yysyntax_error_status == 0)
-          yymsgp = yymsg;
-        else if (yysyntax_error_status == 1)
-          {
-            if (yymsg != yymsgbuf)
-              YYSTACK_FREE (yymsg);
-            yymsg = (char *) YYSTACK_ALLOC (yymsg_alloc);
-            if (!yymsg)
-              {
-                yymsg = yymsgbuf;
-                yymsg_alloc = sizeof yymsgbuf;
-                yysyntax_error_status = 2;
-              }
-            else
-              {
-                yysyntax_error_status = YYSYNTAX_ERROR;
-                yymsgp = yymsg;
-              }
-          }
-        yyerror (yymsgp);
-        if (yysyntax_error_status == 2)
-          goto yyexhaustedlab;
-      }
-# undef YYSYNTAX_ERROR
-#endif
     }
-
-
 
   if (yyerrstatus == 3)
     {
       /* If just tried and failed to reuse lookahead token after an
-	 error, discard it.  */
+         error, discard it.  */
 
       if (yychar <= YYEOF)
-	{
-	  /* Return failure if at end of input.  */
-	  if (yychar == YYEOF)
-	    YYABORT;
-	}
+        {
+          /* Return failure if at end of input.  */
+          if (yychar == YYEOF)
+            YYABORT;
+        }
       else
-	{
-	  yydestruct ("Error: discarding",
-		      yytoken, &yylval);
-	  yychar = YYEMPTY;
-	}
+        {
+          yydestruct ("Error: discarding",
+                      yytoken, &yylval);
+          yychar = YYEMPTY;
+        }
     }
 
   /* Else will try to reuse lookahead token after shifting the error
@@ -2022,14 +1681,13 @@ yyerrlab:
 | yyerrorlab -- error raised explicitly by YYERROR.  |
 `---------------------------------------------------*/
 yyerrorlab:
+  /* Pacify compilers when the user code never invokes YYERROR and the
+     label yyerrorlab therefore never appears in user code.  */
+  if (0)
+    YYERROR;
+  ++yynerrs;
 
-  /* Pacify compilers like GCC when the user code never invokes
-     YYERROR and the label yyerrorlab therefore never appears in user
-     code.  */
-  if (/*CONSTCOND*/ 0)
-     goto yyerrorlab;
-
-  /* Do not reclaim the symbols of the rule which action triggered
+  /* Do not reclaim the symbols of the rule whose action triggered
      this YYERROR.  */
   YYPOPSTACK (yylen);
   yylen = 0;
@@ -2042,29 +1700,30 @@ yyerrorlab:
 | yyerrlab1 -- common code for both syntax error and YYERROR.  |
 `-------------------------------------------------------------*/
 yyerrlab1:
-  yyerrstatus = 3;	/* Each real token shifted decrements this.  */
+  yyerrstatus = 3;      /* Each real token shifted decrements this.  */
 
+  /* Pop stack until we find a state that shifts the error token.  */
   for (;;)
     {
       yyn = yypact[yystate];
       if (!yypact_value_is_default (yyn))
-	{
-	  yyn += YYTERROR;
-	  if (0 <= yyn && yyn <= YYLAST && yycheck[yyn] == YYTERROR)
-	    {
-	      yyn = yytable[yyn];
-	      if (0 < yyn)
-		break;
-	    }
-	}
+        {
+          yyn += YYSYMBOL_YYerror;
+          if (0 <= yyn && yyn <= YYLAST && yycheck[yyn] == YYSYMBOL_YYerror)
+            {
+              yyn = yytable[yyn];
+              if (0 < yyn)
+                break;
+            }
+        }
 
       /* Pop the current state because it cannot handle the error token.  */
       if (yyssp == yyss)
-	YYABORT;
+        YYABORT;
 
 
       yydestruct ("Error: popping",
-		  yystos[yystate], yyvsp);
+                  YY_ACCESSING_SYMBOL (yystate), yyvsp);
       YYPOPSTACK (1);
       yystate = *yyssp;
       YY_STACK_PRINT (yyss, yyssp);
@@ -2076,7 +1735,7 @@ yyerrlab1:
 
 
   /* Shift the error token.  */
-  YY_SYMBOL_PRINT ("Shifting", yystos[yyn], yyvsp, yylsp);
+  YY_SYMBOL_PRINT ("Shifting", YY_ACCESSING_SYMBOL (yyn), yyvsp, yylsp);
 
   yystate = yyn;
   goto yynewstate;
@@ -2087,26 +1746,30 @@ yyerrlab1:
 `-------------------------------------*/
 yyacceptlab:
   yyresult = 0;
-  goto yyreturn;
+  goto yyreturnlab;
+
 
 /*-----------------------------------.
 | yyabortlab -- YYABORT comes here.  |
 `-----------------------------------*/
 yyabortlab:
   yyresult = 1;
-  goto yyreturn;
+  goto yyreturnlab;
 
-#if !defined yyoverflow || YYERROR_VERBOSE
-/*-------------------------------------------------.
-| yyexhaustedlab -- memory exhaustion comes here.  |
-`-------------------------------------------------*/
+
+/*-----------------------------------------------------------.
+| yyexhaustedlab -- YYNOMEM (memory exhaustion) comes here.  |
+`-----------------------------------------------------------*/
 yyexhaustedlab:
   yyerror (YY_("memory exhausted"));
   yyresult = 2;
-  /* Fall through.  */
-#endif
+  goto yyreturnlab;
 
-yyreturn:
+
+/*----------------------------------------------------------.
+| yyreturnlab -- parsing is finished, clean up and return.  |
+`----------------------------------------------------------*/
+yyreturnlab:
   if (yychar != YYEMPTY)
     {
       /* Make sure we have latest lookahead translation.  See comments at
@@ -2115,31 +1778,25 @@ yyreturn:
       yydestruct ("Cleanup: discarding lookahead",
                   yytoken, &yylval);
     }
-  /* Do not reclaim the symbols of the rule which action triggered
+  /* Do not reclaim the symbols of the rule whose action triggered
      this YYABORT or YYACCEPT.  */
   YYPOPSTACK (yylen);
   YY_STACK_PRINT (yyss, yyssp);
   while (yyssp != yyss)
     {
       yydestruct ("Cleanup: popping",
-		  yystos[*yyssp], yyvsp);
+                  YY_ACCESSING_SYMBOL (+*yyssp), yyvsp);
       YYPOPSTACK (1);
     }
 #ifndef yyoverflow
   if (yyss != yyssa)
     YYSTACK_FREE (yyss);
 #endif
-#if YYERROR_VERBOSE
-  if (yymsg != yymsgbuf)
-    YYSTACK_FREE (yymsg);
-#endif
-  /* Make sure YYID is used.  */
-  return YYID (yyresult);
+
+  return yyresult;
 }
 
-
-/* Line 2055 of yacc.c  */
-/* Line 457 of config_parser.y */
+#line 437 "src/core/util/config_parser.y"
 
 
 int yyerror(const char *msg)
@@ -2181,16 +1838,14 @@ int __xlio_parse_config_file (const char *fileName) {
    
 	/* open the file */
 	if (access(fileName, R_OK)) {
-		/*
-		 * Let upper layer inform about no access to open file - based on log level
-		*/
+		printf("libxlio Error: No access to open File:%s %s\n", 
+				fileName, strerror(errno));
 		return(1);
 	}
 
-	/* coverity[toctou] */
 	libxlio_yyin = fopen(fileName,"r");
 	if (!libxlio_yyin) {
-		printf("Error: Fail to open File:%s\n", fileName);
+		printf("libxlio Error: Fail to open File:%s\n", fileName);
 		return(1);
 	}
 	__instance_list.head = NULL;
@@ -2210,12 +1865,10 @@ int __xlio_parse_config_line (const char *line) {
 	
 	__xlio_rule_push_head = 1;
 	
-	/* The below casting is valid because we open the stream as read-only. */
-	/* coverity[alloc_strlen] */
-	libxlio_yyin = fmemopen((void*)line, strlen(line), "r");
+	libxlio_yyin = fmemopen((void *)line, strlen(line), "r");
 	
 	if (!libxlio_yyin) {
-		printf("Error: Fail to parse line:%s\n", line);
+		printf("libxlio Error: Fail to parse line:%s\n", line);
 		return(1);
 	}
 	

--- a/third_party/legacy_config_parser/config_parser.h
+++ b/third_party/legacy_config_parser/config_parser.h
@@ -1,8 +1,9 @@
-/* A Bison parser, made by GNU Bison 2.7.  */
+/* A Bison parser, made by GNU Bison 3.8.2.  */
 
 /* Bison interface for Yacc-like parsers in C
 
-      Copyright (C) 1984, 1989-1990, 2000-2012 Free Software Foundation, Inc.
+   Copyright (C) 1984, 1989-1990, 2000-2015, 2018-2021 Free Software Foundation,
+   Inc.
 
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -15,7 +16,7 @@
    GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License
-   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.  */
 
 /* As a special exception, you may create a larger work that contains
    part or all of the Bison parser skeleton and distribute that work
@@ -30,104 +31,79 @@
    This special exception was added by the Free Software Foundation in
    version 2.2 of Bison.  */
 
-#ifndef YY_CONFIG_PARSER_H_INCLUDED
-#define YY_CONFIG_PARSER_H_INCLUDED
-/* Enabling traces.  */
+/* DO NOT RELY ON FEATURES THAT ARE NOT DOCUMENTED in the manual,
+   especially those whose name start with YY_ or yy_.  They are
+   private implementation details that can be changed or removed.  */
+
+#ifndef YY_LIBXLIO_YY_THIRD_PARTY_LEGACY_CONFIG_PARSER_CONFIG_PARSER_H_INCLUDED
+# define YY_LIBXLIO_YY_THIRD_PARTY_LEGACY_CONFIG_PARSER_CONFIG_PARSER_H_INCLUDED
+/* Debug traces.  */
 #ifndef YYDEBUG
-#define YYDEBUG 0
+# define YYDEBUG 0
 #endif
 #if YYDEBUG
 extern int libxlio_yydebug;
 #endif
 
-/* Tokens.  */
+/* Token kinds.  */
 #ifndef YYTOKENTYPE
-#define YYTOKENTYPE
-/* Put the tokens into the symbol table, so that GDB and other debuggers
-   know about them.  */
-enum yytokentype {
-    USE = 258,
-    TCP_CLIENT = 259,
-    TCP_SERVER = 260,
-    UDP_SENDER = 261,
-    UDP_RECEIVER = 262,
-    UDP_CONNECT = 263,
-    TCP = 264,
-    UDP = 265,
-    OS = 266,
-    XLIO = 267,
-    SDP = 268,
-    SA = 269,
-    INT = 270,
-    APP_ID = 271,
-    PROGRAM = 272,
-    USER_DEFINED_ID_STR = 273,
-    LOG = 274,
-    DEST = 275,
-    STDERR = 276,
-    SYSLOG = 277,
-    FILENAME = 278,
-    NAME = 279,
-    LEVEL = 280,
-    LINE = 281
+# define YYTOKENTYPE
+  enum yytokentype
+  {
+    YYEMPTY = -2,
+    YYEOF = 0,                     /* "end of file"  */
+    YYerror = 256,                 /* error  */
+    YYUNDEF = 257,                 /* "invalid token"  */
+    USE = 258,                     /* "use"  */
+    TCP_CLIENT = 259,              /* "tcp client"  */
+    TCP_SERVER = 260,              /* "tcp server"  */
+    UDP_SENDER = 261,              /* "udp sender"  */
+    UDP_RECEIVER = 262,            /* "udp receiver"  */
+    UDP_CONNECT = 263,             /* "udp connect"  */
+    TCP = 264,                     /* "tcp"  */
+    UDP = 265,                     /* "udp"  */
+    OS = 266,                      /* "os"  */
+    XLIO = 267,                    /* "xlio"  */
+    SDP = 268,                     /* "sdp"  */
+    SA = 269,                      /* "sa"  */
+    INT = 270,                     /* "integer value"  */
+    APP_ID = 271,                  /* "application id"  */
+    PROGRAM = 272,                 /* "program name"  */
+    USER_DEFINED_ID_STR = 273,     /* "userdefined id str"  */
+    LOG = 274,                     /* "log statement"  */
+    DEST = 275,                    /* "destination"  */
+    STDERR = 276,                  /* "ystderr"  */
+    SYSLOG = 277,                  /* "syslog"  */
+    FILENAME = 278,                /* "yfile"  */
+    NAME = 279,                    /* "a name"  */
+    LEVEL = 280,                   /* "min-level"  */
+    LINE = 281                     /* "new line"  */
+  };
+  typedef enum yytokentype yytoken_kind_t;
+#endif
+
+/* Value type.  */
+#if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
+union YYSTYPE
+{
+#line 286 "src/core/util/config_parser.y"
+
+  int        ival;
+  char      *sval;
+
+#line 95 "third_party/legacy_config_parser/config_parser.h"
+
 };
+typedef union YYSTYPE YYSTYPE;
+# define YYSTYPE_IS_TRIVIAL 1
+# define YYSTYPE_IS_DECLARED 1
 #endif
-/* Tokens.  */
-#define USE                 258
-#define TCP_CLIENT          259
-#define TCP_SERVER          260
-#define UDP_SENDER          261
-#define UDP_RECEIVER        262
-#define UDP_CONNECT         263
-#define TCP                 264
-#define UDP                 265
-#define OS                  266
-#define XLIO                267
-#define SDP                 268
-#define SA                  269
-#define INT                 270
-#define APP_ID              271
-#define PROGRAM             272
-#define USER_DEFINED_ID_STR 273
-#define LOG                 274
-#define DEST                275
-#define STDERR              276
-#define SYSLOG              277
-#define FILENAME            278
-#define NAME                279
-#define LEVEL               280
-#define LINE                281
 
-#if !defined YYSTYPE && !defined YYSTYPE_IS_DECLARED
-typedef union YYSTYPE {
-    /* Line 2058 of yacc.c  */
-    /* Line 306 of config_parser.y */
-
-    int ival;
-    char *sval;
-
-    /* Line 2058 of yacc.c  */
-    /* Line 115 of config_parser.h */
-} YYSTYPE;
-#define YYSTYPE_IS_TRIVIAL  1
-#define yystype             YYSTYPE /* obsolescent; will be withdrawn */
-#define YYSTYPE_IS_DECLARED 1
-#endif
 
 extern YYSTYPE libxlio_yylval;
 
-#ifdef YYPARSE_PARAM
-#if defined __STDC__ || defined __cplusplus
-int libxlio_yyparse(void *YYPARSE_PARAM);
-#else
-int libxlio_yyparse();
-#endif
-#else /* ! YYPARSE_PARAM */
-#if defined __STDC__ || defined __cplusplus
-int libxlio_yyparse(void);
-#else
-int libxlio_yyparse();
-#endif
-#endif /* ! YYPARSE_PARAM */
 
-#endif /* !YY_CONFIG_PARSER_H_INCLUDED  */
+int libxlio_yyparse (void);
+
+
+#endif /* !YY_LIBXLIO_YY_THIRD_PARTY_LEGACY_CONFIG_PARSER_CONFIG_PARSER_H_INCLUDED  */

--- a/third_party/legacy_config_parser/config_scanner.c
+++ b/third_party/legacy_config_parser/config_scanner.c
@@ -1,5 +1,6 @@
+#line 2 "third_party/legacy_config_parser/config_scanner.c"
 
-/* Line 3 of config_scanner.c */
+#line 4 "third_party/legacy_config_parser/config_scanner.c"
 
 #define  YY_INT_ALIGNED short int
 
@@ -7,11 +8,17 @@
 
 #define yy_create_buffer libxlio_yy_create_buffer
 #define yy_delete_buffer libxlio_yy_delete_buffer
-#define yy_flex_debug libxlio_yy_flex_debug
+#define yy_scan_buffer libxlio_yy_scan_buffer
+#define yy_scan_string libxlio_yy_scan_string
+#define yy_scan_bytes libxlio_yy_scan_bytes
 #define yy_init_buffer libxlio_yy_init_buffer
 #define yy_flush_buffer libxlio_yy_flush_buffer
 #define yy_load_buffer_state libxlio_yy_load_buffer_state
 #define yy_switch_to_buffer libxlio_yy_switch_to_buffer
+#define yypush_buffer_state libxlio_yypush_buffer_state
+#define yypop_buffer_state libxlio_yypop_buffer_state
+#define yyensure_buffer_stack libxlio_yyensure_buffer_stack
+#define yy_flex_debug libxlio_yy_flex_debug
 #define yyin libxlio_yyin
 #define yyleng libxlio_yyleng
 #define yylex libxlio_yylex
@@ -26,10 +33,244 @@
 
 #define FLEX_SCANNER
 #define YY_FLEX_MAJOR_VERSION 2
-#define YY_FLEX_MINOR_VERSION 5
-#define YY_FLEX_SUBMINOR_VERSION 39
+#define YY_FLEX_MINOR_VERSION 6
+#define YY_FLEX_SUBMINOR_VERSION 4
 #if YY_FLEX_SUBMINOR_VERSION > 0
 #define FLEX_BETA
+#endif
+
+#ifdef yy_create_buffer
+#define libxlio_yy_create_buffer_ALREADY_DEFINED
+#else
+#define yy_create_buffer libxlio_yy_create_buffer
+#endif
+
+#ifdef yy_delete_buffer
+#define libxlio_yy_delete_buffer_ALREADY_DEFINED
+#else
+#define yy_delete_buffer libxlio_yy_delete_buffer
+#endif
+
+#ifdef yy_scan_buffer
+#define libxlio_yy_scan_buffer_ALREADY_DEFINED
+#else
+#define yy_scan_buffer libxlio_yy_scan_buffer
+#endif
+
+#ifdef yy_scan_string
+#define libxlio_yy_scan_string_ALREADY_DEFINED
+#else
+#define yy_scan_string libxlio_yy_scan_string
+#endif
+
+#ifdef yy_scan_bytes
+#define libxlio_yy_scan_bytes_ALREADY_DEFINED
+#else
+#define yy_scan_bytes libxlio_yy_scan_bytes
+#endif
+
+#ifdef yy_init_buffer
+#define libxlio_yy_init_buffer_ALREADY_DEFINED
+#else
+#define yy_init_buffer libxlio_yy_init_buffer
+#endif
+
+#ifdef yy_flush_buffer
+#define libxlio_yy_flush_buffer_ALREADY_DEFINED
+#else
+#define yy_flush_buffer libxlio_yy_flush_buffer
+#endif
+
+#ifdef yy_load_buffer_state
+#define libxlio_yy_load_buffer_state_ALREADY_DEFINED
+#else
+#define yy_load_buffer_state libxlio_yy_load_buffer_state
+#endif
+
+#ifdef yy_switch_to_buffer
+#define libxlio_yy_switch_to_buffer_ALREADY_DEFINED
+#else
+#define yy_switch_to_buffer libxlio_yy_switch_to_buffer
+#endif
+
+#ifdef yypush_buffer_state
+#define libxlio_yypush_buffer_state_ALREADY_DEFINED
+#else
+#define yypush_buffer_state libxlio_yypush_buffer_state
+#endif
+
+#ifdef yypop_buffer_state
+#define libxlio_yypop_buffer_state_ALREADY_DEFINED
+#else
+#define yypop_buffer_state libxlio_yypop_buffer_state
+#endif
+
+#ifdef yyensure_buffer_stack
+#define libxlio_yyensure_buffer_stack_ALREADY_DEFINED
+#else
+#define yyensure_buffer_stack libxlio_yyensure_buffer_stack
+#endif
+
+#ifdef yylex
+#define libxlio_yylex_ALREADY_DEFINED
+#else
+#define yylex libxlio_yylex
+#endif
+
+#ifdef yyrestart
+#define libxlio_yyrestart_ALREADY_DEFINED
+#else
+#define yyrestart libxlio_yyrestart
+#endif
+
+#ifdef yylex_init
+#define libxlio_yylex_init_ALREADY_DEFINED
+#else
+#define yylex_init libxlio_yylex_init
+#endif
+
+#ifdef yylex_init_extra
+#define libxlio_yylex_init_extra_ALREADY_DEFINED
+#else
+#define yylex_init_extra libxlio_yylex_init_extra
+#endif
+
+#ifdef yylex_destroy
+#define libxlio_yylex_destroy_ALREADY_DEFINED
+#else
+#define yylex_destroy libxlio_yylex_destroy
+#endif
+
+#ifdef yyget_debug
+#define libxlio_yyget_debug_ALREADY_DEFINED
+#else
+#define yyget_debug libxlio_yyget_debug
+#endif
+
+#ifdef yyset_debug
+#define libxlio_yyset_debug_ALREADY_DEFINED
+#else
+#define yyset_debug libxlio_yyset_debug
+#endif
+
+#ifdef yyget_extra
+#define libxlio_yyget_extra_ALREADY_DEFINED
+#else
+#define yyget_extra libxlio_yyget_extra
+#endif
+
+#ifdef yyset_extra
+#define libxlio_yyset_extra_ALREADY_DEFINED
+#else
+#define yyset_extra libxlio_yyset_extra
+#endif
+
+#ifdef yyget_in
+#define libxlio_yyget_in_ALREADY_DEFINED
+#else
+#define yyget_in libxlio_yyget_in
+#endif
+
+#ifdef yyset_in
+#define libxlio_yyset_in_ALREADY_DEFINED
+#else
+#define yyset_in libxlio_yyset_in
+#endif
+
+#ifdef yyget_out
+#define libxlio_yyget_out_ALREADY_DEFINED
+#else
+#define yyget_out libxlio_yyget_out
+#endif
+
+#ifdef yyset_out
+#define libxlio_yyset_out_ALREADY_DEFINED
+#else
+#define yyset_out libxlio_yyset_out
+#endif
+
+#ifdef yyget_leng
+#define libxlio_yyget_leng_ALREADY_DEFINED
+#else
+#define yyget_leng libxlio_yyget_leng
+#endif
+
+#ifdef yyget_text
+#define libxlio_yyget_text_ALREADY_DEFINED
+#else
+#define yyget_text libxlio_yyget_text
+#endif
+
+#ifdef yyget_lineno
+#define libxlio_yyget_lineno_ALREADY_DEFINED
+#else
+#define yyget_lineno libxlio_yyget_lineno
+#endif
+
+#ifdef yyset_lineno
+#define libxlio_yyset_lineno_ALREADY_DEFINED
+#else
+#define yyset_lineno libxlio_yyset_lineno
+#endif
+
+#ifdef yywrap
+#define libxlio_yywrap_ALREADY_DEFINED
+#else
+#define yywrap libxlio_yywrap
+#endif
+
+#ifdef yyalloc
+#define libxlio_yyalloc_ALREADY_DEFINED
+#else
+#define yyalloc libxlio_yyalloc
+#endif
+
+#ifdef yyrealloc
+#define libxlio_yyrealloc_ALREADY_DEFINED
+#else
+#define yyrealloc libxlio_yyrealloc
+#endif
+
+#ifdef yyfree
+#define libxlio_yyfree_ALREADY_DEFINED
+#else
+#define yyfree libxlio_yyfree
+#endif
+
+#ifdef yytext
+#define libxlio_yytext_ALREADY_DEFINED
+#else
+#define yytext libxlio_yytext
+#endif
+
+#ifdef yyleng
+#define libxlio_yyleng_ALREADY_DEFINED
+#else
+#define yyleng libxlio_yyleng
+#endif
+
+#ifdef yyin
+#define libxlio_yyin_ALREADY_DEFINED
+#else
+#define yyin libxlio_yyin
+#endif
+
+#ifdef yyout
+#define libxlio_yyout_ALREADY_DEFINED
+#else
+#define yyout libxlio_yyout
+#endif
+
+#ifdef yy_flex_debug
+#define libxlio_yy_flex_debug_ALREADY_DEFINED
+#else
+#define yy_flex_debug libxlio_yy_flex_debug
+#endif
+
+#ifdef yylineno
+#define libxlio_yylineno_ALREADY_DEFINED
+#else
+#define yylineno libxlio_yylineno
 #endif
 
 /* First, we deal with  platform-specific or compiler-specific issues. */
@@ -102,60 +343,48 @@ typedef unsigned int flex_uint32_t;
 #define UINT32_MAX             (4294967295U)
 #endif
 
+#ifndef SIZE_MAX
+#define SIZE_MAX               (~(size_t)0)
+#endif
+
 #endif /* ! C99 */
 
 #endif /* ! FLEXINT_H */
 
-#ifdef __cplusplus
+/* begin standard C++ headers. */
 
-/* The "const" storage-class-modifier is valid. */
-#define YY_USE_CONST
-
-#else	/* ! __cplusplus */
-
-/* C99 requires __STDC__ to be defined as 1. */
-#if defined (__STDC__)
-
-#define YY_USE_CONST
-
-#endif	/* defined (__STDC__) */
-#endif	/* ! __cplusplus */
-
-#ifdef YY_USE_CONST
+/* TODO: this is always defined, so inline it */
 #define yyconst const
+
+#if defined(__GNUC__) && __GNUC__ >= 3
+#define yynoreturn __attribute__((__noreturn__))
 #else
-#define yyconst
+#define yynoreturn
 #endif
 
 /* Returned upon end-of-file. */
 #define YY_NULL 0
 
-/* Promotes a possibly negative, possibly signed char to an unsigned
- * integer for use as an array index.  If the signed char is negative,
- * we want to instead treat it as an 8-bit unsigned char, hence the
- * double cast.
+/* Promotes a possibly negative, possibly signed char to an
+ *   integer in range [0..255] for use as an array index.
  */
-#define YY_SC_TO_UI(c) ((unsigned int) (unsigned char) c)
+#define YY_SC_TO_UI(c) ((YY_CHAR) (c))
 
 /* Enter a start condition.  This macro really ought to take a parameter,
  * but we do it the disgusting crufty way forced on us by the ()-less
  * definition of BEGIN.
  */
 #define BEGIN (yy_start) = 1 + 2 *
-
 /* Translate the current start state into a value that can be later handed
  * to BEGIN to return to the state.  The YYSTATE alias is for lex
  * compatibility.
  */
 #define YY_START (((yy_start) - 1) / 2)
 #define YYSTATE YY_START
-
 /* Action number for EOF rule of a given start state. */
 #define YY_STATE_EOF(state) (YY_END_OF_BUFFER + state + 1)
-
 /* Special action meaning "start processing a new file". */
-#define YY_NEW_FILE libxlio_yyrestart(libxlio_yyin  )
-
+#define YY_NEW_FILE yyrestart( yyin  )
 #define YY_END_OF_BUFFER_CHAR 0
 
 /* Size of default input buffer. */
@@ -185,14 +414,14 @@ typedef struct yy_buffer_state *YY_BUFFER_STATE;
 typedef size_t yy_size_t;
 #endif
 
-extern yy_size_t libxlio_yyleng;
+extern int yyleng;
 
-extern FILE *libxlio_yyin, *libxlio_yyout;
+extern FILE *yyin, *yyout;
 
 #define EOB_ACT_CONTINUE_SCAN 0
 #define EOB_ACT_END_OF_FILE 1
 #define EOB_ACT_LAST_MATCH 2
-
+    
     #define YY_LESS_LINENO(n)
     #define YY_LINENO_REWIND_TO(ptr)
     
@@ -200,16 +429,15 @@ extern FILE *libxlio_yyin, *libxlio_yyout;
 #define yyless(n) \
 	do \
 		{ \
-		/* Undo effects of setting up libxlio_yytext. */ \
+		/* Undo effects of setting up yytext. */ \
         int yyless_macro_arg = (n); \
         YY_LESS_LINENO(yyless_macro_arg);\
 		*yy_cp = (yy_hold_char); \
 		YY_RESTORE_YY_MORE_OFFSET \
 		(yy_c_buf_p) = yy_cp = yy_bp + yyless_macro_arg - YY_MORE_ADJ; \
-		YY_DO_BEFORE_ACTION; /* set up libxlio_yytext again */ \
+		YY_DO_BEFORE_ACTION; /* set up yytext again */ \
 		} \
 	while ( 0 )
-
 #define unput(c) yyunput( c, (yytext_ptr)  )
 
 #ifndef YY_STRUCT_YY_BUFFER_STATE
@@ -224,12 +452,12 @@ struct yy_buffer_state
 	/* Size of input buffer in bytes, not including room for EOB
 	 * characters.
 	 */
-	yy_size_t yy_buf_size;
+	int yy_buf_size;
 
 	/* Number of characters read into yy_ch_buf, not including EOB
 	 * characters.
 	 */
-	yy_size_t yy_n_chars;
+	int yy_n_chars;
 
 	/* Whether we "own" the buffer - i.e., we know we created it,
 	 * and can realloc() it to grow it, and should free() it to
@@ -252,7 +480,7 @@ struct yy_buffer_state
 
     int yy_bs_lineno; /**< The line count. */
     int yy_bs_column; /**< The column count. */
-    
+
 	/* Whether to try to fill the input buffer when we reach the
 	 * end of it.
 	 */
@@ -269,8 +497,8 @@ struct yy_buffer_state
 	 * possible backing-up.
 	 *
 	 * When we actually see the EOF, we change the status to "new"
-	 * (via libxlio_yyrestart()), so that the user can continue scanning by
-	 * just pointing libxlio_yyin at a new input file.
+	 * (via yyrestart()), so that the user can continue scanning by
+	 * just pointing yyin at a new input file.
 	 */
 #define YY_BUFFER_EOF_PENDING 2
 
@@ -280,7 +508,7 @@ struct yy_buffer_state
 /* Stack of input buffers. */
 static size_t yy_buffer_stack_top = 0; /**< index of top of stack. */
 static size_t yy_buffer_stack_max = 0; /**< capacity of stack. */
-static YY_BUFFER_STATE * yy_buffer_stack = 0; /**< Stack as an array. */
+static YY_BUFFER_STATE * yy_buffer_stack = NULL; /**< Stack as an array. */
 
 /* We provide macros for accessing buffer states in case in the
  * future we want to put the buffer states in a more general
@@ -291,103 +519,98 @@ static YY_BUFFER_STATE * yy_buffer_stack = 0; /**< Stack as an array. */
 #define YY_CURRENT_BUFFER ( (yy_buffer_stack) \
                           ? (yy_buffer_stack)[(yy_buffer_stack_top)] \
                           : NULL)
-
 /* Same as previous macro, but useful when we know that the buffer stack is not
  * NULL or when we need an lvalue. For internal use only.
  */
 #define YY_CURRENT_BUFFER_LVALUE (yy_buffer_stack)[(yy_buffer_stack_top)]
 
-/* yy_hold_char holds the character lost when libxlio_yytext is formed. */
+/* yy_hold_char holds the character lost when yytext is formed. */
 static char yy_hold_char;
-static yy_size_t yy_n_chars;		/* number of characters read into yy_ch_buf */
-yy_size_t libxlio_yyleng;
+static int yy_n_chars;		/* number of characters read into yy_ch_buf */
+int yyleng;
 
 /* Points to current character in buffer. */
-static char *yy_c_buf_p = (char *) 0;
+static char *yy_c_buf_p = NULL;
 static int yy_init = 0;		/* whether we need to initialize */
 static int yy_start = 0;	/* start state number */
 
-/* Flag which is used to allow libxlio_yywrap()'s to do buffer switches
- * instead of setting up a fresh libxlio_yyin.  A bit of a hack ...
+/* Flag which is used to allow yywrap()'s to do buffer switches
+ * instead of setting up a fresh yyin.  A bit of a hack ...
  */
 static int yy_did_buffer_switch_on_eof;
 
-void libxlio_yyrestart (FILE *input_file  );
-void libxlio_yy_switch_to_buffer (YY_BUFFER_STATE new_buffer  );
-YY_BUFFER_STATE libxlio_yy_create_buffer (FILE *file,int size  );
-void libxlio_yy_delete_buffer (YY_BUFFER_STATE b  );
-void libxlio_yy_flush_buffer (YY_BUFFER_STATE b  );
-void libxlio_yypush_buffer_state (YY_BUFFER_STATE new_buffer  );
-void libxlio_yypop_buffer_state (void );
+void yyrestart ( FILE *input_file  );
+void yy_switch_to_buffer ( YY_BUFFER_STATE new_buffer  );
+YY_BUFFER_STATE yy_create_buffer ( FILE *file, int size  );
+void yy_delete_buffer ( YY_BUFFER_STATE b  );
+void yy_flush_buffer ( YY_BUFFER_STATE b  );
+void yypush_buffer_state ( YY_BUFFER_STATE new_buffer  );
+void yypop_buffer_state ( void );
 
-static void libxlio_yyensure_buffer_stack (void );
-static void libxlio_yy_load_buffer_state (void );
-static void libxlio_yy_init_buffer (YY_BUFFER_STATE b,FILE *file  );
+static void yyensure_buffer_stack ( void );
+static void yy_load_buffer_state ( void );
+static void yy_init_buffer ( YY_BUFFER_STATE b, FILE *file  );
+#define YY_FLUSH_BUFFER yy_flush_buffer( YY_CURRENT_BUFFER )
 
-#define YY_FLUSH_BUFFER libxlio_yy_flush_buffer(YY_CURRENT_BUFFER )
+YY_BUFFER_STATE yy_scan_buffer ( char *base, yy_size_t size  );
+YY_BUFFER_STATE yy_scan_string ( const char *yy_str  );
+YY_BUFFER_STATE yy_scan_bytes ( const char *bytes, int len  );
 
-YY_BUFFER_STATE libxlio_yy_scan_buffer (char *base,yy_size_t size  );
-YY_BUFFER_STATE libxlio_yy_scan_string (yyconst char *yy_str  );
-YY_BUFFER_STATE libxlio_yy_scan_bytes (yyconst char *bytes,yy_size_t len  );
+void *yyalloc ( yy_size_t  );
+void *yyrealloc ( void *, yy_size_t  );
+void yyfree ( void *  );
 
-void *libxlio_yyalloc (yy_size_t  );
-void *libxlio_yyrealloc (void *,yy_size_t  );
-void libxlio_yyfree (void *  );
-
-#define yy_new_buffer libxlio_yy_create_buffer
-
+#define yy_new_buffer yy_create_buffer
 #define yy_set_interactive(is_interactive) \
 	{ \
 	if ( ! YY_CURRENT_BUFFER ){ \
-        libxlio_yyensure_buffer_stack (); \
+        yyensure_buffer_stack (); \
 		YY_CURRENT_BUFFER_LVALUE =    \
-            libxlio_yy_create_buffer(libxlio_yyin,YY_BUF_SIZE ); \
+            yy_create_buffer( yyin, YY_BUF_SIZE ); \
 	} \
 	YY_CURRENT_BUFFER_LVALUE->yy_is_interactive = is_interactive; \
 	}
-
 #define yy_set_bol(at_bol) \
 	{ \
 	if ( ! YY_CURRENT_BUFFER ){\
-        libxlio_yyensure_buffer_stack (); \
+        yyensure_buffer_stack (); \
 		YY_CURRENT_BUFFER_LVALUE =    \
-            libxlio_yy_create_buffer(libxlio_yyin,YY_BUF_SIZE ); \
+            yy_create_buffer( yyin, YY_BUF_SIZE ); \
 	} \
 	YY_CURRENT_BUFFER_LVALUE->yy_at_bol = at_bol; \
 	}
-
 #define YY_AT_BOL() (YY_CURRENT_BUFFER_LVALUE->yy_at_bol)
 
 /* Begin user sect3 */
+typedef flex_uint8_t YY_CHAR;
 
-typedef unsigned char YY_CHAR;
-
-FILE *libxlio_yyin = (FILE *) 0, *libxlio_yyout = (FILE *) 0;
+FILE *yyin = NULL, *yyout = NULL;
 
 typedef int yy_state_type;
 
-extern int libxlio_yylineno;
+extern int yylineno;
+int yylineno = 1;
 
-int libxlio_yylineno = 1;
+extern char *yytext;
+#ifdef yytext_ptr
+#undef yytext_ptr
+#endif
+#define yytext_ptr yytext
 
-extern char *libxlio_yytext;
-#define yytext_ptr libxlio_yytext
-
-static yy_state_type yy_get_previous_state (void );
-static yy_state_type yy_try_NUL_trans (yy_state_type current_state  );
-static int yy_get_next_buffer (void );
-static void yy_fatal_error (yyconst char msg[]  );
+static yy_state_type yy_get_previous_state ( void );
+static yy_state_type yy_try_NUL_trans ( yy_state_type current_state  );
+static int yy_get_next_buffer ( void );
+static void yynoreturn yy_fatal_error ( const char* msg  );
 
 /* Done after the current pattern has been matched and before the
- * corresponding action - sets up libxlio_yytext.
+ * corresponding action - sets up yytext.
  */
 #define YY_DO_BEFORE_ACTION \
 	(yytext_ptr) = yy_bp; \
-	libxlio_yyleng = (size_t) (yy_cp - yy_bp); \
+	yyleng = (int) (yy_cp - yy_bp); \
 	(yy_hold_char) = *yy_cp; \
 	*yy_cp = '\0'; \
 	(yy_c_buf_p) = yy_cp;
-
 #define YY_NUM_RULES 29
 #define YY_END_OF_BUFFER 30
 /* This struct is not used in this scanner,
@@ -397,7 +620,7 @@ struct yy_trans_info
 	flex_int32_t yy_verify;
 	flex_int32_t yy_nxt;
 	};
-static yyconst flex_int16_t yy_accept[473] =
+static const flex_int16_t yy_accept[477] =
     {   0,
         0,    0,    0,    0,    0,    0,    0,    0,   30,   28,
        27,   25,   26,    5,    5,   28,   28,   28,   28,   28,
@@ -415,45 +638,45 @@ static yyconst flex_int16_t yy_accept[473] =
         3,    3,    3,    3,    3,    3,    3,    1,    4,    4,
         4,    4,    4,    4,    4,    4,    4,    4,    4,    4,
         4,    4,    4,    4,    4,    1,    0,    0,    6,    0,
-       17,    0,   13,   14,   12,   16,    0,    0,    1,   24,
-       24,    6,   24,   17,   24,   13,   14,   12,   16,   24,
+       17,    0,   13,   14,   12,    0,    0,    0,    1,   24,
+       24,    6,   24,   17,   24,   13,   14,   12,   24,   24,
        24,    3,    3,    3,    3,    3,    3,    3,    3,    3,
         3,    3,    3,    4,    4,    4,    4,    4,    4,    4,
         4,    4,    4,    4,    4,    0,    0,    0,    0,    0,
 
-        0,    0,    0,   24,   24,   24,   24,   24,   24,   24,
-       24,    3,    3,    3,    3,    3,    3,    3,    3,    4,
-        4,    4,    4,    4,    4,    4,    4,    0,    0,    0,
-        0,    0,    0,    0,    0,    0,   11,    0,   24,   24,
-       24,   24,   24,   24,   24,   24,   24,   11,   24,    3,
-        3,    3,    3,    3,    3,    3,    3,    3,    3,    3,
-        4,    4,    4,    4,    4,    4,    4,    4,    4,    4,
-        4,    0,    0,    0,   10,    0,    0,    0,    0,    0,
-        0,   24,   24,   24,   10,   24,   24,   24,   24,   24,
-       24,    3,    3,    3,    3,    3,    3,    3,    3,    3,
-
-        3,    4,    4,    4,    4,    4,    4,    4,    4,    4,
-        4,    0,    0,    0,    0,    0,    0,    0,    0,    9,
-       24,   24,   24,   24,   24,   24,   24,   24,    9,    3,
-        3,    3,    3,    3,    3,    3,    3,    3,    4,    4,
-        4,    4,    4,    4,    4,    4,    4,    0,    0,    0,
-        0,    0,    0,    0,    0,   24,   24,   24,   24,   24,
-       24,   24,   24,    3,    3,    3,    3,    3,    3,    3,
-        3,    4,    4,    4,    4,    4,    4,    4,    4,    0,
-        0,    8,    0,    0,    0,    0,    0,   24,   24,    8,
+        0,   16,    0,    0,   24,   24,   24,   24,   24,   24,
+       16,   24,   24,    3,    3,    3,    3,    3,    3,    3,
+        3,    3,    4,    4,    4,    4,    4,    4,    4,    4,
+        4,    0,    0,    0,    0,    0,    0,    0,    0,    0,
+       11,    0,   24,   24,   24,   24,   24,   24,   24,   24,
+       24,   11,   24,    3,    3,    3,    3,    3,    3,    3,
+        3,    3,    3,    3,    4,    4,    4,    4,    4,    4,
+        4,    4,    4,    4,    4,    0,    0,    0,   10,    0,
+        0,    0,    0,    0,    0,   24,   24,   24,   10,   24,
        24,   24,   24,   24,   24,    3,    3,    3,    3,    3,
 
-        3,    3,    3,    4,    4,    4,    4,    4,    4,    4,
-        4,    0,    0,   19,   20,    0,    0,   21,   24,   24,
-       19,   20,   24,   24,   21,    3,    3,    3,    3,    3,
-        3,    3,    4,    4,    4,    4,    4,    4,    4,    0,
-        7,   23,    0,   24,    7,   23,   24,    3,    3,    3,
-        3,    4,    4,    4,    4,    0,   22,   24,   22,    3,
-        3,    4,    4,    0,   24,    3,    4,    2,    2,    2,
-        2,    0
+        3,    3,    3,    3,    3,    4,    4,    4,    4,    4,
+        4,    4,    4,    4,    4,    0,    0,    0,    0,    0,
+        0,    0,    0,    9,   24,   24,   24,   24,   24,   24,
+       24,   24,    9,    3,    3,    3,    3,    3,    3,    3,
+        3,    3,    4,    4,    4,    4,    4,    4,    4,    4,
+        4,    0,    0,    0,    0,    0,    0,    0,    0,   24,
+       24,   24,   24,   24,   24,   24,   24,    3,    3,    3,
+        3,    3,    3,    3,    3,    4,    4,    4,    4,    4,
+        4,    4,    4,    0,    0,    8,    0,    0,    0,    0,
+        0,   24,   24,    8,   24,   24,   24,   24,   24,    3,
+
+        3,    3,    3,    3,    3,    3,    3,    4,    4,    4,
+        4,    4,    4,    4,    4,    0,    0,   19,   20,    0,
+        0,   21,   24,   24,   19,   20,   24,   24,   21,    3,
+        3,    3,    3,    3,    3,    3,    4,    4,    4,    4,
+        4,    4,    4,    0,    7,   23,    0,   24,    7,   23,
+       24,    3,    3,    3,    3,    4,    4,    4,    4,    0,
+       22,   24,   22,    3,    3,    4,    4,    0,   24,    3,
+        4,    2,    2,    2,    2,    0
     } ;
 
-static yyconst flex_int32_t yy_ec[256] =
+static const YY_CHAR yy_ec[256] =
     {   0,
         1,    1,    1,    1,    1,    1,    1,    1,    2,    3,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
@@ -467,8 +690,8 @@ static yyconst flex_int32_t yy_ec[256] =
         1,    1,    1,    1,    8,    1,    9,    1,   10,   11,
 
        12,   13,   14,    1,   15,    1,    1,   16,   17,   18,
-       19,   20,    1,   21,   22,   23,   24,   25,    1,    1,
-       26,    1,    1,    1,    1,    1,    1,    1,    1,    1,
+       19,   20,    1,   21,   22,   23,   24,   25,    1,   26,
+       27,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
@@ -485,266 +708,268 @@ static yyconst flex_int32_t yy_ec[256] =
         1,    1,    1,    1,    1
     } ;
 
-static yyconst flex_int32_t yy_meta[27] =
+static const YY_CHAR yy_meta[28] =
     {   0,
         1,    2,    3,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
-        1,    1,    1,    1,    1,    1
+        1,    1,    1,    1,    1,    1,    1
     } ;
 
-static yyconst flex_int16_t yy_base[485] =
+static const flex_int16_t yy_base[489] =
     {   0,
-        0,   25,   29,   54,   58,   83,   87,  112,  548,  549,
-      545,  549,    0,  549,  111,  526,  533,  525,  528,  520,
-      110,  531,  104,  523,  107,  120,    0,    0,  537,    0,
-      121,  518,  525,  517,  520,  512,  114,  523,  119,  515,
-      120,  529,    0,  528,    0,  125,  509,  516,  508,  511,
-      503,  126,  514,  123,  506,  125,  520,    0,  519,    0,
-      137,  500,  507,  499,  502,  494,  137,  505,  128,  497,
-      136,  511,  510,    0,  147,  491,  488,  495,  490,  549,
-      549,  487,  484,  485,  484,  491,  493,  486,  477,  153,
-        0,    0,    0,  497,  153,  478,  475,  482,  477,    0,
+        0,   26,   30,   56,   60,   86,   90,  116,  556,  557,
+      553,  557,    0,  557,  115,  534,  541,  533,  536,  528,
+      114,  539,  108,  532,  111,  124,    0,    0,  545,    0,
+      125,  526,  533,  525,  528,  520,  118,  531,  124,  524,
+      121,  537,    0,  536,    0,  130,  517,  524,  516,  519,
+      511,  129,  522,  128,  515,  129,  528,    0,  527,    0,
+      141,  508,  515,  507,  510,  502,  143,  513,  133,  506,
+      136,  519,  518,    0,  153,  499,  496,  503,  498,  557,
+      557,  495,  492,  493,  492,  499,  495,  494,  485,  159,
+        0,    0,    0,  505,  158,  486,  483,  490,  485,    0,
 
-        0,  474,  471,  472,  471,  478,  480,  473,  464,  484,
-        0,  483,  155,  464,  461,  468,  463,    0,    0,  460,
-      457,  458,  457,  464,  466,  459,  450,  470,    0,  469,
-      158,  450,  447,  454,  449,    0,    0,  446,  443,  444,
-      443,  450,  452,  445,  436,  456,  441,  433,  549,  450,
-      549,  438,  445,  444,  549,  549,  435,  439,    0,  433,
-      425,    0,  442,    0,  430,  437,  436,    0,    0,  427,
-      431,  425,  417,    0,  434,    0,  422,  429,  428,    0,
-        0,  419,  423,  417,  409,    0,  426,    0,  414,  421,
-      420,    0,    0,  411,  415,  410,  409,  407,  403,  146,
+        0,  482,  479,  480,  479,  486,  482,  481,  472,  492,
+        0,  491,  160,  472,  469,  476,  471,    0,    0,  468,
+      465,  466,  465,  472,  468,  467,  458,  478,    0,  477,
+      162,  458,  455,  462,  457,    0,    0,  454,  451,  452,
+      451,  458,  454,  453,  444,  464,  449,  441,  557,  458,
+      557,  446,  453,  452,  557,  440,  442,  446,    0,  440,
+      432,    0,  449,    0,  437,  444,  443,    0,  431,  433,
+      437,  431,  423,    0,  440,    0,  428,  435,  434,    0,
+      422,  424,  428,  422,  414,    0,  431,    0,  419,  426,
+      425,    0,  413,  415,  419,  414,  413,  411,  407,  152,
 
-      156,  409,  408,  404,  403,  401,  397,  157,  159,  403,
-      402,  398,  397,  395,  391,  160,  162,  397,  396,  392,
-      391,  389,  385,  163,  165,  391,  390,  391,  382,  387,
-      384,  381,  384,  376,  382,  381,  549,  371,  381,  372,
-      377,  374,  371,  374,  366,  372,  371,    0,  361,  371,
-      362,  367,  364,  361,  364,  356,  362,  361,    0,  351,
-      361,  352,  357,  354,  351,  354,  346,  352,  351,    0,
-      341,  352,  351,  334,  549,  343,  336,  338,  345,  336,
-      332,  343,  342,  325,    0,  334,  327,  329,  336,  327,
-      323,  334,  333,  316,    0,  325,  318,  320,  327,  318,
+      161,  557,  413,  412,  408,  407,  405,  401,  162,  165,
+        0,  407,  406,  402,  401,  399,  395,  163,  167,    0,
+      401,  400,  396,  395,  393,  389,  168,  170,    0,  395,
+      394,  395,  386,  391,  388,  385,  388,  380,  386,  385,
+      557,  375,  385,  376,  381,  378,  375,  378,  370,  376,
+      375,    0,  365,  375,  366,  371,  368,  365,  368,  360,
+      366,  365,    0,  355,  365,  356,  361,  358,  355,  358,
+      350,  356,  355,    0,  345,  356,  355,  338,  557,  347,
+      340,  342,  349,  340,  336,  347,  346,  329,    0,  338,
+      331,  333,  340,  331,  327,  338,  337,  320,    0,  329,
 
-      314,  325,  324,  307,    0,  316,  309,  311,  318,  309,
-      305,  302,  301,  311,  310,  296,  302,  307,  307,  549,
-      294,  293,  303,  302,  288,  294,  299,  299,    0,  286,
-      285,  295,  294,  280,  286,  291,  291,    0,  278,  277,
-      287,  286,  272,  278,  283,  283,    0,  278,  277,  275,
-      272,  277,  276,  272,  274,  270,  269,  267,  264,  269,
-      268,  264,  266,  262,  261,  259,  256,  261,  260,  256,
-      258,  254,  253,  251,  248,  253,  252,  248,  250,  242,
-      241,  549,  236,  237,  247,  231,  234,  235,  234,    0,
-      229,  230,  240,  224,  227,  228,  227,    0,  222,  223,
+      322,  324,  331,  322,  318,  329,  328,  311,    0,  320,
+      313,  315,  322,  313,  309,  306,  305,  315,  314,  300,
+      306,  311,  311,  557,  298,  297,  307,  306,  292,  298,
+      303,  303,    0,  290,  289,  299,  298,  284,  290,  295,
+      295,    0,  282,  281,  291,  290,  276,  282,  287,  287,
+        0,  282,  281,  279,  276,  281,  280,  276,  278,  274,
+      273,  271,  268,  273,  272,  268,  270,  266,  265,  263,
+      260,  265,  264,  260,  262,  258,  257,  255,  252,  257,
+      256,  252,  254,  246,  245,  557,  240,  241,  251,  235,
+      238,  239,  238,    0,  233,  234,  244,  228,  231,  232,
 
-      233,  217,  220,  221,  220,    0,  215,  216,  226,  210,
-      213,  215,  214,  549,  549,  208,  218,  549,  211,  210,
-        0,    0,  204,  214,    0,  207,  206,    0,    0,  200,
-      210,    0,  203,  202,    0,    0,  196,  206,    0,  212,
-      549,  549,  195,  210,    0,    0,  193,  208,    0,    0,
-      191,  206,    0,    0,  189,  194,  549,  193,    0,  192,
-        0,  191,    0,  165,  163,  160,  140,  549,    0,    0,
-        0,  549,  187,  189,   85,  191,  193,   56,  195,  197,
-       27,  199,  201,  203
+      231,    0,  226,  227,  237,  221,  224,  225,  224,    0,
+      219,  220,  230,  214,  217,  219,  218,  557,  557,  212,
+      222,  557,  215,  214,    0,    0,  208,  218,    0,  211,
+      210,    0,    0,  204,  214,    0,  207,  206,    0,    0,
+      200,  210,    0,  216,  557,  557,  199,  214,    0,    0,
+      197,  212,    0,    0,  195,  210,    0,    0,  193,  198,
+      557,  197,    0,  196,    0,  166,    0,  168,  165,  146,
+      142,  557,    0,    0,    0,  557,  192,  194,   88,  196,
+      198,   58,  200,  202,   28,  204,  206,  208
     } ;
 
-static yyconst flex_int16_t yy_def[485] =
+static const flex_int16_t yy_def[489] =
     {   0,
-      472,    1,  472,    3,  472,    5,  472,    7,  472,  472,
-      472,  472,  473,  472,  472,  472,  472,  472,  472,  472,
-      472,  472,  472,  472,  472,  472,  474,  475,  476,  475,
-      475,  475,  475,  475,  475,  475,  475,  475,  475,  475,
-      475,  477,  478,  479,  478,  478,  478,  478,  478,  478,
-      478,  478,  478,  478,  478,  478,  480,  481,  482,  481,
-      481,  481,  481,  481,  481,  481,  481,  481,  481,  481,
-      481,  483,  472,  473,  472,  472,  472,  472,  472,  472,
-      472,  472,  472,  472,  472,  472,  472,  472,  472,  472,
-      484,  474,  475,  476,  475,  475,  475,  475,  475,  475,
+      476,    1,  476,    3,  476,    5,  476,    7,  476,  476,
+      476,  476,  477,  476,  476,  476,  476,  476,  476,  476,
+      476,  476,  476,  476,  476,  476,  478,  479,  480,  479,
+      479,  479,  479,  479,  479,  479,  479,  479,  479,  479,
+      479,  481,  482,  483,  482,  482,  482,  482,  482,  482,
+      482,  482,  482,  482,  482,  482,  484,  485,  486,  485,
+      485,  485,  485,  485,  485,  485,  485,  485,  485,  485,
+      485,  487,  476,  477,  476,  476,  476,  476,  476,  476,
+      476,  476,  476,  476,  476,  476,  476,  476,  476,  476,
+      488,  478,  479,  480,  479,  479,  479,  479,  479,  479,
 
-      475,  475,  475,  475,  475,  475,  475,  475,  475,  477,
-      478,  479,  478,  478,  478,  478,  478,  478,  478,  478,
-      478,  478,  478,  478,  478,  478,  478,  480,  481,  482,
-      481,  481,  481,  481,  481,  481,  481,  481,  481,  481,
-      481,  481,  481,  481,  481,  483,  472,  472,  472,  472,
-      472,  472,  472,  472,  472,  472,  472,  472,  484,  475,
-      475,  475,  475,  475,  475,  475,  475,  475,  475,  475,
-      475,  478,  478,  478,  478,  478,  478,  478,  478,  478,
-      478,  478,  478,  481,  481,  481,  481,  481,  481,  481,
-      481,  481,  481,  481,  481,  472,  472,  472,  472,  472,
+      479,  479,  479,  479,  479,  479,  479,  479,  479,  481,
+      482,  483,  482,  482,  482,  482,  482,  482,  482,  482,
+      482,  482,  482,  482,  482,  482,  482,  484,  485,  486,
+      485,  485,  485,  485,  485,  485,  485,  485,  485,  485,
+      485,  485,  485,  485,  485,  487,  476,  476,  476,  476,
+      476,  476,  476,  476,  476,  476,  476,  476,  488,  479,
+      479,  479,  479,  479,  479,  479,  479,  479,  479,  479,
+      479,  482,  482,  482,  482,  482,  482,  482,  482,  482,
+      482,  482,  482,  485,  485,  485,  485,  485,  485,  485,
+      485,  485,  485,  485,  485,  476,  476,  476,  476,  476,
 
-      472,  472,  472,  475,  475,  475,  475,  475,  475,  475,
-      475,  478,  478,  478,  478,  478,  478,  478,  478,  481,
-      481,  481,  481,  481,  481,  481,  481,  472,  472,  472,
-      472,  472,  472,  472,  472,  472,  472,  472,  475,  475,
-      475,  475,  475,  475,  475,  475,  475,  475,  475,  478,
-      478,  478,  478,  478,  478,  478,  478,  478,  478,  478,
-      481,  481,  481,  481,  481,  481,  481,  481,  481,  481,
-      481,  472,  472,  472,  472,  472,  472,  472,  472,  472,
-      472,  475,  475,  475,  475,  475,  475,  475,  475,  475,
-      475,  478,  478,  478,  478,  478,  478,  478,  478,  478,
+      476,  476,  476,  476,  479,  479,  479,  479,  479,  479,
+      479,  479,  479,  482,  482,  482,  482,  482,  482,  482,
+      482,  482,  485,  485,  485,  485,  485,  485,  485,  485,
+      485,  476,  476,  476,  476,  476,  476,  476,  476,  476,
+      476,  476,  479,  479,  479,  479,  479,  479,  479,  479,
+      479,  479,  479,  482,  482,  482,  482,  482,  482,  482,
+      482,  482,  482,  482,  485,  485,  485,  485,  485,  485,
+      485,  485,  485,  485,  485,  476,  476,  476,  476,  476,
+      476,  476,  476,  476,  476,  479,  479,  479,  479,  479,
+      479,  479,  479,  479,  479,  482,  482,  482,  482,  482,
 
-      478,  481,  481,  481,  481,  481,  481,  481,  481,  481,
-      481,  472,  472,  472,  472,  472,  472,  472,  472,  472,
-      475,  475,  475,  475,  475,  475,  475,  475,  475,  478,
-      478,  478,  478,  478,  478,  478,  478,  478,  481,  481,
-      481,  481,  481,  481,  481,  481,  481,  472,  472,  472,
-      472,  472,  472,  472,  472,  475,  475,  475,  475,  475,
-      475,  475,  475,  478,  478,  478,  478,  478,  478,  478,
-      478,  481,  481,  481,  481,  481,  481,  481,  481,  472,
-      472,  472,  472,  472,  472,  472,  472,  475,  475,  475,
-      475,  475,  475,  475,  475,  478,  478,  478,  478,  478,
+      482,  482,  482,  482,  482,  485,  485,  485,  485,  485,
+      485,  485,  485,  485,  485,  476,  476,  476,  476,  476,
+      476,  476,  476,  476,  479,  479,  479,  479,  479,  479,
+      479,  479,  479,  482,  482,  482,  482,  482,  482,  482,
+      482,  482,  485,  485,  485,  485,  485,  485,  485,  485,
+      485,  476,  476,  476,  476,  476,  476,  476,  476,  479,
+      479,  479,  479,  479,  479,  479,  479,  482,  482,  482,
+      482,  482,  482,  482,  482,  485,  485,  485,  485,  485,
+      485,  485,  485,  476,  476,  476,  476,  476,  476,  476,
+      476,  479,  479,  479,  479,  479,  479,  479,  479,  482,
 
-      478,  478,  478,  481,  481,  481,  481,  481,  481,  481,
-      481,  472,  472,  472,  472,  472,  472,  472,  475,  475,
-      475,  475,  475,  475,  475,  478,  478,  478,  478,  478,
-      478,  478,  481,  481,  481,  481,  481,  481,  481,  472,
-      472,  472,  472,  475,  475,  475,  475,  478,  478,  478,
-      478,  481,  481,  481,  481,  472,  472,  475,  475,  478,
-      478,  481,  481,  472,  475,  478,  481,  472,  475,  478,
-      481,    0,  472,  472,  472,  472,  472,  472,  472,  472,
-      472,  472,  472,  472
+      482,  482,  482,  482,  482,  482,  482,  485,  485,  485,
+      485,  485,  485,  485,  485,  476,  476,  476,  476,  476,
+      476,  476,  479,  479,  479,  479,  479,  479,  479,  482,
+      482,  482,  482,  482,  482,  482,  485,  485,  485,  485,
+      485,  485,  485,  476,  476,  476,  476,  479,  479,  479,
+      479,  482,  482,  482,  482,  485,  485,  485,  485,  476,
+      476,  479,  479,  482,  482,  485,  485,  476,  479,  482,
+      485,  476,  479,  482,  485,    0,  476,  476,  476,  476,
+      476,  476,  476,  476,  476,  476,  476,  476
     } ;
 
-static yyconst flex_int16_t yy_nxt[576] =
+static const flex_int16_t yy_nxt[585] =
     {   0,
        10,   11,   12,   13,   10,   14,   15,   10,   16,   10,
        17,   10,   10,   10,   10,   18,   19,   10,   20,   10,
-       10,   21,   22,   23,   24,   25,   26,  129,   27,   28,
-       11,   12,   29,   28,   30,   31,   28,   32,   28,   33,
-       28,   28,   28,   28,   34,   35,   28,   36,   28,   28,
-       37,   38,   39,   40,   41,   26,  111,   42,   43,   11,
-       12,   44,   43,   45,   46,   43,   47,   43,   48,   43,
-       43,   43,   43,   49,   50,   43,   51,   43,   43,   52,
-       53,   54,   55,   56,   26,   93,   57,   58,   11,   12,
-       59,   58,   60,   61,   58,   62,   58,   63,   58,   58,
+       10,   21,   22,   23,   10,   24,   25,   26,  129,   27,
+       28,   11,   12,   29,   28,   30,   31,   28,   32,   28,
+       33,   28,   28,   28,   28,   34,   35,   28,   36,   28,
+       28,   37,   38,   39,   28,   40,   41,   26,  111,   42,
+       43,   11,   12,   44,   43,   45,   46,   43,   47,   43,
+       48,   43,   43,   43,   43,   49,   50,   43,   51,   43,
+       43,   52,   53,   54,   43,   55,   56,   26,   93,   57,
+       58,   11,   12,   59,   58,   60,   61,   58,   62,   58,
 
-       58,   58,   64,   65,   58,   66,   58,   58,   67,   68,
-       69,   70,   71,   26,   85,   72,   75,   75,   81,   88,
-       82,   90,  101,   91,  102,   86,   95,   95,   89,  105,
-      113,  113,  108,  123,  119,   83,  120,  126,  141,  103,
-      106,  109,  131,  131,  124,  137,  127,  138,  144,  142,
-      471,  121,   75,   75,   90,  232,   91,  145,   95,   95,
-      113,  113,  139,  131,  131,  234,  243,  233,  245,  254,
-      470,  256,  265,  469,  267,  468,  235,  236,  244,  246,
-      247,  255,  257,  258,  266,  268,  269,   74,   74,   92,
-       92,   94,   94,  110,  110,  112,  112,  128,  128,  130,
+       63,   58,   58,   58,   58,   64,   65,   58,   66,   58,
+       58,   67,   68,   69,   58,   70,   71,   26,   85,   72,
+       75,   75,   81,   88,   82,   90,  101,   91,  102,   86,
+       95,   95,   89,  108,  105,  113,  113,  119,  123,  120,
+       83,  126,  109,  141,  103,  106,  131,  131,  144,  124,
+      127,  137,  475,  138,  142,  121,  474,  145,   75,   75,
+       90,  236,   91,   95,   95,  113,  113,  131,  131,  139,
+      238,  247,  258,  237,  249,  473,  260,  269,  472,  271,
+      471,  239,  240,  248,  259,  250,  251,  261,  262,  270,
+      272,  273,   74,   74,   92,   92,   94,   94,  110,  110,
 
-      130,  146,  146,  159,  159,  467,  466,  465,  464,  463,
-      462,  461,  460,  459,  458,  457,  456,  455,  454,  453,
-      452,  451,  450,  449,  448,  447,  446,  445,  444,  443,
-      442,  441,  440,  439,  438,  437,  436,  435,  434,  433,
-      432,  431,  430,  429,  428,  427,  426,  425,  424,  423,
-      422,  421,  420,  419,  418,  417,  416,  415,  414,  413,
-      412,  411,  410,  409,  408,  407,  406,  405,  404,  403,
-      402,  401,  400,  399,  398,  397,  396,  395,  394,  393,
-      392,  391,  390,  389,  388,  387,  386,  385,  384,  383,
-      382,  381,  380,  379,  378,  377,  376,  375,  374,  373,
+      112,  112,  128,  128,  130,  130,  146,  146,  159,  159,
+      470,  469,  468,  467,  466,  465,  464,  463,  462,  461,
+      460,  459,  458,  457,  456,  455,  454,  453,  452,  451,
+      450,  449,  448,  447,  446,  445,  444,  443,  442,  441,
+      440,  439,  438,  437,  436,  435,  434,  433,  432,  431,
+      430,  429,  428,  427,  426,  425,  424,  423,  422,  421,
+      420,  419,  418,  417,  416,  415,  414,  413,  412,  411,
+      410,  409,  408,  407,  406,  405,  404,  403,  402,  401,
+      400,  399,  398,  397,  396,  395,  394,  393,  392,  391,
+      390,  389,  388,  387,  386,  385,  384,  383,  382,  381,
 
-      372,  371,  370,  369,  368,  367,  366,  365,  364,  363,
-      362,  361,  360,  359,  358,  357,  356,  355,  354,  353,
-      352,  351,  350,  349,  348,  347,  346,  345,  344,  343,
-      342,  341,  340,  339,  338,  337,  336,  335,  334,  333,
-      332,  331,  330,  329,  328,  327,  326,  325,  324,  323,
-      322,  321,  320,  319,  318,  317,  316,  315,  314,  313,
-      312,  311,  310,  309,  308,  307,  306,  305,  304,  303,
-      302,  301,  300,  299,  298,  297,  296,  295,  294,  293,
-      292,  291,  290,  289,  288,  287,  286,  285,  284,  283,
-      282,  281,  280,  279,  278,  277,  276,  275,  274,  273,
-
-      272,  271,  270,  264,  263,  262,  261,  260,  259,  253,
-      252,  251,  250,  249,  248,  242,  241,  240,  239,  238,
-      237,  231,  230,  229,  228,  227,  226,  225,  224,  223,
-      222,  221,  220,  219,  218,  217,  216,  215,  214,  213,
-      212,  211,  210,  209,  208,  207,  206,  205,  204,  203,
-      202,  201,  200,  199,  198,  197,  196,   92,  195,  194,
-      193,  192,  191,  190,  189,  188,  187,  186,  185,  184,
-       74,   92,  183,  182,  181,  180,  179,  178,  177,  176,
-      175,  174,  173,  172,   74,   92,  171,  170,  169,  168,
-      167,  166,  165,  164,  163,  162,  161,  160,   74,  158,
-
-      157,  156,  155,  154,  153,  152,  151,  150,  149,  148,
-      147,   73,   92,  143,  140,  136,  135,  134,  133,  132,
-       74,   92,  125,  122,  118,  117,  116,  115,  114,   74,
-       92,  107,  104,  100,   99,   98,   97,   96,   74,   87,
-       84,   80,   79,   78,   77,   76,   73,  472,    9,  472,
-      472,  472,  472,  472,  472,  472,  472,  472,  472,  472,
-      472,  472,  472,  472,  472,  472,  472,  472,  472,  472,
-      472,  472,  472,  472,  472
-    } ;
-
-static yyconst flex_int16_t yy_chk[576] =
-    {   0,
-        1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
-        1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
-        1,    1,    1,    1,    1,    1,    2,  481,    2,    3,
-        3,    3,    3,    3,    3,    3,    3,    3,    3,    3,
-        3,    3,    3,    3,    3,    3,    3,    3,    3,    3,
-        3,    3,    3,    3,    3,    4,  478,    4,    5,    5,
-        5,    5,    5,    5,    5,    5,    5,    5,    5,    5,
-        5,    5,    5,    5,    5,    5,    5,    5,    5,    5,
-        5,    5,    5,    5,    6,  475,    6,    7,    7,    7,
-        7,    7,    7,    7,    7,    7,    7,    7,    7,    7,
-
-        7,    7,    7,    7,    7,    7,    7,    7,    7,    7,
-        7,    7,    7,    8,   23,    8,   15,   15,   21,   25,
-       21,   26,   37,   26,   37,   23,   31,   31,   25,   39,
-       46,   46,   41,   54,   52,   21,   52,   56,   69,   37,
-       39,   41,   61,   61,   54,   67,   56,   67,   71,   69,
-      467,   52,   75,   75,   90,  200,   90,   71,   95,   95,
-      113,  113,   67,  131,  131,  201,  208,  200,  209,  216,
-      466,  217,  224,  465,  225,  464,  201,  201,  208,  209,
-      209,  216,  217,  217,  224,  225,  225,  473,  473,  474,
-      474,  476,  476,  477,  477,  479,  479,  480,  480,  482,
-
-      482,  483,  483,  484,  484,  462,  460,  458,  456,  455,
-      452,  451,  448,  447,  444,  443,  440,  438,  437,  434,
-      433,  431,  430,  427,  426,  424,  423,  420,  419,  417,
-      416,  413,  412,  411,  410,  409,  408,  407,  405,  404,
-      403,  402,  401,  400,  399,  397,  396,  395,  394,  393,
-      392,  391,  389,  388,  387,  386,  385,  384,  383,  381,
       380,  379,  378,  377,  376,  375,  374,  373,  372,  371,
       370,  369,  368,  367,  366,  365,  364,  363,  362,  361,
       360,  359,  358,  357,  356,  355,  354,  353,  352,  351,
-      350,  349,  348,  346,  345,  344,  343,  342,  341,  340,
+      350,  349,  348,  347,  346,  345,  344,  343,  342,  341,
+      340,  339,  338,  337,  336,  335,  334,  333,  332,  331,
+      330,  329,  328,  327,  326,  325,  324,  323,  322,  321,
+      320,  319,  318,  317,  316,  315,  314,  313,  312,  311,
+      310,  309,  308,  307,  306,  305,  304,  303,  302,  301,
+      300,  299,  298,  297,  296,  295,  294,  293,  292,  291,
+      290,  289,  288,  287,  286,  285,  284,  283,  282,  281,
 
-      339,  337,  336,  335,  334,  333,  332,  331,  330,  328,
-      327,  326,  325,  324,  323,  322,  321,  319,  318,  317,
-      316,  315,  314,  313,  312,  311,  310,  309,  308,  307,
-      306,  304,  303,  302,  301,  300,  299,  298,  297,  296,
-      294,  293,  292,  291,  290,  289,  288,  287,  286,  284,
-      283,  282,  281,  280,  279,  278,  277,  276,  274,  273,
-      272,  271,  269,  268,  267,  266,  265,  264,  263,  262,
-      261,  260,  258,  257,  256,  255,  254,  253,  252,  251,
-      250,  249,  247,  246,  245,  244,  243,  242,  241,  240,
-      239,  238,  236,  235,  234,  233,  232,  231,  230,  229,
+      280,  279,  278,  277,  276,  275,  274,  268,  267,  266,
+      265,  264,  263,  257,  256,  255,  254,  253,  252,  246,
+      245,  244,  243,  242,  241,  235,  234,  233,  232,  231,
+      230,  229,  228,  227,  226,  225,  224,  223,  222,  221,
+      220,  219,  218,  217,  216,  215,  214,  213,  212,  211,
+      210,  209,  208,  207,  206,  205,  204,  203,  202,  201,
+      200,  199,  198,  197,  196,   92,  195,  194,  193,  192,
+      191,  190,  189,  188,  187,  186,  185,  184,   74,   92,
+      183,  182,  181,  180,  179,  178,  177,  176,  175,  174,
+      173,  172,   74,   92,  171,  170,  169,  168,  167,  166,
 
-      228,  227,  226,  223,  222,  221,  220,  219,  218,  215,
-      214,  213,  212,  211,  210,  207,  206,  205,  204,  203,
-      202,  199,  198,  197,  196,  195,  194,  191,  190,  189,
-      187,  185,  184,  183,  182,  179,  178,  177,  175,  173,
-      172,  171,  170,  167,  166,  165,  163,  161,  160,  158,
-      157,  154,  153,  152,  150,  148,  147,  146,  145,  144,
-      143,  142,  141,  140,  139,  138,  135,  134,  133,  132,
-      130,  128,  127,  126,  125,  124,  123,  122,  121,  120,
-      117,  116,  115,  114,  112,  110,  109,  108,  107,  106,
-      105,  104,  103,  102,   99,   98,   97,   96,   94,   89,
+      165,  164,  163,  162,  161,  160,   74,  158,  157,  156,
+      155,  154,  153,  152,  151,  150,  149,  148,  147,   73,
+       92,  143,  140,  136,  135,  134,  133,  132,   74,   92,
+      125,  122,  118,  117,  116,  115,  114,   74,   92,  107,
+      104,  100,   99,   98,   97,   96,   74,   87,   84,   80,
+       79,   78,   77,   76,   73,  476,    9,  476,  476,  476,
+      476,  476,  476,  476,  476,  476,  476,  476,  476,  476,
+      476,  476,  476,  476,  476,  476,  476,  476,  476,  476,
+      476,  476,  476,  476
+    } ;
 
-       88,   87,   86,   85,   84,   83,   82,   79,   78,   77,
-       76,   73,   72,   70,   68,   66,   65,   64,   63,   62,
-       59,   57,   55,   53,   51,   50,   49,   48,   47,   44,
-       42,   40,   38,   36,   35,   34,   33,   32,   29,   24,
-       22,   20,   19,   18,   17,   16,   11,    9,  472,  472,
-      472,  472,  472,  472,  472,  472,  472,  472,  472,  472,
-      472,  472,  472,  472,  472,  472,  472,  472,  472,  472,
-      472,  472,  472,  472,  472
+static const flex_int16_t yy_chk[585] =
+    {   0,
+        1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
+        1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
+        1,    1,    1,    1,    1,    1,    1,    2,  485,    2,
+        3,    3,    3,    3,    3,    3,    3,    3,    3,    3,
+        3,    3,    3,    3,    3,    3,    3,    3,    3,    3,
+        3,    3,    3,    3,    3,    3,    3,    4,  482,    4,
+        5,    5,    5,    5,    5,    5,    5,    5,    5,    5,
+        5,    5,    5,    5,    5,    5,    5,    5,    5,    5,
+        5,    5,    5,    5,    5,    5,    5,    6,  479,    6,
+        7,    7,    7,    7,    7,    7,    7,    7,    7,    7,
+
+        7,    7,    7,    7,    7,    7,    7,    7,    7,    7,
+        7,    7,    7,    7,    7,    7,    7,    8,   23,    8,
+       15,   15,   21,   25,   21,   26,   37,   26,   37,   23,
+       31,   31,   25,   41,   39,   46,   46,   52,   54,   52,
+       21,   56,   41,   69,   37,   39,   61,   61,   71,   54,
+       56,   67,  471,   67,   69,   52,  470,   71,   75,   75,
+       90,  200,   90,   95,   95,  113,  113,  131,  131,   67,
+      201,  209,  218,  200,  210,  469,  219,  227,  468,  228,
+      466,  201,  201,  209,  218,  210,  210,  219,  219,  227,
+      228,  228,  477,  477,  478,  478,  480,  480,  481,  481,
+
+      483,  483,  484,  484,  486,  486,  487,  487,  488,  488,
+      464,  462,  460,  459,  456,  455,  452,  451,  448,  447,
+      444,  442,  441,  438,  437,  435,  434,  431,  430,  428,
+      427,  424,  423,  421,  420,  417,  416,  415,  414,  413,
+      412,  411,  409,  408,  407,  406,  405,  404,  403,  401,
+      400,  399,  398,  397,  396,  395,  393,  392,  391,  390,
+      389,  388,  387,  385,  384,  383,  382,  381,  380,  379,
+      378,  377,  376,  375,  374,  373,  372,  371,  370,  369,
+      368,  367,  366,  365,  364,  363,  362,  361,  360,  359,
+      358,  357,  356,  355,  354,  353,  352,  350,  349,  348,
+
+      347,  346,  345,  344,  343,  341,  340,  339,  338,  337,
+      336,  335,  334,  332,  331,  330,  329,  328,  327,  326,
+      325,  323,  322,  321,  320,  319,  318,  317,  316,  315,
+      314,  313,  312,  311,  310,  308,  307,  306,  305,  304,
+      303,  302,  301,  300,  298,  297,  296,  295,  294,  293,
+      292,  291,  290,  288,  287,  286,  285,  284,  283,  282,
+      281,  280,  278,  277,  276,  275,  273,  272,  271,  270,
+      269,  268,  267,  266,  265,  264,  262,  261,  260,  259,
+      258,  257,  256,  255,  254,  253,  251,  250,  249,  248,
+      247,  246,  245,  244,  243,  242,  240,  239,  238,  237,
+
+      236,  235,  234,  233,  232,  231,  230,  226,  225,  224,
+      223,  222,  221,  217,  216,  215,  214,  213,  212,  208,
+      207,  206,  205,  204,  203,  199,  198,  197,  196,  195,
+      194,  193,  191,  190,  189,  187,  185,  184,  183,  182,
+      181,  179,  178,  177,  175,  173,  172,  171,  170,  169,
+      167,  166,  165,  163,  161,  160,  158,  157,  156,  154,
+      153,  152,  150,  148,  147,  146,  145,  144,  143,  142,
+      141,  140,  139,  138,  135,  134,  133,  132,  130,  128,
+      127,  126,  125,  124,  123,  122,  121,  120,  117,  116,
+      115,  114,  112,  110,  109,  108,  107,  106,  105,  104,
+
+      103,  102,   99,   98,   97,   96,   94,   89,   88,   87,
+       86,   85,   84,   83,   82,   79,   78,   77,   76,   73,
+       72,   70,   68,   66,   65,   64,   63,   62,   59,   57,
+       55,   53,   51,   50,   49,   48,   47,   44,   42,   40,
+       38,   36,   35,   34,   33,   32,   29,   24,   22,   20,
+       19,   18,   17,   16,   11,    9,  476,  476,  476,  476,
+      476,  476,  476,  476,  476,  476,  476,  476,  476,  476,
+      476,  476,  476,  476,  476,  476,  476,  476,  476,  476,
+      476,  476,  476,  476
     } ;
 
 static yy_state_type yy_last_accepting_state;
 static char *yy_last_accepting_cpos;
 
-extern int libxlio_yy_flex_debug;
-int libxlio_yy_flex_debug = 0;
+extern int yy_flex_debug;
+int yy_flex_debug = 0;
 
 /* The intent behind this definition is that it'll catch
  * any uses of REJECT which flex missed.
@@ -753,35 +978,36 @@ int libxlio_yy_flex_debug = 0;
 #define yymore() yymore_used_but_not_detected
 #define YY_MORE_ADJ 0
 #define YY_RESTORE_YY_MORE_OFFSET
-char *libxlio_yytext;
-/* Line 1 of config_scanner.l */
+char *yytext;
+#line 1 "src/core/util/config_scanner.l"
 /*
  * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
- * Copyright (c) 2021-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: GPL-2.0-only or BSD-2-Clause
  * $Id: ibnl_scanner.ll,v 1.4 2005/02/23 21:08:37 eitan Exp $
  */
-/* Line 36 of config_scanner.l */
+#line 9 "src/core/util/config_scanner.l"
 
 //#define DEBUG 1  
 
 #define yyparse libxlio_yyparse
-#define libxlio_yylex   libxlio_yylex
+#define yylex   libxlio_yylex
 #define yyerror libxlio_yyerror
 #define yylval  libxlio_yylval
 #define yychar  libxlio_yychar
 #define yydebug libxlio_yydebug
 #define yynerrs libxlio_yynerrs
 
-#define libxlio_yywrap  libxlio_yywrap
+#define yywrap  libxlio_yywrap
 
 #include <string.h>
 #include <stdio.h>
 #include "config_parser.h"
 extern long __xlio_config_line_num;
+#line 1008 "third_party/legacy_config_parser/config_scanner.c"
 #define YY_NO_INPUT 1
 
-/* Line 812 of config_scanner.c */
+#line 1011 "third_party/legacy_config_parser/config_scanner.c"
 
 #define INITIAL 0
 #define CANNAME 1
@@ -800,36 +1026,36 @@ extern long __xlio_config_line_num;
 #define YY_EXTRA_TYPE void *
 #endif
 
-static int yy_init_globals (void );
+static int yy_init_globals ( void );
 
 /* Accessor methods to globals.
    These are made visible to non-reentrant scanners for convenience. */
 
-int libxlio_yylex_destroy (void );
+int yylex_destroy ( void );
 
-int libxlio_yyget_debug (void );
+int yyget_debug ( void );
 
-void libxlio_yyset_debug (int debug_flag  );
+void yyset_debug ( int debug_flag  );
 
-YY_EXTRA_TYPE libxlio_yyget_extra (void );
+YY_EXTRA_TYPE yyget_extra ( void );
 
-void libxlio_yyset_extra (YY_EXTRA_TYPE user_defined  );
+void yyset_extra ( YY_EXTRA_TYPE user_defined  );
 
-FILE *libxlio_yyget_in (void );
+FILE *yyget_in ( void );
 
-void libxlio_yyset_in  (FILE * in_str  );
+void yyset_in  ( FILE * _in_str  );
 
-FILE *libxlio_yyget_out (void );
+FILE *yyget_out ( void );
 
-void libxlio_yyset_out  (FILE * out_str  );
+void yyset_out  ( FILE * _out_str  );
 
-yy_size_t libxlio_yyget_leng (void );
+			int yyget_leng ( void );
 
-char *libxlio_yyget_text (void );
+char *yyget_text ( void );
 
-int libxlio_yyget_lineno (void );
+int yyget_lineno ( void );
 
-void libxlio_yyset_lineno (int line_number  );
+void yyset_lineno ( int _line_number  );
 
 /* Macros after this point can all be overridden by user definitions in
  * section 1.
@@ -837,26 +1063,29 @@ void libxlio_yyset_lineno (int line_number  );
 
 #ifndef YY_SKIP_YYWRAP
 #ifdef __cplusplus
-extern "C" int libxlio_yywrap (void );
+extern "C" int yywrap ( void );
 #else
-extern int libxlio_yywrap (void );
+extern int yywrap ( void );
 #endif
+#endif
+
+#ifndef YY_NO_UNPUT
+    
 #endif
 
 #ifndef yytext_ptr
-static void yy_flex_strncpy (char *,yyconst char *,int );
+static void yy_flex_strncpy ( char *, const char *, int );
 #endif
 
 #ifdef YY_NEED_STRLEN
-static int yy_flex_strlen (yyconst char * );
+static int yy_flex_strlen ( const char * );
 #endif
 
 #ifndef YY_NO_INPUT
-
 #ifdef __cplusplus
-static int yyinput (void );
+static int yyinput ( void );
 #else
-static int input (void );
+static int input ( void );
 #endif
 
 #endif
@@ -876,7 +1105,7 @@ static int input (void );
 /* This used to be an fputs(), but since the string might contain NUL's,
  * we now use fwrite().
  */
-#define ECHO do { if (fwrite( libxlio_yytext, libxlio_yyleng, 1, libxlio_yyout )) {} } while (0)
+#define ECHO do { if (fwrite( yytext, (size_t) yyleng, 1, yyout )) {} } while (0)
 #endif
 
 /* Gets input and stuffs it into "buf".  number of characters read, or YY_NULL,
@@ -887,20 +1116,20 @@ static int input (void );
 	if ( YY_CURRENT_BUFFER_LVALUE->yy_is_interactive ) \
 		{ \
 		int c = '*'; \
-		size_t n; \
+		int n; \
 		for ( n = 0; n < max_size && \
-			     (c = getc( libxlio_yyin )) != EOF && c != '\n'; ++n ) \
+			     (c = getc( yyin )) != EOF && c != '\n'; ++n ) \
 			buf[n] = (char) c; \
 		if ( c == '\n' ) \
 			buf[n++] = (char) c; \
-		if ( c == EOF && ferror( libxlio_yyin ) ) \
+		if ( c == EOF && ferror( yyin ) ) \
 			YY_FATAL_ERROR( "input in flex scanner failed" ); \
 		result = n; \
 		} \
 	else \
 		{ \
 		errno=0; \
-		while ( (result = fread(buf, 1, max_size, libxlio_yyin))==0 && ferror(libxlio_yyin)) \
+		while ( (result = (int) fread(buf, 1, (yy_size_t) max_size, yyin)) == 0 && ferror(yyin)) \
 			{ \
 			if( errno != EINTR) \
 				{ \
@@ -908,7 +1137,7 @@ static int input (void );
 				break; \
 				} \
 			errno=0; \
-			clearerr(libxlio_yyin); \
+			clearerr(yyin); \
 			} \
 		}\
 \
@@ -941,12 +1170,12 @@ static int input (void );
 #ifndef YY_DECL
 #define YY_DECL_IS_OURS 1
 
-extern int libxlio_yylex (void);
+extern int yylex (void);
 
-#define YY_DECL int libxlio_yylex (void)
+#define YY_DECL int yylex (void)
 #endif /* !YY_DECL */
 
-/* Code executed at the beginning of each rule, after libxlio_yytext and libxlio_yyleng
+/* Code executed at the beginning of each rule, after yytext and yyleng
  * have been set up.
  */
 #ifndef YY_USER_ACTION
@@ -955,22 +1184,22 @@ extern int libxlio_yylex (void);
 
 /* Code executed at the end of each rule. */
 #ifndef YY_BREAK
-#define YY_BREAK break;
+#define YY_BREAK /*LINTED*/break;
 #endif
 
 #define YY_RULE_SETUP \
-	if ( libxlio_yyleng > 0 ) \
+	if ( yyleng > 0 ) \
 		YY_CURRENT_BUFFER_LVALUE->yy_at_bol = \
-				(libxlio_yytext[libxlio_yyleng - 1] == '\n'); \
+				(yytext[yyleng - 1] == '\n'); \
 	YY_USER_ACTION
 
 /** The main scanner function which does all the work.
  */
 YY_DECL
 {
-	register yy_state_type yy_current_state;
-	register char *yy_cp, *yy_bp;
-	register int yy_act;
+	yy_state_type yy_current_state;
+	char *yy_cp, *yy_bp;
+	int yy_act;
     
 	if ( !(yy_init) )
 		{
@@ -983,34 +1212,32 @@ YY_DECL
 		if ( ! (yy_start) )
 			(yy_start) = 1;	/* first start state */
 
-		if ( ! libxlio_yyin )
-			libxlio_yyin = stdin;
+		if ( ! yyin )
+			yyin = stdin;
 
-		if ( ! libxlio_yyout )
-			libxlio_yyout = stdout;
+		if ( ! yyout )
+			yyout = stdout;
 
 		if ( ! YY_CURRENT_BUFFER ) {
-			libxlio_yyensure_buffer_stack ();
-			//coverity[var_deref_op:FALSE] /* Turn off coverity check for null deref*/
+			yyensure_buffer_stack ();
 			YY_CURRENT_BUFFER_LVALUE =
-					libxlio_yy_create_buffer(libxlio_yyin,YY_BUF_SIZE );
-
+				yy_create_buffer( yyin, YY_BUF_SIZE );
 		}
 
-		libxlio_yy_load_buffer_state( );
+		yy_load_buffer_state(  );
 		}
 
 	{
-/* Line 57 of config_scanner.l */
+#line 30 "src/core/util/config_scanner.l"
 
 
-/* Line 1033 of config_scanner.c */
+#line 1235 "third_party/legacy_config_parser/config_scanner.c"
 
-	while ( 1 )		/* loops until end-of-file is reached */
+	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
 		yy_cp = (yy_c_buf_p);
 
-		/* Support of libxlio_yytext. */
+		/* Support of yytext. */
 		*yy_cp = (yy_hold_char);
 
 		/* yy_bp points to the position in yy_ch_buf of the start of
@@ -1018,13 +1245,12 @@ YY_DECL
 		 */
 		yy_bp = yy_cp;
 
-		/* coverity[var_deref_op] */
 		yy_current_state = (yy_start);
 		yy_current_state += YY_AT_BOL();
 yy_match:
 		do
 			{
-			register YY_CHAR yy_c = yy_ec[YY_SC_TO_UI(*yy_cp)] ;
+			YY_CHAR yy_c = yy_ec[YY_SC_TO_UI(*yy_cp)] ;
 			if ( yy_accept[yy_current_state] )
 				{
 				(yy_last_accepting_state) = yy_current_state;
@@ -1033,13 +1259,13 @@ yy_match:
 			while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
 				{
 				yy_current_state = (int) yy_def[yy_current_state];
-				if ( yy_current_state >= 473 )
-					yy_c = yy_meta[(unsigned int) yy_c];
+				if ( yy_current_state >= 477 )
+					yy_c = yy_meta[yy_c];
 				}
-			yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
+			yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 			++yy_cp;
 			}
-		while ( yy_base[yy_current_state] != 549 );
+		while ( yy_base[yy_current_state] != 557 );
 
 yy_find_action:
 		yy_act = yy_accept[yy_current_state];
@@ -1065,12 +1291,12 @@ do_action:	/* This label is used only to access EOF actions. */
 
 case 1:
 YY_RULE_SETUP
-/* Line 59 of config_scanner.l */
+#line 32 "src/core/util/config_scanner.l"
 {}
 	YY_BREAK
 case 2:
 YY_RULE_SETUP
-/* Line 61 of config_scanner.l */
+#line 34 "src/core/util/config_scanner.l"
 {
 	yylval.ival = APP_ID;
 #ifdef DEBUG 
@@ -1082,10 +1308,10 @@ YY_RULE_SETUP
 	YY_BREAK
 case 3:
 YY_RULE_SETUP
-/* Line 70 of config_scanner.l */
+#line 43 "src/core/util/config_scanner.l"
 {
-	yylval.sval = (char *)malloc(strlen(libxlio_yytext) + 1);
-	strcpy(yylval.sval, libxlio_yytext);
+	yylval.sval = (char *)malloc(strlen(yytext) + 1);
+	strcpy(yylval.sval, yytext);
 #ifdef DEBUG
 	printf("PROGRAM:%s\n",yylval.sval);
 #endif
@@ -1095,10 +1321,10 @@ YY_RULE_SETUP
 	YY_BREAK
 case 4:
 YY_RULE_SETUP
-/* Line 80 of config_scanner.l */
+#line 53 "src/core/util/config_scanner.l"
 {
-	yylval.sval = (char *)malloc(strlen(libxlio_yytext) + 1);
-	strcpy(yylval.sval, libxlio_yytext);
+	yylval.sval = (char *)malloc(strlen(yytext) + 1);
+	strcpy(yylval.sval, yytext);
 #ifdef DEBUG
 	printf("USER_DEFINED_ID_STR:%s\n",yylval.sval);
 #endif
@@ -1108,9 +1334,9 @@ YY_RULE_SETUP
 	YY_BREAK
 case 5:
 YY_RULE_SETUP
-/* Line 90 of config_scanner.l */
+#line 63 "src/core/util/config_scanner.l"
 { 
-	yylval.ival = atoi(libxlio_yytext);
+	yylval.ival = atoi(yytext);
 #ifdef DEBUG
 	printf("INT:%d\n",yylval.ival);
 #endif
@@ -1119,7 +1345,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 6:
 YY_RULE_SETUP
-/* Line 98 of config_scanner.l */
+#line 71 "src/core/util/config_scanner.l"
 {
 	yylval.ival = LOG;
 #ifdef DEBUG
@@ -1130,7 +1356,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 7:
 YY_RULE_SETUP
-/* Line 106 of config_scanner.l */
+#line 79 "src/core/util/config_scanner.l"
 {
 	yylval.ival = DEST;
 #ifdef DEBUG
@@ -1141,7 +1367,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 8:
 YY_RULE_SETUP
-/* Line 114 of config_scanner.l */
+#line 87 "src/core/util/config_scanner.l"
 {
 	yylval.ival = LEVEL;
 #ifdef DEBUG
@@ -1152,7 +1378,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 9:
 YY_RULE_SETUP
-/* Line 122 of config_scanner.l */
+#line 95 "src/core/util/config_scanner.l"
 {
 	yylval.ival = STDERR;
 #ifdef DEBUG
@@ -1163,7 +1389,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 10:
 YY_RULE_SETUP
-/* Line 130 of config_scanner.l */
+#line 103 "src/core/util/config_scanner.l"
 {
 	yylval.ival = SYSLOG;
 #ifdef DEBUG
@@ -1174,7 +1400,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 11:
 YY_RULE_SETUP
-/* Line 138 of config_scanner.l */
+#line 111 "src/core/util/config_scanner.l"
 {
 	yylval.ival = FILENAME;
 #ifdef DEBUG
@@ -1186,7 +1412,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 12:
 YY_RULE_SETUP
-/* Line 149 of config_scanner.l */
+#line 122 "src/core/util/config_scanner.l"
 {
 	yylval.ival = USE;
 #ifdef DEBUG
@@ -1197,7 +1423,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 13:
 YY_RULE_SETUP
-/* Line 157 of config_scanner.l */
+#line 130 "src/core/util/config_scanner.l"
 {
 	yylval.ival = TCP;
 #ifdef DEBUG
@@ -1208,7 +1434,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 14:
 YY_RULE_SETUP
-/* Line 165 of config_scanner.l */
+#line 138 "src/core/util/config_scanner.l"
 {
 	yylval.ival = UDP;
 #ifdef DEBUG
@@ -1219,7 +1445,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 15:
 YY_RULE_SETUP
-/* Line 173 of config_scanner.l */
+#line 146 "src/core/util/config_scanner.l"
 {
 	yylval.ival = OS;
 #ifdef DEBUG
@@ -1230,7 +1456,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 16:
 YY_RULE_SETUP
-/* Line 181 of config_scanner.l */
+#line 154 "src/core/util/config_scanner.l"
 {
 	yylval.ival = XLIO;
 #ifdef DEBUG
@@ -1241,7 +1467,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 17:
 YY_RULE_SETUP
-/* Line 189 of config_scanner.l */
+#line 162 "src/core/util/config_scanner.l"
 {
 	yylval.ival = SDP;
 #ifdef DEBUG
@@ -1252,7 +1478,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 18:
 YY_RULE_SETUP
-/* Line 197 of config_scanner.l */
+#line 170 "src/core/util/config_scanner.l"
 {
 	yylval.ival = SA;
 #ifdef DEBUG
@@ -1263,7 +1489,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 19:
 YY_RULE_SETUP
-/* Line 205 of config_scanner.l */
+#line 178 "src/core/util/config_scanner.l"
 {
 	yylval.ival = TCP_CLIENT;
 #ifdef DEBUG
@@ -1274,7 +1500,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 20:
 YY_RULE_SETUP
-/* Line 213 of config_scanner.l */
+#line 186 "src/core/util/config_scanner.l"
 {
 	yylval.ival = TCP_SERVER;
 #ifdef DEBUG
@@ -1285,7 +1511,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 21:
 YY_RULE_SETUP
-/* Line 221 of config_scanner.l */
+#line 194 "src/core/util/config_scanner.l"
 {
 	yylval.ival = UDP_SENDER;
 #ifdef DEBUG
@@ -1296,7 +1522,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 22:
 YY_RULE_SETUP
-/* Line 229 of config_scanner.l */
+#line 202 "src/core/util/config_scanner.l"
 {
 	yylval.ival = UDP_RECEIVER;
 #ifdef DEBUG
@@ -1307,7 +1533,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 23:
 YY_RULE_SETUP
-/* Line 237 of config_scanner.l */
+#line 210 "src/core/util/config_scanner.l"
 {
 	yylval.ival = UDP_CONNECT;
 #ifdef DEBUG
@@ -1318,10 +1544,10 @@ YY_RULE_SETUP
 	YY_BREAK
 case 24:
 YY_RULE_SETUP
-/* Line 245 of config_scanner.l */
+#line 218 "src/core/util/config_scanner.l"
 {
-	yylval.sval = (char *)malloc(strlen(libxlio_yytext) + 1);
-	strcpy(yylval.sval, libxlio_yytext);
+	yylval.sval = (char *)malloc(strlen(yytext) + 1);
+	strcpy(yylval.sval, yytext);
 #ifdef DEBUG
 	printf("NAME:%s\n",yylval.sval);
 #endif
@@ -1332,7 +1558,7 @@ YY_RULE_SETUP
 case 25:
 /* rule 25 can match eol */
 YY_RULE_SETUP
-/* Line 255 of config_scanner.l */
+#line 228 "src/core/util/config_scanner.l"
 {
 	__xlio_config_line_num++;
 #ifdef DEBUG
@@ -1344,32 +1570,32 @@ YY_RULE_SETUP
 	YY_BREAK
 case 26:
 YY_RULE_SETUP
-/* Line 264 of config_scanner.l */
+#line 237 "src/core/util/config_scanner.l"
 {
  	__xlio_config_line_num++;
 }
 	YY_BREAK
 case 27:
 YY_RULE_SETUP
-/* Line 268 of config_scanner.l */
+#line 241 "src/core/util/config_scanner.l"
 {}
 	YY_BREAK
 case 28:
 YY_RULE_SETUP
-/* Line 270 of config_scanner.l */
+#line 243 "src/core/util/config_scanner.l"
 {
 #ifdef DEBUG
-	printf("CHAR:%c\n",libxlio_yytext[0]);
+	printf("CHAR:%c\n",yytext[0]);
 #endif
-	return(libxlio_yytext[0]);
+	return(yytext[0]);
 }
 	YY_BREAK
 case 29:
 YY_RULE_SETUP
-/* Line 277 of config_scanner.l */
+#line 250 "src/core/util/config_scanner.l"
 ECHO;
 	YY_BREAK
-/* Line 1397 of config_scanner.c */
+#line 1599 "third_party/legacy_config_parser/config_scanner.c"
 case YY_STATE_EOF(INITIAL):
 case YY_STATE_EOF(CANNAME):
 case YY_STATE_EOF(APP_ID_S1):
@@ -1389,15 +1615,15 @@ case YY_STATE_EOF(APP_ID_S2):
 			{
 			/* We're scanning a new file or input source.  It's
 			 * possible that this happened because the user
-			 * just pointed libxlio_yyin at a new source and called
-			 * libxlio_yylex().  If so, then we have to assure
+			 * just pointed yyin at a new source and called
+			 * yylex().  If so, then we have to assure
 			 * consistency between YY_CURRENT_BUFFER and our
 			 * globals.  Here is the right place to do so, because
 			 * this is the first action (other than possibly a
 			 * back-up) that will match for the new input source.
 			 */
 			(yy_n_chars) = YY_CURRENT_BUFFER_LVALUE->yy_n_chars;
-			YY_CURRENT_BUFFER_LVALUE->yy_input_file = libxlio_yyin;
+			YY_CURRENT_BUFFER_LVALUE->yy_input_file = yyin;
 			YY_CURRENT_BUFFER_LVALUE->yy_buffer_status = YY_BUFFER_NORMAL;
 			}
 
@@ -1450,11 +1676,11 @@ case YY_STATE_EOF(APP_ID_S2):
 				{
 				(yy_did_buffer_switch_on_eof) = 0;
 
-				if ( libxlio_yywrap( ) )
+				if ( yywrap(  ) )
 					{
 					/* Note: because we've taken care in
 					 * yy_get_next_buffer() to have set up
-					 * libxlio_yytext, we can now set up
+					 * yytext, we can now set up
 					 * yy_c_buf_p so that if some total
 					 * hoser (like flex itself) wants to
 					 * call the scanner after we return the
@@ -1504,7 +1730,7 @@ case YY_STATE_EOF(APP_ID_S2):
 	} /* end of action switch */
 		} /* end of scanning one token */
 	} /* end of user's declarations */
-} /* end of libxlio_yylex */
+} /* end of yylex */
 
 /* yy_get_next_buffer - try to read in a new buffer
  *
@@ -1515,9 +1741,9 @@ case YY_STATE_EOF(APP_ID_S2):
  */
 static int yy_get_next_buffer (void)
 {
-    	register char *dest = YY_CURRENT_BUFFER_LVALUE->yy_ch_buf;
-	register char *source = (yytext_ptr);
-	register int number_to_move, i;
+    	char *dest = YY_CURRENT_BUFFER_LVALUE->yy_ch_buf;
+	char *source = (yytext_ptr);
+	int number_to_move, i;
 	int ret_val;
 
 	if ( (yy_c_buf_p) > &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[(yy_n_chars) + 1] )
@@ -1546,7 +1772,7 @@ static int yy_get_next_buffer (void)
 	/* Try to read more data. */
 
 	/* First move last chars to start of buffer. */
-	number_to_move = (int) ((yy_c_buf_p) - (yytext_ptr)) - 1;
+	number_to_move = (int) ((yy_c_buf_p) - (yytext_ptr) - 1);
 
 	for ( i = 0; i < number_to_move; ++i )
 		*(dest++) = *(source++);
@@ -1559,7 +1785,7 @@ static int yy_get_next_buffer (void)
 
 	else
 		{
-			yy_size_t num_to_read =
+			int num_to_read =
 			YY_CURRENT_BUFFER_LVALUE->yy_buf_size - number_to_move - 1;
 
 		while ( num_to_read <= 0 )
@@ -1573,7 +1799,7 @@ static int yy_get_next_buffer (void)
 
 			if ( b->yy_is_our_buffer )
 				{
-				yy_size_t new_size = b->yy_buf_size * 2;
+				int new_size = b->yy_buf_size * 2;
 
 				if ( new_size <= 0 )
 					b->yy_buf_size += b->yy_buf_size / 8;
@@ -1582,11 +1808,12 @@ static int yy_get_next_buffer (void)
 
 				b->yy_ch_buf = (char *)
 					/* Include room in for 2 EOB chars. */
-					libxlio_yyrealloc((void *) b->yy_ch_buf,b->yy_buf_size + 2  );
+					yyrealloc( (void *) b->yy_ch_buf,
+							 (yy_size_t) (b->yy_buf_size + 2)  );
 				}
 			else
 				/* Can't grow it, we don't own it. */
-				b->yy_ch_buf = 0;
+				b->yy_ch_buf = NULL;
 
 			if ( ! b->yy_ch_buf )
 				YY_FATAL_ERROR(
@@ -1614,7 +1841,7 @@ static int yy_get_next_buffer (void)
 		if ( number_to_move == YY_MORE_ADJ )
 			{
 			ret_val = EOB_ACT_END_OF_FILE;
-			libxlio_yyrestart(libxlio_yyin  );
+			yyrestart( yyin  );
 			}
 
 		else
@@ -1628,12 +1855,15 @@ static int yy_get_next_buffer (void)
 	else
 		ret_val = EOB_ACT_CONTINUE_SCAN;
 
-	if ((yy_size_t) ((yy_n_chars) + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
+	if (((yy_n_chars) + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
 		/* Extend the array by 50%, plus the number we really need. */
-		yy_size_t new_size = (yy_n_chars) + number_to_move + ((yy_n_chars) >> 1);
-		YY_CURRENT_BUFFER_LVALUE->yy_ch_buf = (char *) libxlio_yyrealloc((void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf,new_size  );
+		int new_size = (yy_n_chars) + number_to_move + ((yy_n_chars) >> 1);
+		YY_CURRENT_BUFFER_LVALUE->yy_ch_buf = (char *) yyrealloc(
+			(void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf, (yy_size_t) new_size  );
 		if ( ! YY_CURRENT_BUFFER_LVALUE->yy_ch_buf )
 			YY_FATAL_ERROR( "out of dynamic memory in yy_get_next_buffer()" );
+		/* "- 2" to take care of EOB's */
+		YY_CURRENT_BUFFER_LVALUE->yy_buf_size = (int) (new_size - 2);
 	}
 
 	(yy_n_chars) += number_to_move;
@@ -1649,15 +1879,15 @@ static int yy_get_next_buffer (void)
 
     static yy_state_type yy_get_previous_state (void)
 {
-	register yy_state_type yy_current_state;
-	register char *yy_cp;
+	yy_state_type yy_current_state;
+	char *yy_cp;
     
 	yy_current_state = (yy_start);
 	yy_current_state += YY_AT_BOL();
 
 	for ( yy_cp = (yytext_ptr) + YY_MORE_ADJ; yy_cp < (yy_c_buf_p); ++yy_cp )
 		{
-		register YY_CHAR yy_c = (*yy_cp ? yy_ec[YY_SC_TO_UI(*yy_cp)] : 1);
+		YY_CHAR yy_c = (*yy_cp ? yy_ec[YY_SC_TO_UI(*yy_cp)] : 1);
 		if ( yy_accept[yy_current_state] )
 			{
 			(yy_last_accepting_state) = yy_current_state;
@@ -1666,10 +1896,10 @@ static int yy_get_next_buffer (void)
 		while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
 			{
 			yy_current_state = (int) yy_def[yy_current_state];
-			if ( yy_current_state >= 473 )
-				yy_c = yy_meta[(unsigned int) yy_c];
+			if ( yy_current_state >= 477 )
+				yy_c = yy_meta[yy_c];
 			}
-		yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
+		yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 		}
 
 	return yy_current_state;
@@ -1682,10 +1912,10 @@ static int yy_get_next_buffer (void)
  */
     static yy_state_type yy_try_NUL_trans  (yy_state_type yy_current_state )
 {
-	register int yy_is_jam;
-    	register char *yy_cp = (yy_c_buf_p);
+	int yy_is_jam;
+    	char *yy_cp = (yy_c_buf_p);
 
-	register YY_CHAR yy_c = 1;
+	YY_CHAR yy_c = 1;
 	if ( yy_accept[yy_current_state] )
 		{
 		(yy_last_accepting_state) = yy_current_state;
@@ -1694,14 +1924,18 @@ static int yy_get_next_buffer (void)
 	while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
 		{
 		yy_current_state = (int) yy_def[yy_current_state];
-		if ( yy_current_state >= 473 )
-			yy_c = yy_meta[(unsigned int) yy_c];
+		if ( yy_current_state >= 477 )
+			yy_c = yy_meta[yy_c];
 		}
-	yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
-	yy_is_jam = (yy_current_state == 472);
+	yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
+	yy_is_jam = (yy_current_state == 476);
 
 		return yy_is_jam ? 0 : yy_current_state;
 }
+
+#ifndef YY_NO_UNPUT
+
+#endif
 
 #ifndef YY_NO_INPUT
 #ifdef __cplusplus
@@ -1727,7 +1961,7 @@ static int yy_get_next_buffer (void)
 
 		else
 			{ /* need more input */
-			yy_size_t offset = (yy_c_buf_p) - (yytext_ptr);
+			int offset = (int) ((yy_c_buf_p) - (yytext_ptr));
 			++(yy_c_buf_p);
 
 			switch ( yy_get_next_buffer(  ) )
@@ -1744,14 +1978,14 @@ static int yy_get_next_buffer (void)
 					 */
 
 					/* Reset buffer status. */
-					libxlio_yyrestart(libxlio_yyin );
+					yyrestart( yyin );
 
 					/*FALLTHROUGH*/
 
 				case EOB_ACT_END_OF_FILE:
 					{
-					if ( libxlio_yywrap( ) )
-						return EOF;
+					if ( yywrap(  ) )
+						return 0;
 
 					if ( ! (yy_did_buffer_switch_on_eof) )
 						YY_NEW_FILE;
@@ -1770,7 +2004,7 @@ static int yy_get_next_buffer (void)
 		}
 
 	c = *(unsigned char *) (yy_c_buf_p);	/* cast for 8-bit char's */
-	*(yy_c_buf_p) = '\0';	/* preserve libxlio_yytext */
+	*(yy_c_buf_p) = '\0';	/* preserve yytext */
 	(yy_hold_char) = *++(yy_c_buf_p);
 
 	YY_CURRENT_BUFFER_LVALUE->yy_at_bol = (c == '\n');
@@ -1784,34 +2018,32 @@ static int yy_get_next_buffer (void)
  * 
  * @note This function does not reset the start condition to @c INITIAL .
  */
-    void libxlio_yyrestart  (FILE * input_file )
+    void yyrestart  (FILE * input_file )
 {
     
 	if ( ! YY_CURRENT_BUFFER ){
-        libxlio_yyensure_buffer_stack ();
-		if ( yy_buffer_stack ) {
-			YY_CURRENT_BUFFER_LVALUE =
-            			libxlio_yy_create_buffer(libxlio_yyin,YY_BUF_SIZE );
-		}
+        yyensure_buffer_stack ();
+		YY_CURRENT_BUFFER_LVALUE =
+            yy_create_buffer( yyin, YY_BUF_SIZE );
 	}
 
-	libxlio_yy_init_buffer(YY_CURRENT_BUFFER,input_file );
-	libxlio_yy_load_buffer_state( );
+	yy_init_buffer( YY_CURRENT_BUFFER, input_file );
+	yy_load_buffer_state(  );
 }
 
 /** Switch to a different input buffer.
  * @param new_buffer The new input buffer.
  * 
  */
-    void libxlio_yy_switch_to_buffer  (YY_BUFFER_STATE  new_buffer )
+    void yy_switch_to_buffer  (YY_BUFFER_STATE  new_buffer )
 {
     
 	/* TODO. We should be able to replace this entire function body
 	 * with
-	 *		libxlio_yypop_buffer_state();
-	 *		libxlio_yypush_buffer_state(new_buffer);
+	 *		yypop_buffer_state();
+	 *		yypush_buffer_state(new_buffer);
      */
-	libxlio_yyensure_buffer_stack ();
+	yyensure_buffer_stack ();
 	if ( YY_CURRENT_BUFFER == new_buffer )
 		return;
 
@@ -1823,24 +2055,22 @@ static int yy_get_next_buffer (void)
 		YY_CURRENT_BUFFER_LVALUE->yy_n_chars = (yy_n_chars);
 		}
 
-	if ( yy_buffer_stack ) {
-		YY_CURRENT_BUFFER_LVALUE = new_buffer;
-	}
-	libxlio_yy_load_buffer_state( );
+	YY_CURRENT_BUFFER_LVALUE = new_buffer;
+	yy_load_buffer_state(  );
 
 	/* We don't actually know whether we did this switch during
-	 * EOF (libxlio_yywrap()) processing, but the only time this flag
-	 * is looked at is after libxlio_yywrap() is called, so it's safe
+	 * EOF (yywrap()) processing, but the only time this flag
+	 * is looked at is after yywrap() is called, so it's safe
 	 * to go ahead and always set it.
 	 */
 	(yy_did_buffer_switch_on_eof) = 1;
 }
 
-static void libxlio_yy_load_buffer_state  (void)
+static void yy_load_buffer_state  (void)
 {
     	(yy_n_chars) = YY_CURRENT_BUFFER_LVALUE->yy_n_chars;
 	(yytext_ptr) = (yy_c_buf_p) = YY_CURRENT_BUFFER_LVALUE->yy_buf_pos;
-	libxlio_yyin = YY_CURRENT_BUFFER_LVALUE->yy_input_file;
+	yyin = YY_CURRENT_BUFFER_LVALUE->yy_input_file;
 	(yy_hold_char) = *(yy_c_buf_p);
 }
 
@@ -1850,35 +2080,35 @@ static void libxlio_yy_load_buffer_state  (void)
  * 
  * @return the allocated buffer state.
  */
-    YY_BUFFER_STATE libxlio_yy_create_buffer  (FILE * file, int  size )
+    YY_BUFFER_STATE yy_create_buffer  (FILE * file, int  size )
 {
 	YY_BUFFER_STATE b;
     
-	b = (YY_BUFFER_STATE) libxlio_yyalloc(sizeof( struct yy_buffer_state )  );
+	b = (YY_BUFFER_STATE) yyalloc( sizeof( struct yy_buffer_state )  );
 	if ( ! b )
-		YY_FATAL_ERROR( "out of dynamic memory in libxlio_yy_create_buffer()" );
+		YY_FATAL_ERROR( "out of dynamic memory in yy_create_buffer()" );
 
 	b->yy_buf_size = size;
 
 	/* yy_ch_buf has to be 2 characters longer than the size given because
 	 * we need to put in 2 end-of-buffer characters.
 	 */
-	b->yy_ch_buf = (char *) libxlio_yyalloc(b->yy_buf_size + 2  );
+	b->yy_ch_buf = (char *) yyalloc( (yy_size_t) (b->yy_buf_size + 2)  );
 	if ( ! b->yy_ch_buf )
-		YY_FATAL_ERROR( "out of dynamic memory in libxlio_yy_create_buffer()" );
+		YY_FATAL_ERROR( "out of dynamic memory in yy_create_buffer()" );
 
 	b->yy_is_our_buffer = 1;
 
-	libxlio_yy_init_buffer(b,file );
+	yy_init_buffer( b, file );
 
 	return b;
 }
 
 /** Destroy the buffer.
- * @param b a buffer created with libxlio_yy_create_buffer()
+ * @param b a buffer created with yy_create_buffer()
  * 
  */
-    void libxlio_yy_delete_buffer (YY_BUFFER_STATE  b )
+    void yy_delete_buffer (YY_BUFFER_STATE  b )
 {
     
 	if ( ! b )
@@ -1888,29 +2118,27 @@ static void libxlio_yy_load_buffer_state  (void)
 		YY_CURRENT_BUFFER_LVALUE = (YY_BUFFER_STATE) 0;
 
 	if ( b->yy_is_our_buffer )
-		libxlio_yyfree((void *) b->yy_ch_buf  );
+		yyfree( (void *) b->yy_ch_buf  );
 
-	libxlio_yyfree((void *) b  );
+	yyfree( (void *) b  );
 }
 
 /* Initializes or reinitializes a buffer.
  * This function is sometimes called more than once on the same buffer,
- * such as during a libxlio_yyrestart() or at EOF.
+ * such as during a yyrestart() or at EOF.
  */
-    static void libxlio_yy_init_buffer  (YY_BUFFER_STATE  b, FILE * file )
+    static void yy_init_buffer  (YY_BUFFER_STATE  b, FILE * file )
 
 {
 	int oerrno = errno;
-
-	if (!b) return;
-
-	libxlio_yy_flush_buffer(b );
+    
+	yy_flush_buffer( b );
 
 	b->yy_input_file = file;
 	b->yy_fill_buffer = 1;
 
-    /* If b is the current buffer, then libxlio_yy_init_buffer was _probably_
-     * called from libxlio_yyrestart() or through yy_get_next_buffer.
+    /* If b is the current buffer, then yy_init_buffer was _probably_
+     * called from yyrestart() or through yy_get_next_buffer.
      * In that case, we don't want to reset the lineno or column.
      */
     if (b != YY_CURRENT_BUFFER){
@@ -1927,7 +2155,7 @@ static void libxlio_yy_load_buffer_state  (void)
  * @param b the buffer state to be flushed, usually @c YY_CURRENT_BUFFER.
  * 
  */
-    void libxlio_yy_flush_buffer (YY_BUFFER_STATE  b )
+    void yy_flush_buffer (YY_BUFFER_STATE  b )
 {
     	if ( ! b )
 		return;
@@ -1947,7 +2175,7 @@ static void libxlio_yy_load_buffer_state  (void)
 	b->yy_buffer_status = YY_BUFFER_NEW;
 
 	if ( b == YY_CURRENT_BUFFER )
-		libxlio_yy_load_buffer_state( );
+		yy_load_buffer_state(  );
 }
 
 /** Pushes the new state onto the stack. The new state becomes
@@ -1956,14 +2184,14 @@ static void libxlio_yy_load_buffer_state  (void)
  *  @param new_buffer The new state.
  *  
  */
-void libxlio_yypush_buffer_state (YY_BUFFER_STATE new_buffer )
+void yypush_buffer_state (YY_BUFFER_STATE new_buffer )
 {
     	if (new_buffer == NULL)
 		return;
 
-	libxlio_yyensure_buffer_stack();
+	yyensure_buffer_stack();
 
-	/* This block is copied from libxlio_yy_switch_to_buffer. */
+	/* This block is copied from yy_switch_to_buffer. */
 	if ( YY_CURRENT_BUFFER )
 		{
 		/* Flush out information for old buffer. */
@@ -1973,15 +2201,12 @@ void libxlio_yypush_buffer_state (YY_BUFFER_STATE new_buffer )
 		}
 
 	/* Only push if top exists. Otherwise, replace top. */
-	if (YY_CURRENT_BUFFER) {
+	if (YY_CURRENT_BUFFER)
 		(yy_buffer_stack_top)++;
-	}
-	if (yy_buffer_stack) {
-		YY_CURRENT_BUFFER_LVALUE = new_buffer;
-	}
+	YY_CURRENT_BUFFER_LVALUE = new_buffer;
 
-	/* copied from libxlio_yy_switch_to_buffer. */
-	libxlio_yy_load_buffer_state( );
+	/* copied from yy_switch_to_buffer. */
+	yy_load_buffer_state(  );
 	(yy_did_buffer_switch_on_eof) = 1;
 }
 
@@ -1989,18 +2214,18 @@ void libxlio_yypush_buffer_state (YY_BUFFER_STATE new_buffer )
  *  The next element becomes the new top.
  *  
  */
-void libxlio_yypop_buffer_state (void)
+void yypop_buffer_state (void)
 {
     	if (!YY_CURRENT_BUFFER)
 		return;
 
-	libxlio_yy_delete_buffer(YY_CURRENT_BUFFER );
+	yy_delete_buffer(YY_CURRENT_BUFFER );
 	YY_CURRENT_BUFFER_LVALUE = NULL;
 	if ((yy_buffer_stack_top) > 0)
 		--(yy_buffer_stack_top);
 
 	if (YY_CURRENT_BUFFER) {
-		libxlio_yy_load_buffer_state( );
+		yy_load_buffer_state(  );
 		(yy_did_buffer_switch_on_eof) = 1;
 	}
 }
@@ -2008,7 +2233,7 @@ void libxlio_yypop_buffer_state (void)
 /* Allocates the stack if it does not exist.
  *  Guarantees space for at least one push.
  */
-static void libxlio_yyensure_buffer_stack (void)
+static void yyensure_buffer_stack (void)
 {
 	yy_size_t num_to_alloc;
     
@@ -2018,15 +2243,15 @@ static void libxlio_yyensure_buffer_stack (void)
 		 * scanner will even need a stack. We use 2 instead of 1 to avoid an
 		 * immediate realloc on the next call.
          */
-		num_to_alloc = 1;
-		(yy_buffer_stack) = (struct yy_buffer_state**)libxlio_yyalloc
+      num_to_alloc = 1; /* After all that talk, this was set to 1 anyways... */
+		(yy_buffer_stack) = (struct yy_buffer_state**)yyalloc
 								(num_to_alloc * sizeof(struct yy_buffer_state*)
 								);
 		if ( ! (yy_buffer_stack) )
-			YY_FATAL_ERROR( "out of dynamic memory in libxlio_yyensure_buffer_stack()" );
-								  
+			YY_FATAL_ERROR( "out of dynamic memory in yyensure_buffer_stack()" );
+
 		memset((yy_buffer_stack), 0, num_to_alloc * sizeof(struct yy_buffer_state*));
-				
+
 		(yy_buffer_stack_max) = num_to_alloc;
 		(yy_buffer_stack_top) = 0;
 		return;
@@ -2035,15 +2260,15 @@ static void libxlio_yyensure_buffer_stack (void)
 	if ((yy_buffer_stack_top) >= ((yy_buffer_stack_max)) - 1){
 
 		/* Increase the buffer to prepare for a possible push. */
-		int grow_size = 8 /* arbitrary grow size */;
+		yy_size_t grow_size = 8 /* arbitrary grow size */;
 
 		num_to_alloc = (yy_buffer_stack_max) + grow_size;
-		(yy_buffer_stack) = (struct yy_buffer_state**)libxlio_yyrealloc
+		(yy_buffer_stack) = (struct yy_buffer_state**)yyrealloc
 								((yy_buffer_stack),
 								num_to_alloc * sizeof(struct yy_buffer_state*)
 								);
 		if ( ! (yy_buffer_stack) )
-			YY_FATAL_ERROR( "out of dynamic memory in libxlio_yyensure_buffer_stack()" );
+			YY_FATAL_ERROR( "out of dynamic memory in yyensure_buffer_stack()" );
 
 		/* zero only the new slots.*/
 		memset((yy_buffer_stack) + (yy_buffer_stack_max), 0, grow_size * sizeof(struct yy_buffer_state*));
@@ -2055,9 +2280,9 @@ static void libxlio_yyensure_buffer_stack (void)
  * @param base the character buffer
  * @param size the size in bytes of the character buffer
  * 
- * @return the newly allocated buffer state object. 
+ * @return the newly allocated buffer state object.
  */
-YY_BUFFER_STATE libxlio_yy_scan_buffer  (char * base, yy_size_t  size )
+YY_BUFFER_STATE yy_scan_buffer  (char * base, yy_size_t  size )
 {
 	YY_BUFFER_STATE b;
     
@@ -2065,69 +2290,69 @@ YY_BUFFER_STATE libxlio_yy_scan_buffer  (char * base, yy_size_t  size )
 	     base[size-2] != YY_END_OF_BUFFER_CHAR ||
 	     base[size-1] != YY_END_OF_BUFFER_CHAR )
 		/* They forgot to leave room for the EOB's. */
-		return 0;
+		return NULL;
 
-	b = (YY_BUFFER_STATE) libxlio_yyalloc(sizeof( struct yy_buffer_state )  );
+	b = (YY_BUFFER_STATE) yyalloc( sizeof( struct yy_buffer_state )  );
 	if ( ! b )
-		YY_FATAL_ERROR( "out of dynamic memory in libxlio_yy_scan_buffer()" );
+		YY_FATAL_ERROR( "out of dynamic memory in yy_scan_buffer()" );
 
-	b->yy_buf_size = size - 2;	/* "- 2" to take care of EOB's */
+	b->yy_buf_size = (int) (size - 2);	/* "- 2" to take care of EOB's */
 	b->yy_buf_pos = b->yy_ch_buf = base;
 	b->yy_is_our_buffer = 0;
-	b->yy_input_file = 0;
+	b->yy_input_file = NULL;
 	b->yy_n_chars = b->yy_buf_size;
 	b->yy_is_interactive = 0;
 	b->yy_at_bol = 1;
 	b->yy_fill_buffer = 0;
 	b->yy_buffer_status = YY_BUFFER_NEW;
 
-	libxlio_yy_switch_to_buffer(b  );
+	yy_switch_to_buffer( b  );
 
 	return b;
 }
 
-/** Setup the input buffer state to scan a string. The next call to libxlio_yylex() will
+/** Setup the input buffer state to scan a string. The next call to yylex() will
  * scan from a @e copy of @a str.
  * @param yystr a NUL-terminated string to scan
  * 
  * @return the newly allocated buffer state object.
  * @note If you want to scan bytes that may contain NUL values, then use
- *       libxlio_yy_scan_bytes() instead.
+ *       yy_scan_bytes() instead.
  */
-YY_BUFFER_STATE libxlio_yy_scan_string (yyconst char * yystr )
+YY_BUFFER_STATE yy_scan_string (const char * yystr )
 {
     
-	return libxlio_yy_scan_bytes(yystr,strlen(yystr) );
+	return yy_scan_bytes( yystr, (int) strlen(yystr) );
 }
 
-/** Setup the input buffer state to scan the given bytes. The next call to libxlio_yylex() will
+/** Setup the input buffer state to scan the given bytes. The next call to yylex() will
  * scan from a @e copy of @a bytes.
  * @param yybytes the byte buffer to scan
  * @param _yybytes_len the number of bytes in the buffer pointed to by @a bytes.
  * 
  * @return the newly allocated buffer state object.
  */
-YY_BUFFER_STATE libxlio_yy_scan_bytes  (yyconst char * yybytes, yy_size_t  _yybytes_len )
+YY_BUFFER_STATE yy_scan_bytes  (const char * yybytes, int  _yybytes_len )
 {
 	YY_BUFFER_STATE b;
 	char *buf;
 	yy_size_t n;
-	yy_size_t i;
+	int i;
     
 	/* Get memory for full buffer, including space for trailing EOB's. */
-	n = _yybytes_len + 2;
-	buf = (char *) libxlio_yyalloc(n  );
+	n = (yy_size_t) (_yybytes_len + 2);
+	buf = (char *) yyalloc( n  );
 	if ( ! buf )
-		YY_FATAL_ERROR( "out of dynamic memory in libxlio_yy_scan_bytes()" );
+		YY_FATAL_ERROR( "out of dynamic memory in yy_scan_bytes()" );
 
 	for ( i = 0; i < _yybytes_len; ++i )
 		buf[i] = yybytes[i];
 
 	buf[_yybytes_len] = buf[_yybytes_len+1] = YY_END_OF_BUFFER_CHAR;
 
-	b = libxlio_yy_scan_buffer(buf,n );
+	b = yy_scan_buffer( buf, n );
 	if ( ! b )
-		YY_FATAL_ERROR( "bad buffer in libxlio_yy_scan_bytes()" );
+		YY_FATAL_ERROR( "bad buffer in yy_scan_bytes()" );
 
 	/* It's okay to grow etc. this buffer, and we should throw it
 	 * away when we're done.
@@ -2141,9 +2366,9 @@ YY_BUFFER_STATE libxlio_yy_scan_bytes  (yyconst char * yybytes, yy_size_t  _yyby
 #define YY_EXIT_FAILURE 2
 #endif
 
-static void yy_fatal_error (yyconst char* msg )
+static void yynoreturn yy_fatal_error (const char* msg )
 {
-    	(void) fprintf( stderr, "%s\n", msg );
+			fprintf( stderr, "%s\n", msg );
 	exit( YY_EXIT_FAILURE );
 }
 
@@ -2153,14 +2378,14 @@ static void yy_fatal_error (yyconst char* msg )
 #define yyless(n) \
 	do \
 		{ \
-		/* Undo effects of setting up libxlio_yytext. */ \
+		/* Undo effects of setting up yytext. */ \
         int yyless_macro_arg = (n); \
         YY_LESS_LINENO(yyless_macro_arg);\
-		libxlio_yytext[libxlio_yyleng] = (yy_hold_char); \
-		(yy_c_buf_p) = libxlio_yytext + yyless_macro_arg; \
+		yytext[yyleng] = (yy_hold_char); \
+		(yy_c_buf_p) = yytext + yyless_macro_arg; \
 		(yy_hold_char) = *(yy_c_buf_p); \
 		*(yy_c_buf_p) = '\0'; \
-		libxlio_yyleng = yyless_macro_arg; \
+		yyleng = yyless_macro_arg; \
 		} \
 	while ( 0 )
 
@@ -2169,126 +2394,126 @@ static void yy_fatal_error (yyconst char* msg )
 /** Get the current line number.
  * 
  */
-int libxlio_yyget_lineno  (void)
+int yyget_lineno  (void)
 {
-        
-    return libxlio_yylineno;
+    
+    return yylineno;
 }
 
 /** Get the input stream.
  * 
  */
-FILE *libxlio_yyget_in  (void)
+FILE *yyget_in  (void)
 {
-        return libxlio_yyin;
+        return yyin;
 }
 
 /** Get the output stream.
  * 
  */
-FILE *libxlio_yyget_out  (void)
+FILE *yyget_out  (void)
 {
-        return libxlio_yyout;
+        return yyout;
 }
 
 /** Get the length of the current token.
  * 
  */
-yy_size_t libxlio_yyget_leng  (void)
+int yyget_leng  (void)
 {
-        return libxlio_yyleng;
+        return yyleng;
 }
 
 /** Get the current token.
  * 
  */
 
-char *libxlio_yyget_text  (void)
+char *yyget_text  (void)
 {
-        return libxlio_yytext;
+        return yytext;
 }
 
 /** Set the current line number.
- * @param line_number
+ * @param _line_number line number
  * 
  */
-void libxlio_yyset_lineno (int  line_number )
+void yyset_lineno (int  _line_number )
 {
     
-    libxlio_yylineno = line_number;
+    yylineno = _line_number;
 }
 
 /** Set the input stream. This does not discard the current
  * input buffer.
- * @param in_str A readable stream.
+ * @param _in_str A readable stream.
  * 
- * @see libxlio_yy_switch_to_buffer
+ * @see yy_switch_to_buffer
  */
-void libxlio_yyset_in (FILE *  in_str )
+void yyset_in (FILE *  _in_str )
 {
-        libxlio_yyin = in_str ;
+        yyin = _in_str ;
 }
 
-void libxlio_yyset_out (FILE *  out_str )
+void yyset_out (FILE *  _out_str )
 {
-        libxlio_yyout = out_str ;
+        yyout = _out_str ;
 }
 
-int libxlio_yyget_debug  (void)
+int yyget_debug  (void)
 {
-        return libxlio_yy_flex_debug;
+        return yy_flex_debug;
 }
 
-void libxlio_yyset_debug (int  bdebug )
+void yyset_debug (int  _bdebug )
 {
-        libxlio_yy_flex_debug = bdebug ;
+        yy_flex_debug = _bdebug ;
 }
 
 static int yy_init_globals (void)
 {
         /* Initialization is the same as for the non-reentrant scanner.
-     * This function is called from libxlio_yylex_destroy(), so don't allocate here.
+     * This function is called from yylex_destroy(), so don't allocate here.
      */
 
-    (yy_buffer_stack) = 0;
+    (yy_buffer_stack) = NULL;
     (yy_buffer_stack_top) = 0;
     (yy_buffer_stack_max) = 0;
-    (yy_c_buf_p) = (char *) 0;
+    (yy_c_buf_p) = NULL;
     (yy_init) = 0;
     (yy_start) = 0;
 
 /* Defined in main.c */
 #ifdef YY_STDINIT
-    libxlio_yyin = stdin;
-    libxlio_yyout = stdout;
+    yyin = stdin;
+    yyout = stdout;
 #else
-    libxlio_yyin = (FILE *) 0;
-    libxlio_yyout = (FILE *) 0;
+    yyin = NULL;
+    yyout = NULL;
 #endif
 
     /* For future reference: Set errno on error, since we are called by
-     * libxlio_yylex_init()
+     * yylex_init()
      */
     return 0;
 }
 
-/* libxlio_yylex_destroy is for both reentrant and non-reentrant scanners. */
-int libxlio_yylex_destroy  (void)
+/* yylex_destroy is for both reentrant and non-reentrant scanners. */
+int yylex_destroy  (void)
 {
     
     /* Pop the buffer stack, destroying each element. */
 	while(YY_CURRENT_BUFFER){
-		libxlio_yy_delete_buffer(YY_CURRENT_BUFFER  );
+		yy_delete_buffer( YY_CURRENT_BUFFER  );
 		YY_CURRENT_BUFFER_LVALUE = NULL;
-		libxlio_yypop_buffer_state();
+		yypop_buffer_state();
 	}
 
 	/* Destroy the stack itself. */
-	libxlio_yyfree((yy_buffer_stack) );
+	yyfree((yy_buffer_stack) );
 	(yy_buffer_stack) = NULL;
 
     /* Reset the globals. This is important in a non-reentrant scanner so the next time
-     * libxlio_yylex() is called, initialization will occur. */
+     * yylex() is called, initialization will occur. */
     yy_init_globals( );
 
     return 0;
@@ -2299,18 +2524,19 @@ int libxlio_yylex_destroy  (void)
  */
 
 #ifndef yytext_ptr
-static void yy_flex_strncpy (char* s1, yyconst char * s2, int n )
+static void yy_flex_strncpy (char* s1, const char * s2, int n )
 {
-	register int i;
+		
+	int i;
 	for ( i = 0; i < n; ++i )
 		s1[i] = s2[i];
 }
 #endif
 
 #ifdef YY_NEED_STRLEN
-static int yy_flex_strlen (yyconst char * s )
+static int yy_flex_strlen (const char * s )
 {
-	register int n;
+	int n;
 	for ( n = 0; s[n]; ++n )
 		;
 
@@ -2318,13 +2544,14 @@ static int yy_flex_strlen (yyconst char * s )
 }
 #endif
 
-void *libxlio_yyalloc (yy_size_t  size )
+void *yyalloc (yy_size_t  size )
 {
-	return (void *) malloc( size );
+			return malloc(size);
 }
 
-void *libxlio_yyrealloc  (void * ptr, yy_size_t  size )
+void *yyrealloc  (void * ptr, yy_size_t  size )
 {
+		
 	/* The cast to (char *) in the following accommodates both
 	 * implementations that use char* generic pointers, and those
 	 * that use void* generic pointers.  It works with the latter
@@ -2332,21 +2559,20 @@ void *libxlio_yyrealloc  (void * ptr, yy_size_t  size )
 	 * any pointer type to void*, and deal with argument conversions
 	 * as though doing an assignment.
 	 */
-	return (void *) realloc( (char *) ptr, size );
+	return realloc(ptr, size);
 }
 
-void libxlio_yyfree (void * ptr )
+void yyfree (void * ptr )
 {
-	free( (char *) ptr );	/* see libxlio_yyrealloc() for (char *) cast */
+			free( (char *) ptr );	/* see yyrealloc() for (char *) cast */
 }
 
 #define YYTABLES_NAME "yytables"
 
-/* Line 276 of config_scanner.l */
+#line 250 "src/core/util/config_scanner.l"
 
 
-
-int libxlio_yywrap ()
+int yywrap ()
 {
 	return (1);
 }


### PR DESCRIPTION
## Description
The pre-generated flex scanner DFA tables were never regenerated after the VMA-to-XLIO rename. The rename was a text find-and-replace that updated action code (return XLIO) but left the numeric DFA transition tables encoding the old "vma" keyword. Character 'x' remained in equivalence class 1 (catch-all), making "use xlio" impossible to tokenize -- the lexer returned raw 'x' causing a parse error.

Regenerate config_scanner.c and config_parser.c/h from the .l/.y sources using flex 2.6.4 and bison 3.8.2. Fix const mismatch in config_parser.y for __xlio_parse_config_line signature.

##### What
Fix "use xlio" keyword rejected by acceleration rules parser.

##### Why ?
use xlio tcp_client <addr>:<port>:*:* in acceleration rules (both legacy .conf and new JSON config) produces syntax error, unexpected unrecognized-token, while use os works fine. 

Root cause: c and h files were never regenerated to comply to config_parser.y

##### How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc._

## Change type
What kind of change does this PR introduce?
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

