### PR TITLE
[CI] issue: HPCINFRA-4382 Upgrade clang-tools-extra to 21.1.8

### DIFF
--- a/.ci/dockerfiles/Dockerfile.rhel8.6
+++ b/.ci/dockerfiles/Dockerfile.rhel8.6
@@ -18,7 +18,7 @@ FROM core as static
 ARG _LOGIN=svc-nbu-swx-media
 
 RUN yum makecache && \
-    yum install -y yum-utils clang-tools-extra-20.1.8 sudo curl autoconf automake make libtool \
+    yum install -y yum-utils clang-tools-extra-21.1.8 sudo curl autoconf automake make libtool \
     libnl3-devel libnl3 rdma-core-devel rdma-core bc && \
     yum-config-manager --add-repo https://archives.fedoraproject.org/pub/archive/epel/7/x86_64/ && \
     yum --nogpgcheck install -y cppcheck && \

--- a/.ci/matrix_job.yaml
+++ b/.ci/matrix_job.yaml
@@ -93,7 +93,7 @@ runs_on_dockers:
      arch: 'x86_64',
      name: 'xlio_static.csbuild',
      uri: '$arch/$name',
-     tag: '20260427',
+     tag: '20260517',
      build_args: '--no-cache --target static',
      category: 'tool'
     }


### PR DESCRIPTION
## Description
The xlio_static.csbuild image installs clang-tools-extra-20.1.8, which was bumped to a newer version in the RHEL 8 AppStream repo and is no longer available.

##### What
Upgrade clang-tools-extra to 21.1.8

##### Why ?
_Justification for the PR. If there is existing issue/bug please reference._

##### How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc._

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

