### PR TITLE
issue: 4963693 Restore default DNS-to-OS offloading rule in package

### DIFF
--- a/contrib/scripts/libxlio.spec.in
+++ b/contrib/scripts/libxlio.spec.in
@@ -166,6 +166,7 @@ fi
 %dir %{_pkgdocdir}
 %doc %{_pkgdocdir}/README
 %doc %{_pkgdocdir}/CHANGES
+%config(noreplace) %{_sysconfdir}/libxlio.conf
 %config(noreplace) %{_sysconfdir}/xlio_config_schema.json
 %config(noreplace) %{_sysconfdir}/libxlio_config.json
 %{_sbindir}/xliod

--- a/debian/libxlio.install
+++ b/debian/libxlio.install
@@ -3,6 +3,7 @@ usr/lib/libxlio.so
 usr/share/doc/libxlio/README
 usr/share/doc/libxlio/CHANGES
 usr/sbin/
+etc/libxlio.conf
 etc/xlio_config_schema.json
 etc/libxlio_config.json
 contrib/scripts/xlio.service lib/systemd/system

--- a/docs/man/xlio.7.in
+++ b/docs/man/xlio.7.in
@@ -18,10 +18,20 @@ XLIO dynamically links with these applications at run-time, redirect standard
 socket API calls allowing them to be accelerated without modification.
 
 .SH FILES
+.I /etc/libxlio.conf
+.RS
+The system wide configuration file. Look inside libxlio.conf for instructions
+and examples.
+.RE
 .I /etc/xlio_config_schema.json
 .RS
-The JSON Schema for XLIO configuration files.
+The JSON Schema for XLIO configuration files. (XLIO_USE_NEW_CONFIG=1 path).
 and examples.
+.RE
+.I /etc/libxlio_config.json
+.RS
+The default JSON acceleration-control configuration. Contains the initial
+rule set applied at library load time (XLIO_USE_NEW_CONFIG=1 path).
 .RE
 .I /usr/share/doc/libxlio/README
 .RS

--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -19,9 +19,10 @@ SUBDIRS = infra netlink
 
 EXTRA_DIST = \
 	config/descriptor_providers/xlio_config_schema.json \
-	config/descriptor_providers/libxlio_config.json
+	config/descriptor_providers/libxlio_config.json \
+	util/libxlio.conf
 
-sysconf_DATA = config/descriptor_providers/xlio_config_schema.json config/descriptor_providers/libxlio_config.json
+sysconf_DATA = config/descriptor_providers/xlio_config_schema.json config/descriptor_providers/libxlio_config.json util/libxlio.conf
 otherincludedir = $(includedir)/mellanox
 otherinclude_HEADERS = \
 	xlio.h \

--- a/src/core/config/descriptor_providers/libxlio_config.json
+++ b/src/core/config/descriptor_providers/libxlio_config.json
@@ -1,1 +1,11 @@
-{}
+{
+    "acceleration_control": {
+        "rules": [
+            {
+                "id": "*",
+                "name": "*",
+                "actions": ["use os udp_connect *:53"]
+            }
+        ]
+    }
+}


### PR DESCRIPTION
## Description
The libxlio.conf file was dropped from the package during the transition to the new JSON config system. This removed the default rule "use os udp_connect *:53" which routes DNS traffic through the OS, changing out-of-box offloading behavior.

Re-add libxlio.conf to packaging (Makefile, RPM spec, Debian install, man page) and populate libxlio_config.json with the equivalent acceleration_control rule for the new config path.

##### What
Restore default DNS-to-OS offloading rule (use os udp_connect *:53) missing from XLIO package.

##### Why ?
When transitioning to the new JSON config system, libxlio.conf was removed from the package. This file contained a default rule routing DNS traffic (UDP port 53) through the OS, and its removal changed out-of-box offloading behavior.

##### How ?
 - Re-added libxlio.conf to packaging targets: Makefile.am (sysconf_DATA + EXTRA_DIST), libxlio.spec.in (%files), debian/libxlio.install, and xlio.7.in man page.
 - Populated the shipped libxlio_config.json (previously {}) with an equivalent acceleration_control.rules entry, so the new config path (XLIO_USE_NEW_CONFIG=1) also gets the DNS-to-OS rule by default.

## Change type
What kind of change does this PR introduce?
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

