### PR TITLE
issue: 4938837 Skip socket event CB for half-open incoming connections

### DIFF
--- a/src/core/sock/sockinfo_tcp.cpp
+++ b/src/core/sock/sockinfo_tcp.cpp
@@ -656,7 +656,11 @@ void sockinfo_tcp::add_tx_ring_to_group()
 
 void sockinfo_tcp::xlio_socket_event(int event, int value)
 {
-    if (is_xlio_socket()) {
+    /* Before accept_cb on accepted children, suppress app events CBs:
+     * m_parent != nullptr means the socket is a "half-open" incoming connection
+     * that hasn't reached the application yet, so we can't notify the app yet.
+     */
+    if (is_xlio_socket() && !m_parent) {
         /* poll_group::m_socket_event_cb must be always set. */
         m_p_group->m_socket_event_cb(reinterpret_cast<xlio_socket_t>(this), m_xlio_socket_userdata,
                                      event, value);


### PR DESCRIPTION
Prevent xlio socket event CB for half-open incoming connections because the application does not know the socket yet, so we can't notify the app about events on the socket.

## Description
Please provide a summary of the change.

##### What
_Subject: what this PR is doing in one line._ 

##### Why ?
_Justification for the PR. If there is existing issue/bug please reference._

##### How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc._

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined socket event handling to prevent callback invocation in specific connection states, improving stability in socket lifecycle management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->