### PR TITLE
issue 4938837: [XLIO][Ultra API] - Call error callback only after accept callback

### DIFF
--- a/src/core/sock/sock-extra.cpp
+++ b/src/core/sock/sock-extra.cpp
@@ -211,7 +211,7 @@ extern "C" int xlio_socket_create(const struct xlio_socket_attr *attr, xlio_sock
         errno = ENOMEM;
         return -1;
     }
-    si->set_xlio_socket(attr);
+    si->set_xlio_socket(attr, true /* Allow app callbacks */);
 
     poll_group *grp = reinterpret_cast<poll_group *>(attr->group);
     grp->add_socket(si);

--- a/src/core/sock/sockinfo_tcp.cpp
+++ b/src/core/sock/sockinfo_tcp.cpp
@@ -392,7 +392,12 @@ void sockinfo_tcp::rx_add_ring_cb(ring *p_ring)
     sockinfo::rx_add_ring_cb(p_ring);
 }
 
-void sockinfo_tcp::set_xlio_socket(const struct xlio_socket_attr *attr)
+bool sockinfo_tcp::xlio_app_callbacks_allowed() const
+{
+    return is_xlio_socket() && m_p_group && m_xlio_app_callbacks_allowed;
+}
+
+void sockinfo_tcp::set_xlio_socket(const struct xlio_socket_attr *attr, bool allow_app_callbacks)
 {
     if (is_shadow_socket_present() && m_rx_epfd != -1) {
         // XLIO Socket API doesn't use per socket epfd
@@ -422,6 +427,7 @@ void sockinfo_tcp::set_xlio_socket(const struct xlio_socket_attr *attr)
     tcp_acked(&m_pcb, nullptr);
     set_blocking(false);
     m_is_xlio_socket = true;
+    m_xlio_app_callbacks_allowed = allow_app_callbacks;
 }
 
 void sockinfo_tcp::set_entity_context(entity_context *ctx)
@@ -612,7 +618,7 @@ int sockinfo_tcp::attach_xlio_group(poll_group *group)
 
     // TODO reinitialize lwip callbacks
 
-    set_xlio_socket(&attr);
+    set_xlio_socket(&attr, true /* Allow app callbacks */);
     group->add_socket(this);
 
     std::lock_guard<decltype(m_tcp_con_lock)> lock(m_tcp_con_lock);
@@ -656,7 +662,9 @@ void sockinfo_tcp::add_tx_ring_to_group()
 
 void sockinfo_tcp::xlio_socket_event(int event, int value)
 {
-    if (is_xlio_socket()) {
+    /* Before accept_cb on accepted children, suppress app events (incl. ERROR): see
+     * m_xlio_app_callbacks_allowed. */
+    if (xlio_app_callbacks_allowed()) {
         /* poll_group::m_socket_event_cb must be always set. */
         m_p_group->m_socket_event_cb(reinterpret_cast<xlio_socket_t>(this), m_xlio_socket_userdata,
                                      event, value);
@@ -702,6 +710,9 @@ err_t sockinfo_tcp::rx_lwip_cb_xlio_socket(void *arg, struct tcp_pcb *pcb, struc
                     conn->save_strq_stats(reinterpret_cast<mem_buf_desc_t *>(ptmp)->rx.strides_num);
                 }
             }
+            // No need to check if conn->xlio_app_callbacks_allowed() allows
+            // the callback. RX packets arrive only after socket is established and
+            // app is aware of it.
             conn->m_p_group->m_socket_rx_cb(reinterpret_cast<xlio_socket_t>(conn),
                                             conn->m_xlio_socket_userdata, ptmp->payload, ptmp->len,
                                             mem_buf_desc_t::to_xlio_buf(ptmp));
@@ -3511,7 +3522,7 @@ sockinfo_tcp *sockinfo_tcp::accept_clone()
             .group = reinterpret_cast<xlio_poll_group_t>(m_p_group),
             .userdata_sq = 0,
         };
-        si->set_xlio_socket(&attr);
+        si->set_xlio_socket(&attr, false /* until accept_cb is called */);
         m_p_group->add_socket(si);
     }
 
@@ -3650,6 +3661,9 @@ bool sockinfo_tcp::wait_for_listen_rss_children_ready()
 void sockinfo_tcp::accept_connection_xlio_socket(sockinfo_tcp *new_sock)
 {
     remove_received_syn_socket(new_sock);
+    // Set this before making the callback, so user can call xlio_socket_attach_group(),
+    // which calls sockinfo_tcp::attach_xlio_group(), from within the callback.
+    new_sock->m_xlio_app_callbacks_allowed = true;
     m_p_group->m_socket_accept_cb(reinterpret_cast<xlio_socket_t>(new_sock),
                                   reinterpret_cast<xlio_socket_t>(this), m_xlio_socket_userdata);
 }
@@ -5791,6 +5805,9 @@ void sockinfo_tcp::tcp_express_zc_callback(mem_buf_desc_t *p_desc)
     const uintptr_t opaque_op = reinterpret_cast<uintptr_t>(p_desc->lwip_pbuf.desc.opaque);
 
     if (opaque_op && si->m_p_group && si->m_p_group->m_socket_comp_cb) {
+        // No need to also check if si->xlio_app_callbacks_allowed() allows
+        // the callback. Completion events can happen only after app has sent data,
+        // hence the app is aware of this socket
         si->m_p_group->m_socket_comp_cb(reinterpret_cast<xlio_socket_t>(si),
                                         si->m_xlio_socket_userdata, opaque_op);
     }

--- a/src/core/sock/sockinfo_tcp.h
+++ b/src/core/sock/sockinfo_tcp.h
@@ -391,7 +391,8 @@ public:
     int tcp_tx_express_inline(const struct iovec *iov, unsigned iov_len, unsigned flags);
     void flush();
     void make_dirty();
-    void set_xlio_socket(const struct xlio_socket_attr *attr);
+    // Sets XLIO socket attributes and status of application callbacks gating
+    void set_xlio_socket(const struct xlio_socket_attr *attr, bool allow_app_callbacks);
     int update_xlio_socket(unsigned flags, uintptr_t userdata_sq);
     void add_tx_ring_to_group();
     int detach_xlio_group();
@@ -421,6 +422,9 @@ private:
     bool prepare_listen_to_close();
     void remove_received_syn_socket(sockinfo_tcp *accepted);
     void accept_connection_xlio_socket(sockinfo_tcp *new_sock);
+    // Returns true if application is aware of this socket (i.e. was created or accepted by the
+    // application).
+    bool xlio_app_callbacks_allowed() const;
 
     // Builds rfs key
     static void create_flow_tuple_key_from_pcb(flow_tuple &key, struct tcp_pcb *pcb);
@@ -613,10 +617,12 @@ private:
     std::atomic<int32_t> m_snd_buf;
     uint32_t m_snd_buf_max;
     sockinfo_tcp *m_parent;
+
     // received packet source (true if its from internal thread)
     bool m_b_incoming;
-    bool m_b_attached;
+    bool m_b_attached; // For socket reuse
     bool m_timer_registered = false;
+
     /* connection state machine */
     int m_conn_timeout;
     /* RCVBUF acconting */
@@ -670,6 +676,10 @@ private:
     bool m_b_xlio_socket_dirty = false;
     uintptr_t m_xlio_socket_userdata = 0;
     rfs_rule *m_p_rule_extracted = nullptr;
+
+    // When false, poll-group event/rx/comp callbacks are suppressed (accepted child before
+    // accept_cb).
+    bool m_xlio_app_callbacks_allowed = false;
 
     mem_buf_desc_t *m_store = nullptr;
     uint32_t m_store_offset = 0;


### PR DESCRIPTION
## Description
Make sure Ultra-API callbacks for Events are made only for sockets which the application is aware of.
An application is aware of sockets it created (i.e. connect(), listen()), and sockets that it learned about using the accept callback.

##### Why ?
The contract between XLIO Ultra API and an application is that the application gets callbacks only of sockets it is aware of.
This way, the app can be sure that when it sets user-data for sockets it creates and sockets it accepts, all callbacks will have a valid user-data value.

##### How ?
Add sockinfo_tcp::m_xlio_app_callbacks_allowed, which is set to true for sockets the application is aware of, set is accordingly and use it to gate callbacks.

## Change type
What kind of change does this PR introduce?
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [X] Code follows the style de facto guidelines of this project
- [X] Comments have been inserted in hard to understand places
- [X] Documentation has been updated (if necessary)
- [X] Test has been added (if possible)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved socket initialization and attachment behavior to more reliably control callback execution timing during socket lifecycle operations, particularly for socket creation, acceptance, and group attachment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->