### PR TITLE
issue: 5020006 Sync stats file after fork for new config

### DIFF
--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -255,10 +255,7 @@ static int free_libxlio_resources()
 
     vlog_stop();
 
-    if (g_stats_file) {
-        fclose(g_stats_file);
-        g_stats_file = nullptr;
-    }
+    close_stats_file();
 
 #if defined(DEFINED_NGINX) || defined(DEFINED_ENVOY)
     if (g_p_app) {

--- a/src/core/sock/sock-redirect.cpp
+++ b/src/core/sock/sock-redirect.cpp
@@ -2321,15 +2321,7 @@ EXPORT_SYMBOL pid_t XLIO_SYMBOL(fork)(void)
         srdr_logdbg_exit("Child Process: starting with %d", getpid());
         g_is_forked_child = false;
 
-        const char *stats_filename = getenv(SYS_VAR_STATS_FILENAME);
-        if (stats_filename && strstr(stats_filename, "%d")) {
-            // Re-open the stats file in case of per-process filename.
-            if (g_stats_file) {
-                fclose(g_stats_file);
-                g_stats_file = nullptr;
-            }
-            open_stats_file();
-        }
+        sync_stats_file_with_config();
         sock_redirect_main();
 
 #if defined(DEFINED_NGINX)

--- a/src/core/util/utils.cpp
+++ b/src/core/util/utils.cpp
@@ -49,6 +49,8 @@ using namespace std;
 #undef MODULE_NAME
 #define MODULE_NAME "utils:"
 
+static string g_stats_file_open_path;
+
 int check_if_regular_file(const char *path)
 {
     static struct stat __sys_st;
@@ -66,17 +68,54 @@ int check_if_regular_file(const char *path)
 
 void open_stats_file()
 {
-    if (*safe_mce_sys().stats_filename) {
-        if (check_if_regular_file(safe_mce_sys().stats_filename)) {
-            vlog_printf(VLOG_WARNING,
-                        "FAILED to create " PRODUCT_NAME
-                        " statistics file. %s is not a regular file.\n",
-                        safe_mce_sys().stats_filename);
-        } else if (!(g_stats_file = fopen(safe_mce_sys().stats_filename, "w"))) {
-            vlog_printf(VLOG_WARNING, "Couldn't open statistics file: %s (errno=%d)\n",
-                        safe_mce_sys().stats_filename, errno);
-        }
+    const char *stats_filename = safe_mce_sys().stats_filename;
+
+    if (stats_filename[0] == '\0') {
+        return;
     }
+
+    if (check_if_regular_file(stats_filename)) {
+        vlog_printf(VLOG_WARNING,
+                    "FAILED to create " PRODUCT_NAME
+                    " statistics file. %s is not a regular file.\n",
+                    stats_filename);
+        return;
+    }
+
+    FILE *stats_file = fopen(stats_filename, "w");
+    if (!stats_file) {
+        vlog_printf(VLOG_WARNING, "Couldn't open statistics file: %s (errno=%d)\n", stats_filename,
+                    errno);
+        return;
+    }
+
+    g_stats_file = stats_file;
+    g_stats_file_open_path = stats_filename;
+}
+
+void close_stats_file()
+{
+    if (g_stats_file) {
+        fclose(g_stats_file);
+        g_stats_file = nullptr;
+    }
+    g_stats_file_open_path.clear();
+}
+
+void sync_stats_file_with_config()
+{
+    const char *stats_filename = safe_mce_sys().stats_filename;
+
+    if (!g_stats_file && stats_filename[0] == '\0') {
+        return;
+    }
+
+    if (g_stats_file && g_stats_file_open_path == stats_filename) {
+        return;
+    }
+
+    close_stats_file();
+    open_stats_file();
 }
 
 int get_sys_max_fd_num(int def_max_fd /*=1024*/)

--- a/src/core/util/utils.h
+++ b/src/core/util/utils.h
@@ -43,6 +43,8 @@
 int check_if_regular_file(const char *path);
 
 void open_stats_file();
+void close_stats_file();
+void sync_stats_file_with_config();
 
 /**
  * L3 and L4 Header Checksum Calculation

--- a/tests/gtest/output/config.cc
+++ b/tests/gtest/output/config.cc
@@ -6,7 +6,9 @@
 
 #include <climits>
 #include <cstdlib>
+#include <dirent.h>
 #include <fstream>
+#include <unistd.h>
 
 #include "common/def.h"
 
@@ -440,4 +442,53 @@ TEST_F(output, config_pid_substitution_new_config)
 
     unlink(config_file.c_str());
     int unused __attribute__((unused)) = system(("rm -rf " + report_dir).c_str());
+}
+
+/**
+ * @test output.config_stats_file_pid_substitution_after_fork_new_config
+ * @brief monitor.stats.file_path with %d is reopened with the child PID after fork.
+ */
+TEST_F(output, config_stats_file_pid_substitution_after_fork_new_config)
+{
+    std::string stats_dir = "/tmp/xlio_test_stats_pid_nc_" + std::to_string(getpid());
+    ASSERT_EQ(system(("mkdir -p " + stats_dir).c_str()), 0) << "Failed to create test directory";
+
+    std::string stats_pattern = "xlio_stats_";
+    std::string config_file = m_prefix + "/stats_pid_test_config.json";
+    {
+        std::ofstream cfg(config_file);
+        cfg << R"({ "monitor": { "stats": { "fd_num": 16, "file_path": ")" << stats_dir << "/"
+            << stats_pattern << R"(%d.log" } } })";
+    }
+
+    std::string cmd = "XLIO_USE_NEW_CONFIG=1 XLIO_CONFIG_FILE=" + config_file +
+        " python3 -c 'import os, socket; s=socket.socket(); pid=os.fork(); "
+        "os._exit(0) if pid == 0 else os.waitpid(pid, 0)' > " +
+        m_output_file + " 2>&1";
+    int rc = system(cmd.c_str());
+    ASSERT_EQ(rc, 0) << "Command failed: " << cmd;
+
+    DIR *dir = opendir(stats_dir.c_str());
+    ASSERT_NE(dir, nullptr) << "Cannot open stats directory: " << stats_dir;
+
+    size_t file_count = 0;
+    while (dirent *entry = readdir(dir)) {
+        std::string filename = entry->d_name;
+        const std::string stats_suffix = ".log";
+        bool is_stats_file = filename.find(stats_pattern) == 0 &&
+            filename.size() >= stats_suffix.size() &&
+            filename.compare(filename.size() - stats_suffix.size(), stats_suffix.size(),
+                             stats_suffix) == 0;
+        if (is_stats_file) {
+            ++file_count;
+            unlink((stats_dir + "/" + filename).c_str());
+        }
+    }
+    closedir(dir);
+
+    ASSERT_EQ(file_count, 2U) << "Expected separate parent and child stats files under "
+                              << stats_dir;
+
+    unlink(config_file.c_str());
+    ASSERT_EQ(0, rmdir(stats_dir.c_str())) << "Failed to remove stats directory: " << stats_dir;
 }


### PR DESCRIPTION
## Description
Track the currently opened stats file path and resync the persistent stats FILE* after fork once child config has been reloaded. This lets monitor.stats.file_path with %d reopen on the child PID path, matching legacy XLIO_STATS_FILE behavior.

Add gtest coverage for JSON-configured stats file PID substitution across fork.

##### What
Fix `monitor.stats.file_path` `%d` PID substitution after fork for new JSON config.

##### Why ?
Issue 5020006. JSON-configured stats paths with `%d` were resolved to the worker PID after fork, but the inherited stats `FILE*` still pointed to the master-opened file. Legacy `XLIO_STATS_FILE` worked because the fork path checked the env var directly, making new config behavior inconsistent.

##### How ?
Track the currently opened stats file path and sync the persistent stats file handle after fork once child config is reloaded. If the resolved configured path differs from the open path, close the inherited file and reopen using the child’s current `safe_mce_sys().stats_filename`. Added gtest coverage for JSON `monitor.stats.file_path` with `%d` across fork.

## Change type
What kind of change does this PR introduce?
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stats file handling during process forking to ensure proper file closure and configuration synchronization.

* **Tests**
  * Added test for stats file behavior with process forking and PID-based filename substitution.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mellanox/libxlio/pull/620)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->