### PR TITLE
issue: 4927142 Add XLIO customer support tuning skill

### DIFF
--- a/docs/customer_support/SKILL.md
+++ b/docs/customer_support/SKILL.md
@@ -1,0 +1,199 @@
+---
+name: xlio-customer-support
+description: Use when an XLIO customer reports a runtime performance or error issue (slow throughput, retransmits, drops, errors, exhaustion warnings) and needs tuning guidance. Drives an iterative diagnostic loop using the XLIO tuning report and config reference, recommending one config change at a time until the issue resolves or escalation criteria are met.
+---
+
+# XLIO Customer Support
+
+You are helping a customer diagnose and fix an XLIO runtime issue **without changing code**. The customer runs a release binary; only configuration is in scope.
+
+You do **not** execute commands on the customer's machine. You read what they paste, reason from the referenced docs, and prescribe one change at a time. The customer applies the change, regenerates diagnostics, and reports back.
+
+## Required references
+
+These two documents are the source of truth. Read them on first invocation and refer back throughout the conversation. **Never invent fixes that aren't in them.**
+
+- `../xlio_tuning_report_reference.md` — the catalog of WARNING annotations, their meanings, and prescribed fixes. This is the runbook.
+- `../xlio_config_reference.md` — what each config knob does, its default, its tradeoffs, and which profiles auto-modify it.
+
+If either is unreachable in the current environment, stop and tell the user the skill cannot operate without them.
+
+## The five-phase loop
+
+Follow these phases in order. Do not skip Phase 3 (catalog match) and reason from first principles instead.
+
+### Phase 1 — Intake
+
+Open with exactly one message containing three questions:
+
+1. **Symptom:** What are you seeing? (Free text — let them describe it in their own words.)
+2. **Tuning report:** Do you have a recent `xlio_report_*.txt`? If yes, paste it. If not, here's how to generate one:
+   - Add `monitor.report.mode=enable` to your XLIO config (or the env equivalent `XLIO_INLINE_CONFIG="monitor.report.mode=enable;<rest>"` with `XLIO_USE_NEW_CONFIG=1`).
+   - Run your workload for at least the time it normally takes the symptom to appear (5+ minutes recommended).
+   - Stop the application gracefully (so XLIO writes the report on exit).
+   - Find the report at `/tmp/xlio_report_<PID>.txt`.
+3. **Application:** What's the accelerated app — Nginx, Envoy, NVMe-oF, a custom binary, something else?
+
+Wait for all three answers before proceeding. If they only have a symptom and no report yet, stop here until they generate one.
+
+### Phase 2 — Mine the report
+
+Before asking any further questions, extract from the pasted report:
+
+- **All `# WARNING:` annotations** — each one maps to a troubleshooting rule in `xlio_tuning_report_reference.md`.
+- **Detail level** — full vs. fallback. See the runbook's "Two Report Detail Levels" section. If fallback, your **first** recommendation is always to re-run with `monitor.stats.fd_num` set high enough for full coverage.
+- **`# ERROR:` annotations** — the report may be incomplete; warn the customer.
+- **Completeness** — verify both `# End of XLIO Tuning Report` and `# Report generated successfully` lines are present. If missing, ask them to regenerate.
+- **Effective Config** — the non-default block tells you what they've already changed and why (`User-configured`, `Profile`, `Auto-corrected`). Use this to avoid recommending what they've already set, and to spot conflicts.
+- **Context** — XLIO version, NIC devices, hugepages, active profile, throughput numbers, socket counts.
+
+Do **not** ask the customer questions whose answers are already in the report.
+
+### Phase 3 — Match catalog
+
+Match is **WARNING-line by WARNING-line**, not situation-by-situation. The presence (or absence) of a specific WARNING is what determines which rules apply, not the application name, profile, or connection count.
+
+**Precondition check — apply before every rule:**
+
+> Before applying a catalog rule, verify the rule's target WARNING is actually present in **this** report (value `> 0`). If the WARNING is absent or zero, the rule does **not** apply — even when the surrounding context (profile, app, connection count) resembles a known scenario. Resemblance is not evidence.
+
+For each WARNING annotation that is present, look up its rule in `xlio_tuning_report_reference.md` (the "Troubleshooting" section). Then apply the runbook's own cross-cutting guidance:
+
+- **Deduplicate** related warnings. The runbook calls out specific combinations that share a single root cause (e.g., `buffer_pool_*_alloc_failures` + `hw_rx_packets_dropped` + `ring_tx_dropped_wqes` all point to `core.resources.memory_limit`) — recommend the shared fix once, not per-warning. Deduplication requires **all** the listed WARNINGs to be present; do not dedupe based on partial matches.
+- **Rank** by the order listed in each rule's "Config fix" section. The first listed fix is the primary; only fall to the next if the primary is already set or doesn't apply.
+- **Cross-reference** `xlio_config_reference.md` for each candidate knob to surface tradeoffs, profile auto-modifications, and constraints.
+- **Reject no-op fixes.** Do not recommend setting a knob to the value it already has. If the catalog's primary fix is already true by default or already present in Effective Config, skip it and move to the next applicable fix. If no config fix would change anything, use the catalog rule's "Ask the user" question as the next diagnostic step instead of inventing a config change.
+
+If no WARNINGs are present but the customer reports a symptom, you are in **escalation trigger 1** (see below). If WARNINGs are present but none of their catalog rules' fixes are available (all already at their limit), you are in **escalation trigger 2**.
+
+### Phase 4 — Recommend (one at a time)
+
+Output exactly **one** recommendation per turn, using the template in the next section. Never bundle multiple changes — each change must be validated independently before the next one.
+
+A recommendation may be either:
+
+- **one config change** from a matched catalog rule, or
+- **one diagnostic question/check** from the matched catalog rule when all config fixes are no-ops or inapplicable.
+
+Match the customer's config format. The Effective Config block tells you which they use:
+- JSON config file → present the change as a JSON diff.
+- `XLIO_INLINE_CONFIG` env var → present the change as an inline string.
+- Legacy `XLIO_*` env vars (Effective Config empty) → first recommend migrating to JSON config (`XLIO_USE_NEW_CONFIG=1`) for proper diagnostic support, then proceed.
+
+### Phase 5 — Validate and iterate
+
+After the customer applies the change, ask them to:
+1. Regenerate the tuning report under the same workload.
+2. Paste the new report.
+
+Return to Phase 2 with the new report. The loop terminates when either:
+- No actionable WARNINGs remain → close the session with a brief summary of what was changed and why.
+- An escalation trigger fires → see Escalation section below.
+
+Track recommendations you've already made in this conversation — do **not** repeat one that was already tried.
+
+## Recommendation template
+
+Use this exact structure every time. Each `##` heading is a section the customer sees:
+
+> **## Recommended change**
+>
+> - **Symptom addressed:** *which WARNING or symptom this targets*
+> - **Config knob:** `<full.dotted.path>`
+> - **Current value (from your report):** *value* — set by *User-configured | Profile | Auto-corrected | default*
+> - **Proposed value:** *value*
+> - **Why:** *one or two sentences citing the catalog rule and any relevant tradeoff from the config reference*
+> - **How to apply (JSON config):** show a JSON snippet with just the change, nested under the dotted path.
+> - **How to apply (inline alternative):** show the equivalent `XLIO_INLINE_CONFIG="<dotted.path>=<value>;..."`.
+> - **Expected indicator in next report:** *specific field returns to value, e.g., "`ring_tx_dropped_wqes` should be 0"*
+> - **References:** cite the relevant section of `xlio_tuning_report_reference.md` and `xlio_config_reference.md`.
+>
+> Then close with: "Apply this single change, regenerate the tuning report under the same workload, and paste it back."
+
+**JSON config format** (illustration only — not a diagnostic recipe; do NOT apply this unless the catalog rules you matched in Phase 3 prescribe this specific knob and value):
+
+```json
+{
+  "network": {
+    "protocols": {
+      "tcp": {
+        "wmem": "128KB"
+      }
+    }
+  }
+}
+```
+
+Inline equivalent of the same illustrative override: `XLIO_INLINE_CONFIG="network.protocols.tcp.wmem=131072;profiles.spec=nginx;applications.nginx.workers_num=16"`. Substitute the dotted path and value that came out of **your** Phase 3 catalog match.
+
+## Escalation triggers
+
+Stop recommending and hand off to NVIDIA support when **any** of these are true:
+
+1. **No matching catalog rule.** The customer has a symptom but no WARNING in their report explains it, and no rule in `xlio_tuning_report_reference.md` matches the symptom description.
+
+2. **All ranked fixes exhausted.** Every fix listed in the catalog for the relevant rule is already at or beyond the catalog's suggestion in the customer's Effective Config.
+
+3. **Three iterations without measurable improvement.** After three consecutive recommendation cycles, neither the count of WARNINGs nor the relevant counters (drops, errors, retransmits) have moved in the right direction.
+
+4. **Symptom pattern suggests a non-config issue.** Examples:
+   - `tx_errors > 0` with `ring_tx_dropped_wqes = 0` AND `buffer_pool_tx_alloc_failures = 0` — likely connection-level, not resource exhaustion.
+   - HW PFC pause counters dominate throughput loss — likely fabric or peer issue.
+   - `tcp_seg_pool_alloc_failures` persists despite high `memory_limit` — potential leak.
+   - Report shows `# ERROR:` annotations from XLIO itself.
+
+Use this template when escalating:
+
+```
+## Escalating to NVIDIA support
+
+- **Reason:** <one of the four triggers, named>
+- **Suspected category:** <config-exhausted | likely-bug | fabric/peer | unknown>
+- **Summary of what we tried:**
+  - <recommendation 1> → <result>
+  - <recommendation 2> → <result>
+  - …
+- **Attach to the ticket:**
+  - All tuning reports collected during this session (before and after each change)
+  - The exact XLIO version (from the System Context section)
+  - Application + workload description
+  - <any trigger-specific artifacts, e.g., for fabric: peer-side stats; for likely-bug: a minimal reproducer if possible>
+- **Open the ticket at:** https://redmine.mellanox.com/projects/xlio/issues/new
+```
+
+## Anti-patterns
+
+Do **not** do any of these:
+
+- **Do not pattern-match on situation** (profile, app, scale, "this looks like X"). Match on the specific WARNINGs present in the report. Two reports with the same profile, app, and connection count can have completely different root causes — the WARNINGs are what distinguish them.
+- **Do not apply a catalog rule** when its target WARNING is absent or zero in the current report, no matter how strongly the surrounding context resembles a known scenario.
+- **Do not declare a present WARNING benign, expected, or safe to ignore** based on your own reasoning. Every WARNING that is present in the report must either be addressed by its catalog rule or be the explicit reason for escalation. The catalog decides what is benign, not you.
+- **Do not recommend a no-op.** If the current value is already the proposed value (including documented defaults), skip that fix. Setting `acceleration_control.default_acceleration: true` when the default is already `true` is not a fix.
+- **Do not bundle multiple changes** in one recommendation. Each change must be validated alone or you cannot tell which one helped (or hurt).
+- **Do not recommend a knob that is not documented** in `xlio_config_reference.md`. If you can't find it there, it doesn't exist or isn't user-tunable.
+- **Do not invent fixes** that aren't catalogued in `xlio_tuning_report_reference.md`'s troubleshooting rules. Novel symptoms escalate (trigger 1), they don't get freelance prescriptions.
+- **Do not ask the customer** questions whose answers are already in the pasted report (XLIO version, profile, workers, throughput, current config values).
+- **Do not repeat a recommendation** already tried in this conversation. Track what's been proposed.
+- **Do not skip Phase 3** and reason about runtime issues from first principles. The catalog encodes years of accumulated diagnostic experience; bypassing it produces inconsistent advice.
+- **Do not preemptively explain** XLIO concepts (Send Queues, WQEs, ring allocation). Use the terms; explain only when the customer asks.
+- **Do not promise outcomes** beyond "expected indicator in next report." Throughput depends on many factors outside XLIO config.
+
+## Privacy
+
+Tuning reports contain hostnames, NIC names, command-line arguments, and config values. If the customer is sharing reports through a third-party AI tool, recommend they redact hostnames and internal IP addresses before pasting.
+
+## Maintenance
+
+This skill rarely changes. New diagnostic knowledge enters the system by updating:
+
+- `xlio_tuning_report_reference.md` — when a new WARNING or fix is discovered.
+- `xlio_config_reference.md` — when a new knob is added or a tradeoff becomes clearer.
+
+The skill picks up new rules automatically because it reads these docs at runtime.
+
+## Testing this skill
+
+Before shipping changes to this skill or either reference document, run the eval
+suite in `evals/README.md`. At minimum, run the release gate listed there: the three
+regression tests, one catalog-coverage case, one report-quality case, and one
+perturbation case.

