### PR TITLE
issue: 4977472 Retry tcp_output if unsent stalls with empty unacked

### DIFF
--- a/src/core/lwip/tcp.c
+++ b/src/core/lwip/tcp.c
@@ -679,9 +679,16 @@ void tcp_slowtmr(struct tcp_pcb *pcb)
                                 ("tcp_slowtmr: cwnd %" U16_F " ssthresh %" U16_F "\n", pcb->cwnd,
                                  pcb->ssthresh));
 
-                    /* The following needs to be called AFTER cwnd is set to one
-                       mss - STJ */
+                    /* The following needs to be called AFTER cwnd is set to one mss */
                     tcp_rexmit_rto(pcb);
+                } else if (pcb->unacked == NULL && pcb->rtime >= 0 && pcb->unsent != NULL) {
+                    /* Retry tcp_output() when unsent data is stalled with an empty unacked queue.
+                     * This happens after fast retransmit empties unacked and tcp_output() fails
+                     * to send (e.g. segment split blocked by pbuf ref > 1). Without unacked
+                     * segments, the RTO above cannot fire and TCP progress can stop.
+                     */
+                    pcb->rtime = 0;
+                    tcp_output(pcb);
                 }
             }
         }


### PR DESCRIPTION
## Description
After fast retransmit removes the only segment from the unacked queue, tcp_output() may fail to send the retransmitted segment if it needs splitting and tcp_split_segment() bails out on pbuf ref > 1 (hardware DMA still in progress). This can leave the connection permanently stuck:

 - unacked is NULL, so the RTO check in tcp_slowtmr never fires
 - When ref eventually drops to 1, nothing re-triggers tcp_output()
 - Unless ACK arrives or user calls send() operation, TCP won't progress

Detect this state in the slow timer and retry tcp_output from the timer context. Recovery takes up to slow timer period after the HW TX completion and dropping the pbuf reference count.

##### What
Fix TCP progress stuck after retransmission when the head segment doesn't fit into TCP window and the split fails.

##### Why ?
Bugfix, TCP progress stuck.

## Change type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TCP transmission handling to ensure pending data is retransmitted in edge cases where the standard retry mechanism cannot be triggered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->