### PR TITLE
issue: 4961328 Increase netlink socket buffer size to 8MB

### DIFF
--- a/src/core/netlink/netlink_wrapper.cpp
+++ b/src/core/netlink/netlink_wrapper.cpp
@@ -10,6 +10,8 @@
 #include <fcntl.h>
 #include <net/route.h>
 
+#include "core/util/sys_vars.h"
+#include "core/util/sysctl_reader.h"
 #include "vlogger/vlogger.h"
 #include "utils/bullseye.h"
 #include "netlink_wrapper.h"
@@ -301,6 +303,14 @@ int netlink_wrapper::open_channel()
         return -1;
     }
     BULLSEYE_EXCLUDE_BLOCK_END
+
+    int rmem_max = safe_mce_sys().sysctl_reader.get_net_core_rmem_max();
+    int wmem_max = safe_mce_sys().sysctl_reader.get_net_core_wmem_max();
+    int err = nl_socket_set_buffer_size(m_socket_handle, rmem_max, wmem_max);
+    if (err < 0) {
+        nl_logdbg("Failed to set netlink socket buffer size to (r=%d, w=%d): %d", rmem_max,
+                  wmem_max, err);
+    }
 
     return 0;
 }


### PR DESCRIPTION
Increase the netlink socket receive and send buffer sizes to 8MB. This prevents "No buffer space available" (ENOBUFS) errors that occur when the netlink socket buffer fills up during periods of high netlink message volume, ensuring reliable reading of network events.

## Description
Please provide a summary of the change.

##### What
_Subject: what this PR is doing in one line._ 

##### Why ?
_Justification for the PR. If there is existing issue/bug please reference._

##### How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc._

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

