### PR TITLE
issue: 4724535 Align TCP congestion startup with RFC behavior

### DIFF
--- a/src/core/lwip/cc_cubic.c
+++ b/src/core/lwip/cc_cubic.c
@@ -119,7 +119,10 @@ static void cubic_ack_received(struct tcp_pcb *pcb, uint16_t type)
         /* Use the logic in NewReno ack_received() for slow start. */
         if (pcb->cwnd <= pcb->ssthresh /*||
 		    cubic_data->min_rtt_ticks == 0*/) {
-            pcb->cwnd += pcb->mss;
+            u32_t increase = tcp_calc_slow_start_increment(pcb->acked, pcb->mss);
+            if ((u32_t)(pcb->cwnd + increase) > pcb->cwnd) {
+                pcb->cwnd += increase;
+            }
         } else if (cubic_data->min_rtt_ticks > 0) {
             ticks_since_cong = ticks - cubic_data->t_last_cong;
 
@@ -251,8 +254,8 @@ static void cubic_conn_init(struct tcp_pcb *pcb)
 {
     struct cubic *cubic_data = pcb->cc_data;
 
-    pcb->cwnd = ((pcb->cwnd == 1) ? (pcb->mss * 2) : pcb->mss);
-    pcb->ssthresh = pcb->mss * 3;
+    pcb->cwnd = tcp_calc_initial_cwnd(pcb->mss);
+    pcb->ssthresh = tcp_calc_initial_ssthresh();
     /*
      * Ensure we have a sane initial value for max_cwnd recorded. Without
      * this here bad things happen when entries from the TCP hostcache

--- a/src/core/lwip/cc_lwip.c
+++ b/src/core/lwip/cc_lwip.c
@@ -82,8 +82,9 @@ static void lwip_ack_received(struct tcp_pcb *pcb, uint16_t type)
         }
     } else if (type == CC_ACK) {
         if (pcb->cwnd < pcb->ssthresh) {
-            if ((u32_t)(pcb->cwnd + pcb->mss) > pcb->cwnd) {
-                pcb->cwnd += pcb->mss;
+            u32_t increase = tcp_calc_slow_start_increment(pcb->acked, pcb->mss);
+            if ((u32_t)(pcb->cwnd + increase) > pcb->cwnd) {
+                pcb->cwnd += increase;
             }
             LWIP_DEBUGF(TCP_CWND_DEBUG, ("tcp_receive: slow start cwnd %" U32_F "\n", pcb->cwnd));
         } else {
@@ -136,7 +137,8 @@ static void lwip_post_recovery(struct tcp_pcb *pcb)
 
 static void lwip_conn_init(struct tcp_pcb *pcb)
 {
-    pcb->cwnd = ((pcb->cwnd == 1) ? (pcb->mss * 2) : pcb->mss);
+    pcb->cwnd = tcp_calc_initial_cwnd(pcb->mss);
+    pcb->ssthresh = tcp_calc_initial_ssthresh();
 }
 
 #endif // TCP_CC_ALGO_MOD

--- a/src/core/lwip/tcp.c
+++ b/src/core/lwip/tcp.c
@@ -560,7 +560,7 @@ err_t tcp_connect(struct tcp_pcb *pcb, const ip_addr_t *ipaddr, u16_t port, bool
     pcb->advtsd_mss = tcp_send_mss(pcb);
     pcb->mss = pcb->advtsd_mss;
     pcb->cwnd = 1;
-    pcb->ssthresh = pcb->mss * 10;
+    pcb->ssthresh = tcp_calc_initial_ssthresh();
     pcb->connected = connected;
 
     /* Send a SYN together with the MSS option. */

--- a/src/core/lwip/tcp.h
+++ b/src/core/lwip/tcp.h
@@ -83,6 +83,31 @@ struct tcp_pcb;
 
 extern enum cc_algo_mod lwip_cc_algo_module;
 
+/* RFC 5681 permits an arbitrarily high initial ssthresh; Linux uses an effectively
+ * infinite initial threshold so startup is governed by cwnd, not ssthresh. */
+#define TCP_INITIAL_SSTHRESH ((u32_t)0x7FFFFFFFU)
+
+/* RFC 3390 / upstream lwIP initial window:
+ * min(4 * SMSS, max(2 * SMSS, 4380 bytes)). */
+static inline u32_t tcp_calc_initial_cwnd(u32_t mss)
+{
+    return LWIP_MIN(4U * mss, LWIP_MAX(2U * mss, 4380U));
+}
+
+static inline u32_t tcp_calc_initial_ssthresh(void)
+{
+    return TCP_INITIAL_SSTHRESH;
+}
+
+/* RFC 3465 Appropriate Byte Counting, as implemented by upstream lwIP: cap
+ * slow-start growth from a stretch ACK to at most 2 * SMSS. */
+static inline u32_t tcp_calc_slow_start_increment(u32_t acked, u16_t mss)
+{
+    u32_t max_increment = 2U * (u32_t)mss;
+
+    return LWIP_MIN(acked, max_increment);
+}
+
 /** Function prototype for tcp accept callback functions. Called when a new
  * connection can be accepted on a listening pcb.
  *

--- a/src/core/lwip/tcp_in.c
+++ b/src/core/lwip/tcp_in.c
@@ -579,13 +579,12 @@ static err_t tcp_process(struct tcp_pcb *pcb, tcp_in_data *in_data)
             pcb->mss = LWIP_MIN(pcb->mss, tcp_send_mss(pcb));
 #endif /* TCP_CALCULATE_EFF_SEND_MSS */
 
-            /* Set ssthresh again after changing pcb->mss (already set in tcp_connect
-             * but for the default value of pcb->mss) */
-            pcb->ssthresh = pcb->mss * 10;
+            /* Recalculate after tcp_parseopt/tcp_send_mss may have changed pcb->mss. */
+            pcb->ssthresh = tcp_calc_initial_ssthresh();
 #if TCP_CC_ALGO_MOD
             cc_conn_init(pcb);
 #else
-            pcb->cwnd = ((pcb->cwnd == 1) ? (pcb->mss * 2) : pcb->mss);
+            pcb->cwnd = tcp_calc_initial_cwnd(pcb->mss);
 #endif
             rseg = pcb->unacked;
             pcb->unacked = rseg->next;
@@ -653,7 +652,9 @@ static err_t tcp_process(struct tcp_pcb *pcb, tcp_in_data *in_data)
                 pcb->cwnd = old_cwnd;
                 cc_conn_init(pcb);
 #else
-                pcb->cwnd = ((old_cwnd == 1) ? (pcb->mss * 2) : pcb->mss);
+                LWIP_UNUSED_ARG(old_cwnd);
+                pcb->cwnd = tcp_calc_initial_cwnd(pcb->mss);
+                pcb->ssthresh = tcp_calc_initial_ssthresh();
 #endif
                 if (in_data->recv_flags & TF_GOT_FIN) {
                     tcp_ack_now(pcb);
@@ -1127,8 +1128,9 @@ static void tcp_receive(struct tcp_pcb *pcb, tcp_in_data *in_data)
                 cc_ack_received(pcb, CC_ACK);
 #else
                 if (pcb->cwnd < pcb->ssthresh) {
-                    if ((u32_t)(pcb->cwnd + pcb->mss) > pcb->cwnd) {
-                        pcb->cwnd += pcb->mss;
+                    u32_t increase = tcp_calc_slow_start_increment(pcb->acked, pcb->mss);
+                    if ((u32_t)(pcb->cwnd + increase) > pcb->cwnd) {
+                        pcb->cwnd += increase;
                     }
                     LWIP_DEBUGF(TCP_CWND_DEBUG,
                                 ("tcp_receive: slow start cwnd %" U32_F "\n", pcb->cwnd));

--- a/tests/gtest/Makefile.am
+++ b/tests/gtest/Makefile.am
@@ -100,6 +100,7 @@ gtest_SOURCES = \
 	\
 	tcp/tcp_accept.cc \
 	tcp/tcp_bind.cc \
+	tcp/tcp_cc.cc \
 	tcp/tcp_connect.cc \
 	tcp/tcp_connect_nb.cc \
 	tcp/tcp_event.cc \

--- a/tests/gtest/tcp/tcp_cc.cc
+++ b/tests/gtest/tcp/tcp_cc.cc
@@ -1,0 +1,28 @@
+/*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+ * Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: GPL-2.0-only or BSD-2-Clause
+ */
+
+#include "googletest/include/gtest/gtest.h"
+
+#include "src/core/lwip/tcp.h"
+
+TEST(tcp_cc, initial_cwnd_uses_rfc3390_formula)
+{
+    EXPECT_EQ(4U * 512U, tcp_calc_initial_cwnd(512));
+    EXPECT_EQ(4380U, tcp_calc_initial_cwnd(1460));
+    EXPECT_EQ(2U * 8960U, tcp_calc_initial_cwnd(8960));
+}
+
+TEST(tcp_cc, initial_ssthresh_is_effectively_unlimited)
+{
+    EXPECT_EQ(0x7FFFFFFFU, tcp_calc_initial_ssthresh());
+}
+
+TEST(tcp_cc, slow_start_caps_stretch_ack_to_two_mss)
+{
+    EXPECT_EQ(1460U, tcp_calc_slow_start_increment(1460U, 1460));
+    EXPECT_EQ(2U * 1460U, tcp_calc_slow_start_increment(64U * 1024U, 1460));
+    EXPECT_EQ(100U, tcp_calc_slow_start_increment(100U, 1460));
+}


### PR DESCRIPTION
## Description
Use RFC3390 initial cwnd, effectively unlimited initial ssthresh, and RFC3465 slow-start stretch ACK capping across lwIP and CUBIC paths.

Add gtest coverage for the shared TCP congestion-control helper calculations.

##### What
Align TCP congestion startup with RFC behavior.

##### Why ?
Initial cwnd, initial ssthresh, and slow-start growth should match
RFC3390/RFC5681/RFC3465 behavior and upstream lwIP logic.

##### How ?
Add shared helpers for initial cwnd, initial ssthresh, and slow-start
stretch ACK capping. Use them in lwIP, CUBIC, active-open, and
passive-open TCP paths, with gtest coverage for the helper formulas.

## Change type
What kind of change does this PR introduce?
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

