### PR TITLE
issue: 4938837 Ultra API - Call event cb only after accept cb

### DIFF
--- a/src/core/sock/sock-extra.cpp
+++ b/src/core/sock/sock-extra.cpp
@@ -212,6 +212,8 @@ extern "C" int xlio_socket_create(const struct xlio_socket_attr *attr, xlio_sock
         return -1;
     }
     si->set_xlio_socket(attr);
+    // App just created this socket so surely it is aware of it.
+    si->set_xlio_app_callbacks_allowed();
 
     poll_group *grp = reinterpret_cast<poll_group *>(attr->group);
     grp->add_socket(si);

--- a/src/core/sock/sockinfo_tcp.cpp
+++ b/src/core/sock/sockinfo_tcp.cpp
@@ -656,11 +656,8 @@ void sockinfo_tcp::add_tx_ring_to_group()
 
 void sockinfo_tcp::xlio_socket_event(int event, int value)
 {
-    /* Before accept_cb on accepted children, suppress app events CBs:
-     * m_parent != nullptr means the socket is a "half-open" incoming connection
-     * that hasn't reached the application yet, so we can't notify the app yet.
-     */
-    if (is_xlio_socket() && !m_parent) {
+    // Before accept_cb on accepted children, suppress app events CBs
+    if (is_xlio_socket() && is_xlio_app_callbacks_allowed()) {
         /* poll_group::m_socket_event_cb must be always set. */
         m_p_group->m_socket_event_cb(reinterpret_cast<xlio_socket_t>(this), m_xlio_socket_userdata,
                                      event, value);
@@ -3654,6 +3651,7 @@ bool sockinfo_tcp::wait_for_listen_rss_children_ready()
 void sockinfo_tcp::accept_connection_xlio_socket(sockinfo_tcp *new_sock)
 {
     remove_received_syn_socket(new_sock);
+    new_sock->set_xlio_app_callbacks_allowed();
     m_p_group->m_socket_accept_cb(reinterpret_cast<xlio_socket_t>(new_sock),
                                   reinterpret_cast<xlio_socket_t>(this), m_xlio_socket_userdata);
 }
@@ -3920,6 +3918,7 @@ err_t sockinfo_tcp::syn_received_timewait_cb(void *arg, struct tcp_pcb *newpcb)
     new_sock->m_snd_buf = new_sock->m_snd_buf_max;
     new_sock->m_rcvbuff_max = std::max(listen_sock->m_rcvbuff_max, 2 * new_sock->m_pcb.mss);
     new_sock->fit_rcv_wnd(true);
+    new_sock->m_xlio_app_callbacks_allowed = false;
 
     new_sock->register_timer();
 

--- a/src/core/sock/sockinfo_tcp.h
+++ b/src/core/sock/sockinfo_tcp.h
@@ -399,6 +399,8 @@ public:
     void xlio_socket_event(int event, int value);
     static err_t rx_lwip_cb_xlio_socket(void *arg, struct tcp_pcb *tpcb, struct pbuf *p, err_t err);
     static void err_lwip_cb_xlio_socket(void *pcb_container, err_t err);
+    // Ultra-API: Specify that app is aware of this socket and callbacks can be called.
+    void set_xlio_app_callbacks_allowed() { m_xlio_app_callbacks_allowed = true; }
 
 protected:
     void lock_rx_q() override;
@@ -421,6 +423,8 @@ private:
     bool prepare_listen_to_close();
     void remove_received_syn_socket(sockinfo_tcp *accepted);
     void accept_connection_xlio_socket(sockinfo_tcp *new_sock);
+    // Ultra-API: Is app aware of this socket so we can callback on it?
+    bool is_xlio_app_callbacks_allowed() const { return m_xlio_app_callbacks_allowed; }
 
     // Builds rfs key
     static void create_flow_tuple_key_from_pcb(flow_tuple &key, struct tcp_pcb *pcb);
@@ -670,6 +674,10 @@ private:
     bool m_b_xlio_socket_dirty = false;
     uintptr_t m_xlio_socket_userdata = 0;
     rfs_rule *m_p_rule_extracted = nullptr;
+
+    // Ultra-API: When false, poll-group event/rx/comp callbacks are suppressed (Accepted child
+    // before accept_cb).
+    bool m_xlio_app_callbacks_allowed = false;
 
     mem_buf_desc_t *m_store = nullptr;
     uint32_t m_store_offset = 0;


### PR DESCRIPTION
## Description
Gate XLIO poll-group event callbacks until socket is app-visible.

##### What
Make sure Ultra-API callbacks for Events are made only for sockets which the application is aware of.
An application is aware of sockets it created (i.e. connect(), listen()), and sockets that it learned about using the accept callback.

##### How ?
Add sockinfo_tcp::m_xlio_app_callbacks_allowed, which is set to true for sockets the application is aware of, set it accordingly and use it to gate the callback.

## Change type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [x] Code follows the style de facto guidelines of this project
- [x] Comments have been inserted in hard to understand places
- [x] Documentation has been updated (if necessary)
- [x] Test has been added (if possible)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Refined socket event callback handling to ensure callbacks for accepted connections are delivered only at appropriate times during the socket lifecycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->