### PR TITLE
issue: 4977472 Fix unsorted unsent queue after RTO following FR

### DIFF
--- a/src/core/lwip/tcp_out.c
+++ b/src/core/lwip/tcp_out.c
@@ -1579,37 +1579,41 @@ void tcp_rst(u32_t seqno, u32_t ackno, u16_t local_port, u16_t remote_port, stru
  */
 void tcp_rexmit_rto(struct tcp_pcb *pcb)
 {
+    struct tcp_seg *a, *b, **tail;
+
     if (pcb->unacked == NULL) {
         return;
     }
 
-    if (pcb->unsent != NULL && TCP_SEQ_GT(pcb->unacked->seqno, pcb->unsent->seqno)) {
-        // Move fast-retransmitted segments to unacked - RTO after fast retransmission
-        struct tcp_seg *rexmit_start = pcb->unsent;
-        struct tcp_seg *rexmit_end = pcb->unsent;
-        while (rexmit_end->next != NULL &&
-               TCP_SEQ_GT(pcb->unacked->seqno, rexmit_end->next->seqno)) {
-            rexmit_end = rexmit_end->next;
-        }
+    /* Sorted merge of unacked and unsent into a single unsent queue.
+     * Both queues are individually sorted by seqno. A simple prepend of
+     * unacked before unsent is insufficient because partial fast-retransmit
+     * with segment splitting can interleave seqno ranges between the queues.
+     */
+    a = pcb->unacked;
+    b = pcb->unsent;
+    tail = &pcb->unsent;
 
-        pcb->unsent = rexmit_end->next;
-        if (pcb->unsent == NULL) {
-            pcb->last_unsent = NULL;
+    while (a != NULL && b != NULL) {
+        if (TCP_SEQ_LEQ(a->seqno, b->seqno)) {
+            *tail = a;
+            a = a->next;
+        } else {
+            *tail = b;
+            b = b->next;
         }
-
-        rexmit_end->next = pcb->unacked;
-        pcb->unacked = rexmit_start;
+        tail = &((*tail)->next);
     }
+    *tail = (a != NULL) ? a : b;
 
-    /* Move all unacked segments to the head of the unsent queue */
-    if (pcb->unsent) {
-        pcb->last_unacked->next = pcb->unsent;
-    } else {
-        /* If there are no unsent segments, update last_unsent to the last unacked */
+    /* Update last_unsent to the tail with the highest seqno. */
+    if (pcb->last_unsent == NULL) {
+        pcb->last_unsent = pcb->last_unacked;
+    } else if (pcb->last_unacked != NULL &&
+               TCP_SEQ_GT(pcb->last_unacked->seqno, pcb->last_unsent->seqno)) {
         pcb->last_unsent = pcb->last_unacked;
     }
-    /* unsent queue is the concatenated queue (of unacked, unsent) */
-    pcb->unsent = pcb->unacked;
+
     /* unacked queue is now empty */
     pcb->unacked = NULL;
     pcb->last_unacked = NULL;


### PR DESCRIPTION
## Description

When a fast-retransmitted multi-pbuf segment is split by tcp_split_rexmit() and only the first fragment is sent before an RTO fires, tcp_rexmit_rto() produces an unsorted unsent queue.

The root cause is that tcp_rexmit_rto() prepends the entire unacked queue before unsent. After partial fast-retransmit with splitting, the sent fragment (low seqno) sits in unacked alongside the original higher-seqno segments, while the remaining unsent fragments have seqnos between them. Prepending creates an inversion:

  unacked: A1(100) -> B(30100) -> C(31100)
  unsent:  A2(10100) -> A3(20100) -> D(32100)
  result:  A1 -> B -> C -> A2 -> A3 -> D  (B,C before A2,A3)

The existing heuristic that detects fast-retransmit segments in unsent (checking unacked->seqno > unsent->seqno) fails in this case because the sent fragment A1 has the lowest seqno in unacked.

Replace the heuristic and concatenation with a sorted merge of the two individually-sorted queues, which correctly handles all cases.

##### What
Fix TCP progress stuck due to inconsistent unsent queue state (unsorted tcp segments).

##### Why ?
Bugfix, TCP progress stuck.

## Change type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved TCP packet retransmission algorithm to enhance network reliability and connection recovery efficiency during timeout scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->