### PR TITLE
issue: 4642229 Update valgrind suppression

### DIFF
--- a/contrib/valgrind/valgrind_xlio.supp
+++ b/contrib/valgrind/valgrind_xlio.supp
@@ -202,7 +202,7 @@
 ###########################################################
 # sockperf
 {
-   sockperf_leak
+   sockperf_free_check
    Memcheck:Free
    fun:free
    fun:_Z9close_ifdiiP8fds_data


### PR DESCRIPTION
The block sockperf_leak is named to suppress memory leaks, but Memcheck:Free matches invalid/mismatching free errors, not leak reports.

## Description
Please provide a summary of the change.

##### What
_Subject: what this PR is doing in one line._ 

##### Why ?
_Justification for the PR. If there is existing issue/bug please reference._

##### How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc._

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

