### PR TITLE
issue: 5030951 Fix TCP 2-tuple steering rule refcount leak on detach

### DIFF
--- a/src/core/dev/ring_slave.cpp
+++ b/src/core/dev/ring_slave.cpp
@@ -477,6 +477,14 @@ bool steering_handler<KEY4T, KEY2T, HDR>::detach_flow(flow_tuple &flow_spec_5t, 
         sock_addr rule_key(flow_spec_5t.get_family(), &flow_spec_5t.get_dst_ip(),
                            flow_spec_5t.get_dst_port());
         if (safe_mce_sys().tcp_3t_rules || safe_mce_sys().tcp_2t_rules) {
+            if (safe_mce_sys().tcp_2t_rules) {
+                // Mirror attach_flow(): the 2-tuple steering rule's reference counter is keyed by
+                // destination IP only (port zeroed). Without zeroing the port here the lookup
+                // misses, the shared rule's refcount is never decremented to 0, the rule is never
+                // destroyed and it keeps the TIR (and thus the RX RQ/CQ) alive, leaking the CQ
+                // buffer on every ring teardown (RM#5030951).
+                rule_key.set_in_port(0);
+            }
             auto dst_port_iter = m_ring.m_tcp_dst_port_attach_map.find(rule_key);
             BULLSEYE_EXCLUDE_BLOCK_START
             if (dst_port_iter == m_ring.m_tcp_dst_port_attach_map.end()) {


### PR DESCRIPTION
## Description
Fix a client-side memory leak (RM#5030951): libxlio leaked the RX completion-queue buffer (~256 MB per ring) on every ring teardown when `tcp.2t_rules` is enabled.

##### What
Mirror `attach_flow()`'s steering-rule key construction in `detach_flow()` for 2-tuple TCP rules.

##### Why ?
Redmine #5030951 - valgrind found a large client-side leak running xlio_perf. The shared TCP steering-rule reference counter (`m_tcp_dst_port_attach_map`) is keyed by a `sock_addr`. `attach_flow()` zeroes the destination port for `tcp_2t_rules`, but `detach_flow()` looked it up with the port still set. The 2-tuple detach therefore missed (`"Could not find matching counter for TCP src port!"`), the rule's refcount was never decremented to 0, the shared steering rule was never destroyed, it kept the dpcp TIR - and thus the RX RQ/CQ - alive, and the mlx5 CQ buffer leaked. The client uses 2-tuple rules (leaked); the server uses 3-tuple rules whose key keeps the port symmetrically on attach and detach (clean) - matching the ticket's client-only symptom.

##### How ?
Add `if (tcp_2t_rules) rule_key.set_in_port(0);` in `steering_handler::detach_flow()` (TCP branch) so the detach key matches attach. The counter reaches 0, the shared rule is destroyed, and the ring RQ/CQ resources are released.

Validated RED -> GREEN on a CX7 back-to-back pair under valgrind with xlio_perf (`tcp.2t_rules`, dedicated-port, bidirectional, 8 workers / 8 client IPs / 50 conn): definitely+indirectly+possibly lost went from ~1.34 GB to 0, no `destroy cq failed`, and traffic completed cleanly (no early rule destroy). Build is 0 warnings; unit_tests 197/197; `commit.sh` green. Blast-radius reviewed: UDP-UC, MC, and TCP-3t are already attach/detach-symmetric (and there is no `udp_2t_rules`), so this is a complete fix for the class.

## Change type
- [x] Bugfix

## Check list
- [x] Code follows the style de facto guidelines of this project
- [x] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)