### PR TITLE
issue: 5006513 Prevent TCP cwnd growth from stalling

### DIFF
--- a/src/core/lwip/cc_lwip.c
+++ b/src/core/lwip/cc_lwip.c
@@ -87,7 +87,13 @@ static void lwip_ack_received(struct tcp_pcb *pcb, uint16_t type)
             }
             LWIP_DEBUGF(TCP_CWND_DEBUG, ("tcp_receive: slow start cwnd %" U32_F "\n", pcb->cwnd));
         } else {
-            u32_t new_cwnd = (pcb->cwnd + ((u32_t)pcb->mss * (u32_t)pcb->mss) / pcb->cwnd);
+            u32_t increment = ((u32_t)pcb->mss * (u32_t)pcb->mss) / pcb->cwnd;
+
+            if (increment == 0) {
+                increment = 1;
+            }
+
+            u32_t new_cwnd = pcb->cwnd + increment;
             if (new_cwnd > pcb->cwnd) {
                 pcb->cwnd = new_cwnd;
             }


### PR DESCRIPTION
## Description
Round the congestion avoidance increment up to one byte when integer division would otherwise produce zero, matching RFC 5681 guidance.

##### What
Prevent TCP congestion window growth from stalling during congestion avoidance.

##### Why ?
RFC 5681 allows `cwnd += SMSS*SMSS/cwnd` during congestion avoidance, but requires rounding up to 1 byte when integer arithmetic would otherwise produce 0. Without this, XLIO can stop growing `cwnd` once `cwnd > SMSS*SMSS`, limiting throughput on high-speed links.

##### How ?
When the congestion-avoidance increment calculation rounds down to 0, force the increment to 1 byte before applying the existing overflow-safe `cwnd` update.

## Change type
What kind of change does this PR introduce?
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