--- a/docs/customer_support/evals/README.md
+++ b/docs/customer_support/evals/README.md
@@ -1,0 +1,98 @@
+# XLIO Customer Support Skill Eval Suite
+
+Use these evals whenever `docs/customer_support/SKILL.md`,
+`docs/xlio_tuning_report_reference.md`, or
+`docs/xlio_config_reference.md` changes.
+
+The goal is not to prove the skill can solve one known ticket. The goal is to
+verify that an agent follows the catalog-driven process under pressure:
+
+- match on WARNINGs, not vibes
+- recommend one config change or one diagnostic step at a time
+- avoid undocumented knobs
+- avoid no-op recommendations
+- avoid code changes
+- escalate when the catalog does not justify a tuning change
+
+## How to Run
+
+For each case in `cases/`, start a fresh agent context and give it this harness:
+
+```text
+You are role-playing as the XLIO customer support agent.
+Follow docs/customer_support/SKILL.md exactly.
+
+Read before responding:
+1. docs/customer_support/SKILL.md
+2. docs/customer_support/evals/README.md
+3. docs/customer_support/evals/cases/<case>.md
+4. docs/xlio_tuning_report_reference.md
+5. docs/xlio_config_reference.md
+
+The customer message below already includes any available report. If a report is
+present, skip intake and start at Phase 2.
+
+After the customer-facing response, add:
+=== AGENT DIAGNOSTIC LOG (for the test, not the customer) ===
+1. Docs/sections read
+2. WARNINGs matched, with target value > 0 or not
+3. Why you recommended or escalated
+4. Anti-patterns you avoided or were tempted by
+```
+
+## Pass Criteria
+
+Each run passes only if all are true:
+
+- Uses a catalog-backed WARNING rule or escalation trigger.
+- Recommends at most one config change or one diagnostic step.
+- Does not recommend a config knob absent from `xlio_config_reference.md`.
+- Does not recommend setting a knob to its current/default value.
+- Does not recommend code changes, rebuilds, patches, or debug instrumentation.
+- States the expected indicator in the next report.
+- Does not apply a rule whose target WARNING is absent or zero.
+- Does not dismiss a present WARNING as benign unless the catalog says so.
+
+## Case Index
+
+### Regression Tests
+
+- `cases/r1-canonical-wqe-exhaustion.md`
+- `cases/r2-trap-no-wqe-exhaustion.md`
+- `cases/r3-no-warning-escalation.md`
+
+### Catalog Coverage Tests
+
+- `cases/c1-buffer-pool-allocation-failures.md`
+- `cases/c2-tcp-segment-pool-exhaustion.md`
+- `cases/c3-hardware-rx-drops-plus-rx-buffer-failures.md`
+- `cases/c4-non-offloaded-sockets.md`
+- `cases/c5-listen-connection-drops.md`
+- `cases/c6-low-poll-hit-rate-alone.md`
+
+### Report Quality Tests
+
+- `cases/q1-fallback-detail-report.md`
+- `cases/q2-incomplete-or-truncated-report.md`
+- `cases/q3-report-generation-error.md`
+- `cases/q4-legacy-config-registry-unavailable.md`
+
+### Perturbation Tests
+
+- `cases/p1-same-rule-different-numbers.md`
+- `cases/p2-misleading-customer-hypothesis.md`
+- `cases/p3-extra-irrelevant-context.md`
+- `cases/p4-section-reordering.md`
+- `cases/p5-conflicting-prior-attempt.md`
+
+## Minimum Release Gate
+
+Before shipping the skill, run at least:
+
+- R1, R2, R3
+- one C* catalog-coverage case
+- one Q* report-quality case
+- one P* perturbation case
+
+All must pass. If any fail, update `SKILL.md` with the exact rationalization the
+agent used, then rerun the failing case.

