### PR TITLE
issue: 5029218 Stabilize UDP null-iov receive timeout

### DIFF
--- a/tests/gtest/udp/udp_send.cc
+++ b/tests/gtest/udp/udp_send.cc
@@ -16,6 +16,10 @@
 
 class udp_send : public udp_base {};
 
+// Keep above XLIO default network.neighbor.arp.uc_delay_msec (10s)
+// so cold/stale neighbor resolution timeout does not race these UDP fork send/recv tests.
+static constexpr int UDP_NEIGHBOR_RESOLUTION_TIMEOUT_SEC = 20;
+
 /**
  * @test udp_send.ti_1
  * @brief
@@ -504,7 +508,7 @@ TEST_F(udp_send, null_iov_elements)
         int fd = udp_base::sock_create();
         EXPECT_LE_ERRNO(0, fd);
         if (0 <= fd) {
-            int rc = set_socket_rcv_timeout(fd, 5);
+            int rc = set_socket_rcv_timeout(fd, UDP_NEIGHBOR_RESOLUTION_TIMEOUT_SEC);
             EXPECT_EQ_ERRNO(0, rc);
 
             rc = bind(fd, &server_addr.addr, sizeof(server_addr));
@@ -603,7 +607,7 @@ TEST_F(udp_send, null_iov_elements_single_iov)
         int fd = udp_base::sock_create();
         EXPECT_LE_ERRNO(0, fd);
         if (0 <= fd) {
-            int rc = set_socket_rcv_timeout(fd, 5);
+            int rc = set_socket_rcv_timeout(fd, UDP_NEIGHBOR_RESOLUTION_TIMEOUT_SEC);
             EXPECT_EQ_ERRNO(0, rc);
 
             rc = bind(fd, &server_addr.addr, sizeof(server_addr));
@@ -723,7 +727,7 @@ TEST_F(udp_send, DISABLED_null_iov_elements_fragmented)
         int fd = udp_base::sock_create();
         EXPECT_LE_ERRNO(0, fd);
         if (0 <= fd) {
-            int rc = set_socket_rcv_timeout(fd, 5);
+            int rc = set_socket_rcv_timeout(fd, UDP_NEIGHBOR_RESOLUTION_TIMEOUT_SEC);
             EXPECT_EQ_ERRNO(0, rc);
 
             rc = bind(fd, &server_addr.addr, sizeof(server_addr));


### PR DESCRIPTION
## Description
udp_send.null_iov_elements can hit a cold or stale XLIO neighbor path where sendmsg() succeeds after queuing data, but delivery waits for neighbor resolution. The old 5 second receive timeout could expire before the queued UDP packet reached the receiver.

Use a named timeout above the default network.neighbor.arp.uc_delay_msec value for the UDP null-iov receive checks.

##### What
Fix sporadic failures of udp_send.null_iov_elements in CI.

##### Why ?
Avoid bot:retest friction.

##### How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc._

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure consistency for UDP communication scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mellanox/libxlio/pull/623)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->