### PR TITLE
[CI] issue: HPCINFRA-3388 Remove runAsUser from containers

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -2,7 +2,9 @@
 
 // load pipeline functions
 // Requires pipeline-github-lib plugin to load library from github
-@Library('github.com/Mellanox/ci-demo@stable_media')
+
+// For testing: set to a specific commit hash.
+@Library('github.com/Mellanox/ci-demo@234f97f0165a28b669bb7ae3bf8da6ea55a86d61')
 def matrix = new com.mellanox.cicd.Matrix()
 
 matrix.main()


### PR DESCRIPTION
## Description
After moving from Jenkins master to Kubernetes containers, runAsUser/runAsGroup cannot be used.

##### What
 Replace runAsUser/runAsGroup with sudo -u.

##### Why ?
[HPCINFRA-3388](https://jirasw.nvidia.com/browse/HPCINFRA-3388)

##### How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc._

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline to run key build, release and antivirus steps under a dedicated build user with adjusted workspace ownership and reduced privilege usage.
  * Simplified container execution configuration by removing explicit user/group fields.
  * Ensured environment (HOME/WORKSPACE) is preserved for invoked release and scan steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->