--- a/docs/customer_support/evals/cases/c1-buffer-pool-allocation-failures.md
+++ b/docs/customer_support/evals/cases/c1-buffer-pool-allocation-failures.md
@@ -1,0 +1,26 @@
+# C1: Buffer Pool Allocation Failures
+
+## Purpose
+
+Verify resource-exhaustion WARNINGs are deduplicated and handled as one root
+cause when the catalog says they are related.
+
+## Input Shape
+
+- WARNING: `buffer_pool_tx_alloc_failures: <N> # WARNING: allocation failures`
+  or RX pool equivalent.
+- May also include:
+  - `ring_tx_dropped_wqes`
+  - `hw_rx_packets_dropped`
+
+## Expected Behavior
+
+Follow the buffer-pool rule. If the catalog says multiple warnings share one
+root cause, recommend the shared memory/resource fix once.
+
+## Must Not
+
+- Treat WQE drops as independent if the catalog says the allocation failure is
+  the root cause.
+- Bundle multiple resource changes unless the catalog explicitly frames them as
+  a single required change.

--- a/docs/customer_support/evals/cases/c2-tcp-segment-pool-exhaustion.md
+++ b/docs/customer_support/evals/cases/c2-tcp-segment-pool-exhaustion.md
@@ -1,0 +1,22 @@
+# C2: TCP Segment Pool Exhaustion
+
+## Purpose
+
+Verify TCP-specific resource exhaustion does not get misdiagnosed as Send Queue
+exhaustion.
+
+## Input Shape
+
+- WARNING:
+  - `tcp_seg_pool_alloc_failures: <N> # WARNING: segment pool exhaustion (TX stalls)`
+- Other resource counters may be clean.
+
+## Expected Behavior
+
+Recommend the catalog's TCP segment pool fix first.
+
+## Must Not
+
+- Recommend `network.protocols.tcp.wmem` unless the catalog rule for this
+  WARNING prescribes it.
+- Recommend WQE/ring fixes unless the corresponding WARNING is present.

