### PR TITLE
Connect on connected socket assertion fix

### DIFF
--- a/src/core/sock/sockinfo_tcp.cpp
+++ b/src/core/sock/sockinfo_tcp.cpp
@@ -2751,6 +2751,11 @@ int sockinfo_tcp::connect(const sockaddr *__to, socklen_t __tolen)
         return -1;
     }
 
+    if (m_conn_state == TCP_CONN_CONNECTING) {
+        errno = EALREADY;
+        return -1;
+    }
+
     // Calling connect more than once should return error codes
     if (m_sock_state > TCP_SOCK_BOUND) {
         switch (m_sock_state) {


### PR DESCRIPTION
## Description
Fix duplicate TCP connect() handling while a blocking connect is already in progress. 
https://redmine.mellanox.com/issues/4961025

##### What
Return EALREADY when connect() is called again on a socket whose TCP connection is still in TCP_CONN_CONNECTING state.

##### Why ?
Without this check, a second connect() on the same socket could reach lwIP tcp_connect() while the PCB was already no longer in CLOSED state, triggering the lwIP assertion:
tcp_connect: can only connected from state CLOSED

##### How ?
Add an early guard in sockinfo_tcp::connect() to detect m_conn_state == TCP_CONN_CONNECTING and return -1 with errno = EALREADY, matching kernel behavior for duplicate connect() while a connection attempt is already in progress.

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed TCP socket connection handling to properly detect when a connection attempt is made on a socket that is already connecting, and now correctly returns an appropriate error response instead of a generic connection state error, improving network error handling accuracy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mellanox/libxlio/pull/622)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->