### PR TITLE
issue 5088334: Ultra API SO_RCVBUF shrink support

### DIFF
--- a/src/core/sock/sockinfo_tcp.cpp
+++ b/src/core/sock/sockinfo_tcp.cpp
@@ -679,7 +679,7 @@ err_t sockinfo_tcp::rx_lwip_cb_xlio_socket(void *arg, struct tcp_pcb *pcb, struc
         return err;
     }
 
-    tcp_recved(pcb, p->tot_len, true);
+    conn->rx_lwip_shrink_rcv_wnd_xlio_socket(p->tot_len);
 
     if (conn->m_p_group->m_socket_rx_cb) {
         struct pbuf *ptmp = p;
@@ -2143,6 +2143,17 @@ inline void sockinfo_tcp::rx_lwip_shrink_rcv_wnd(size_t pbuf_tot_len, int bytes_
         }
         m_rcvbuff_non_tcp_recved += non_tcp_receved_bytes_remaining - bytes_to_shrink;
     }
+}
+
+inline void sockinfo_tcp::rx_lwip_shrink_rcv_wnd_xlio_socket(size_t pbuf_tot_len)
+{
+    if (unlikely(m_pcb.rcv_wnd_max > m_pcb.rcv_wnd_max_desired)) {
+        const uint32_t bytes_to_shrink = std::min(m_pcb.rcv_wnd_max - m_pcb.rcv_wnd_max_desired,
+                                                  static_cast<uint32_t>(pbuf_tot_len));
+        m_pcb.rcv_wnd_max -= bytes_to_shrink;
+    }
+
+    tcp_recved(&m_pcb, static_cast<uint32_t>(pbuf_tot_len), true);
 }
 
 err_t sockinfo_tcp::rx_drop_lwip_cb(void *arg, struct tcp_pcb *tpcb, struct pbuf *p, err_t err)

--- a/src/core/sock/sockinfo_tcp.h
+++ b/src/core/sock/sockinfo_tcp.h
@@ -482,6 +482,7 @@ private:
     void rx_lwip_cb_error(pbuf *p);
     inline void rx_lwip_process_chained_pbufs(pbuf *p);
     inline void rx_lwip_shrink_rcv_wnd(size_t pbuf_tot_len, int nbytes);
+    inline void rx_lwip_shrink_rcv_wnd_xlio_socket(size_t pbuf_tot_len);
     inline void save_packet_info_in_ready_list(pbuf *p);
     // Be sure that m_pcb is initialized
     void set_conn_properties_from_pcb();


### PR DESCRIPTION
## Description
fit_rcv_wnd() was grow-only on the connected path, so a lowered SO_RCVBUF on an established Ultra API Socket connection never shrank the receive window. Growth was already applied immediately.

Ultra API Sockets give the window back in full per delivery, so the cap can drop at once. Lower rcv_wnd_max/rcv_wnd under an is_xlio_socket() gate and leave rcv_ann_wnd to tcp_update_rcv_ann_wnd(), which drains the advertised window without retracting the right edge. R2C/worker-threads sockets keep the rx_lwip_shrink_rcv_wnd() path.

##### What
Adds support for Ultra API shrinkage of SO_RCVBUF sockopt

##### Why ?
Fix Ultra API Gap.

##### How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc._

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Optimized TCP receive window management for improved network efficiency and connection stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->