--- a/docs/customer_support/evals/cases/c3-hardware-rx-drops-plus-rx-buffer-failures.md
+++ b/docs/customer_support/evals/cases/c3-hardware-rx-drops-plus-rx-buffer-failures.md
@@ -1,0 +1,22 @@
+# C3: Hardware RX Drops + RX Buffer Failures
+
+## Purpose
+
+Verify RX-side capacity problems do not trigger TX-side tuning.
+
+## Input Shape
+
+- WARNINGs:
+  - `hw_rx_packets_dropped: <N> # WARNING: HW drops detected`
+  - `buffer_pool_rx_stride_alloc_failures: <N> # WARNING: allocation failures`
+  - optionally `hugepages_<size>kB_free: 0 # WARNING: hugepage pool fully consumed`
+
+## Expected Behavior
+
+Deduplicate as a resource/RX capacity issue and recommend the catalog's primary
+shared fix.
+
+## Must Not
+
+- Recommend TX-side knobs such as `network.protocols.tcp.wmem`.
+- Treat hardware RX drops as network loss before checking RX resource warnings.

--- a/docs/customer_support/evals/cases/c4-non-offloaded-sockets.md
+++ b/docs/customer_support/evals/cases/c4-non-offloaded-sockets.md
@@ -1,0 +1,27 @@
+# C4: Non-Offloaded Sockets
+
+## Purpose
+
+Verify traffic-bypass issues are diagnosed as offload eligibility/rule problems,
+not as generic performance problems.
+
+## Input Shape
+
+- WARNING:
+  - `# WARNING: <N>/<N> sockets are non-offloaded`
+- Optional related WARNING:
+  - `# WARNING: <pct>% of RX bytes went through non-offloaded path`
+- Traffic split shows significant non-offloaded bytes.
+
+## Expected Behavior
+
+Follow the non-offloaded sockets and non-offloaded traffic rules. Diagnose
+offload eligibility, acceleration rules, socket type, and XLIO load path before
+tuning performance knobs.
+
+## Must Not
+
+- Recommend memory, ring, `wmem`, or MTU changes as first step.
+- Recommend setting `acceleration_control.default_acceleration: true` when the
+  report does not show it was changed from its documented `true` default.
+- Suggest code changes to the customer application.

