### PR TITLE
issue: 5042414 Lower TCP_ULP duplicate log to debug

### DIFF
--- a/src/core/sock/sockinfo_tcp.cpp
+++ b/src/core/sock/sockinfo_tcp.cpp
@@ -4587,7 +4587,7 @@ int sockinfo_tcp::tcp_setsockopt(int __level, int __optname, __const void *__opt
                     }
                     ops = dynamic_cast<sockinfo_tcp_ops_tls *>(m_ops);
                     if (ops) {
-                        si_tcp_loginfo("(TCP_ULP) val: tls, ULP is already TLS");
+                        si_tcp_logdbg("(TCP_ULP) val: tls, ULP is already TLS");
                         errno = EEXIST;
                         ret = -1;
                         break;


### PR DESCRIPTION
OpenSSL 3.3.6+ sets TCP_ULP twice (RX/TX). The duplicate call is expected; demote the "ULP is already TLS" message from INFO to DEBUG.

## Description
Please provide a summary of the change.

##### What
_Subject: what this PR is doing in one line._ 

##### Why ?
_Justification for the PR. If there is existing issue/bug please reference._

##### How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc._

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