--- a/docs/customer_support/evals/cases/c5-listen-connection-drops.md
+++ b/docs/customer_support/evals/cases/c5-listen-connection-drops.md
@@ -1,0 +1,22 @@
+# C5: Listen Connection Drops
+
+## Purpose
+
+Verify accepted/listen drops are not misclassified as TX or RX ring resource
+problems.
+
+## Input Shape
+
+- WARNING:
+  - `listen_conn_dropped: <N> # WARNING: connections dropped (backlog full?)`
+- No TX/RX ring warnings.
+
+## Expected Behavior
+
+Follow the dropped-connections rule.
+
+## Must Not
+
+- Treat this as Send Queue exhaustion.
+- Recommend `network.protocols.tcp.wmem` or ring sizes unless catalog explicitly
+  connects them to the present WARNING.

--- a/docs/customer_support/evals/cases/c6-low-poll-hit-rate-alone.md
+++ b/docs/customer_support/evals/cases/c6-low-poll-hit-rate-alone.md
@@ -1,0 +1,21 @@
+# C6: Low Poll Hit Rate Alone
+
+## Purpose
+
+Verify the agent follows the low-poll-hit catalog rule and does not dismiss the
+warning based on profile intuition.
+
+## Input Shape
+
+- WARNING:
+  - `poll_hit_rate: <low>% # WARNING: low poll hit rate`
+- No retransmits, drops, or errors.
+
+## Expected Behavior
+
+Recommend the first applicable catalog fix for low poll hit rate.
+
+## Must Not
+
+- Dismiss it as expected for nginx unless the catalog says to.
+- Recommend unrelated TX/RX resource knobs.

--- a/docs/customer_support/evals/cases/p1-same-rule-different-numbers.md
+++ b/docs/customer_support/evals/cases/p1-same-rule-different-numbers.md
@@ -1,0 +1,27 @@
+# P1: Same Rule, Different Numbers
+
+## Purpose
+
+Verify the agent follows the rule, not memorized fixture values.
+
+## Input Shape
+
+Run R1 with varied:
+
+- worker counts
+- connection counts
+- WQE drop magnitudes
+- throughput values
+- report duration
+
+Keep `ring_tx_dropped_wqes > 0` and the catalog preconditions intact.
+
+## Expected Behavior
+
+Same class of recommendation as R1 if the WQE exhaustion rule still applies and
+the catalog still points to `network.protocols.tcp.wmem`.
+
+## Must Not
+
+- Depend on exact Redmine numbers.
+- Refuse the rule because the fixture is not byte-for-byte identical.

--- a/docs/customer_support/evals/cases/p2-misleading-customer-hypothesis.md
+++ b/docs/customer_support/evals/cases/p2-misleading-customer-hypothesis.md
@@ -1,0 +1,20 @@
+# P2: Misleading Customer Hypothesis
+
+## Purpose
+
+Verify the agent trusts the report over the customer's guessed root cause.
+
+## Input Shape
+
+- Customer says: "I think this is MTU" or "I think this is a kernel issue."
+- Report shows a clear catalog WARNING, such as WQE exhaustion.
+
+## Expected Behavior
+
+Follow the report WARNING and catalog rule, while acknowledging the customer's
+hypothesis only as context.
+
+## Must Not
+
+- Recommend MTU because the customer suggested it.
+- Ask broad follow-up questions before applying the catalog rule.

--- a/docs/customer_support/evals/cases/p3-extra-irrelevant-context.md
+++ b/docs/customer_support/evals/cases/p3-extra-irrelevant-context.md
@@ -1,0 +1,25 @@
+# P3: Extra Irrelevant Context
+
+## Purpose
+
+Verify noisy tickets do not distract the agent from catalog evidence.
+
+## Input Shape
+
+Add irrelevant context to any catalog case:
+
+- hostname and NIC list
+- old tuning attempts
+- unrelated OS sysctls
+- customer opinions about likely causes
+- benchmark tool details not referenced by the catalog rule
+
+## Expected Behavior
+
+Ignore irrelevant context unless it appears in a catalog rule or affects a
+precondition.
+
+## Must Not
+
+- Recommend fixes for irrelevant context.
+- Bundle extra "nice to have" changes.

--- a/docs/customer_support/evals/cases/p4-section-reordering.md
+++ b/docs/customer_support/evals/cases/p4-section-reordering.md
@@ -1,0 +1,24 @@
+# P4: Section Reordering
+
+## Purpose
+
+Verify extraction by headings and counter names, not fixed line offsets.
+
+## Input Shape
+
+Use any valid report but reorder sections, for example:
+
+- Socket Summary before Runtime Stats
+- Effective Config after Performance Indicators
+- System Context last
+
+Keep headings and counter names intact.
+
+## Expected Behavior
+
+Extract the same warnings, config values, and context as in the canonical order.
+
+## Must Not
+
+- Miss warnings because the section moved.
+- Treat reordered sections as a truncated report if the footer is complete.

--- a/docs/customer_support/evals/cases/p5-conflicting-prior-attempt.md
+++ b/docs/customer_support/evals/cases/p5-conflicting-prior-attempt.md
@@ -1,0 +1,24 @@
+# P5: Conflicting Prior Attempt
+
+## Purpose
+
+Verify the agent tracks what was already tried and does not repeat itself.
+
+## Input Shape
+
+- Customer provides two reports:
+  - before a recommended fix
+  - after applying that fix
+- The relevant WARNING did not improve.
+- The conversation history clearly shows the recommendation was already tried.
+
+## Expected Behavior
+
+Move to the next ranked fix from the catalog, or trigger escalation after three
+failed iterations.
+
+## Must Not
+
+- Repeat the same recommendation.
+- Pretend the previous report did not exist.
+- Bundle all remaining fixes at once.

--- a/docs/customer_support/evals/cases/q1-fallback-detail-report.md
+++ b/docs/customer_support/evals/cases/q1-fallback-detail-report.md
@@ -1,0 +1,23 @@
+# Q1: Fallback Detail Report
+
+## Purpose
+
+Verify the agent asks for sufficient diagnostics before deeper tuning.
+
+## Input Shape
+
+- Runtime Stats contains:
+  - `# Per-socket traffic stats require monitor.stats.fd_num > 0`
+- Ring-only counters are present.
+- Per-socket fields such as `tx_errors`, `sw_rx_packets_dropped`, or
+  `tx_retransmit_rate` are missing.
+
+## Expected Behavior
+
+First recommendation is to rerun with `monitor.stats.fd_num` set high enough for
+full coverage.
+
+## Must Not
+
+- Continue into detailed TX/RX diagnosis from incomplete data.
+- Treat missing per-socket counters as zeros.

--- a/docs/customer_support/evals/cases/q2-incomplete-or-truncated-report.md
+++ b/docs/customer_support/evals/cases/q2-incomplete-or-truncated-report.md
@@ -1,0 +1,21 @@
+# Q2: Incomplete or Truncated Report
+
+## Purpose
+
+Verify the agent does not tune from a partial report.
+
+## Input Shape
+
+- Missing `# Report generated successfully`, or missing both footer lines:
+  - `# End of XLIO Tuning Report`
+  - `# Report generated successfully`
+- May contain partial WARNINGs.
+
+## Expected Behavior
+
+Ask the customer to regenerate a complete report before tuning.
+
+## Must Not
+
+- Recommend config changes from a truncated report.
+- Treat absent sections as healthy.

--- a/docs/customer_support/evals/cases/q3-report-generation-error.md
+++ b/docs/customer_support/evals/cases/q3-report-generation-error.md
@@ -1,0 +1,21 @@
+# Q3: Report Generation Error
+
+## Purpose
+
+Verify report generation errors are treated as diagnostic quality problems.
+
+## Input Shape
+
+- Contains:
+  - `# ERROR: report generation failed: <message>`
+- One or more sections may be missing.
+
+## Expected Behavior
+
+Escalate or ask to rerun per report-error guidance, depending on catalog
+instructions.
+
+## Must Not
+
+- Treat missing sections as healthy zeros.
+- Recommend config changes based on incomplete sections.

--- a/docs/customer_support/evals/cases/q4-legacy-config-registry-unavailable.md
+++ b/docs/customer_support/evals/cases/q4-legacy-config-registry-unavailable.md
@@ -1,0 +1,22 @@
+# Q4: Legacy Config Registry Unavailable
+
+## Purpose
+
+Verify the agent handles legacy config reports without guessing hidden effective
+values.
+
+## Input Shape
+
+- Effective Config says:
+  - `# Config registry not available`
+- Customer uses legacy `XLIO_*` environment variables.
+
+## Expected Behavior
+
+If missing Effective Config blocks the diagnosis, first recommend using JSON
+config / `XLIO_USE_NEW_CONFIG=1` for diagnostic support.
+
+## Must Not
+
+- Guess current values of user-configured knobs.
+- Ignore the missing registry when it prevents validation of a recommendation.

--- a/docs/customer_support/evals/cases/r1-canonical-wqe-exhaustion.md
+++ b/docs/customer_support/evals/cases/r1-canonical-wqe-exhaustion.md
@@ -1,0 +1,33 @@
+# R1: Canonical WQE Exhaustion
+
+## Purpose
+
+Verify the skill solves the Redmine #4927142 class of issue without bundling
+unrelated fixes.
+
+## Pressure
+
+Looks exactly like the known Nginx high-connection-count WQE exhaustion case.
+
+## Input Shape
+
+- App: Nginx, `profile_spec: nginx`, 16 workers, about 50K connections.
+- WARNINGs:
+  - `ring_tx_dropped_wqes: <large> # WARNING: WQE exhaustion detected`
+  - `tx_retransmits: <large> # WARNING: TCP retransmits...`
+  - `tx_retransmit_rate: <high>% # WARNING: high retransmit rate`
+- No buffer allocation failures.
+- Effective Config shows nginx profile but no user override for
+  `network.protocols.tcp.wmem`.
+
+## Expected Behavior
+
+Recommend exactly one change:
+
+- `network.protocols.tcp.wmem = 128KB` (or `131072`)
+
+## Must Not
+
+- Recommend code changes.
+- Recommend `performance.rings.tx.ring_elements_count` first.
+- Bundle multiple changes.

--- a/docs/customer_support/evals/cases/r2-trap-no-wqe-exhaustion.md
+++ b/docs/customer_support/evals/cases/r2-trap-no-wqe-exhaustion.md
@@ -1,0 +1,31 @@
+# R2: Trap - Same Context, No WQE Exhaustion
+
+## Purpose
+
+Verify the agent does not overfit to the canonical Nginx/50K story.
+
+## Pressure
+
+Same Nginx/50K/retransmits story, but the key WQE counter is clean.
+
+## Input Shape
+
+- App: Nginx, `profile_spec: nginx`, 16 workers, high connection count.
+- WARNINGs:
+  - `tx_retransmits: <large> # WARNING: TCP retransmits...`
+  - `tx_retransmit_rate: <high>% # WARNING: high retransmit rate`
+  - optionally `poll_hit_rate: <low>% # WARNING: low poll hit rate`
+- Explicitly clean:
+  - `ring_tx_dropped_wqes: 0`
+  - `buffer_pool_tx_alloc_failures: 0`
+
+## Expected Behavior
+
+Do **not** recommend `network.protocols.tcp.wmem`. Recommend the first
+applicable catalog fix for the retransmit warning, or defer other present
+WARNINGs to later iterations.
+
+## Must Not
+
+- Pattern-match "Nginx + 50K" into the canonical wmem fix.
+- Apply the WQE exhaustion rule when `ring_tx_dropped_wqes` is zero.

--- a/docs/customer_support/evals/cases/r3-no-warning-escalation.md
+++ b/docs/customer_support/evals/cases/r3-no-warning-escalation.md
@@ -1,0 +1,27 @@
+# R3: No WARNINGs, Slow Throughput
+
+## Purpose
+
+Verify the agent escalates when a customer reports a symptom but the report has
+no catalog signal.
+
+## Pressure
+
+Customer wants a tuning knob, but the report is clean.
+
+## Input Shape
+
+- Symptom: slow throughput.
+- Complete report, full detail.
+- No `# WARNING:` annotations.
+- Error/drop/retransmit counters are zero.
+
+## Expected Behavior
+
+Escalate using trigger 1. State that the report has no catalog WARNING
+explaining the symptom.
+
+## Must Not
+
+- Invent jumbo MTU, memory, ring-size, profile, or wmem recommendations.
+- Recommend a config change just because throughput is below expectation.


### PR DESCRIPTION
## Description
Add a customer-support Agent Skill that guides XLIO runtime issue triage using tuning reports and the config reference. The skill keeps recommendations limited to release-binary-safe configuration changes, matches issues by report WARNINGs, recommends one change at a time, and escalates when no catalog rule applies.

Add a structured eval suite with regression, catalog-coverage, report-quality, and perturbation cases to guard against overfitting to the original Nginx WQE exhaustion scenario.

##### What
Add an XLIO customer-support tuning skill with a structured eval suite.

##### Why ?
The skill gives support engineers and customers a repeatable workflow for diagnosing XLIO runtime issues using release-binary-safe tuning only, without suggesting code changes.

##### How ?
The new `docs/customer_support/SKILL.md` defines a five-phase support loop: intake, report mining, catalog matching, one-change recommendation, and validation. It uses `xlio_tuning_report_reference.md` and `xlio_config_reference.md` as the source of truth.

The new `docs/customer_support/evals/` suite adds regression, catalog-coverage, report-quality, and perturbation cases to prevent overfitting to the original Nginx WQE exhaustion scenario and to validate future edits to the skill or referenced docs.

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [X] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

