### PR TITLE
issue: 5128171 Fix sporadic ext_vlan_tag gtest CI failures

### DIFF
--- a/tests/gtest/tcp/tcp_sockopt.cc
+++ b/tests/gtest/tcp/tcp_sockopt.cc
@@ -293,7 +293,12 @@ TEST_F(tcp_sockopt, ti_4_ext_vlan_tag_connect_fail)
         long elapsed_ms = (ts_end.tv_sec - ts_start.tv_sec) * 1000L +
             (ts_end.tv_nsec - ts_start.tv_nsec) / 1000000L;
         EXPECT_GE(elapsed_ms, 200L);
-        EXPECT_LT(elapsed_ms, 1000L);
+        // TCP_USER_TIMEOUT is only evaluated at retransmission ticks. With the RFC 6298
+        // 1s initial RTO the abort lands at the first tick (~1s), not at 200ms, so the
+        // upper bound must sit above the initial RTO yet below the next retransmit at
+        // initial + fallback RTO (~4s), proving the timeout fired early instead of
+        // running the full retry chain.
+        EXPECT_LT(elapsed_ms, 3000L);
 
         close(fd);
         exit(testing::Test::HasFailure());
@@ -309,8 +314,9 @@ TEST_F(tcp_sockopt, ti_4_ext_vlan_tag_connect_fail)
 
         barrier_fork(pid);
 
-        ASSERT_EQ(0, wait_fork(pid));
+        int wait_rc = wait_fork(pid);
         close(l_fd);
+        ASSERT_EQ(0, wait_rc);
     }
 }
 


### PR DESCRIPTION
## Description

Redmine #5128171 - the `tcp_sockopt` ext_vlan_tag gtests fail sporadically in CI (deterministically on the Jenkins nodes), blocking every open PR. Commit c13dae19 (issue 4712119) introduced the tests.

Five tests fail as a group: `tcp_sockopt.ti_4_ext_vlan_tag_connect_fail`, `tcp_sockopt.ti_5_ext_vlan_tag_disable`, and `keep_alive/tcp_with_fifo.accepted_socket_inherits_the_setsockopt_param/{0,1,2}`. Only `ti_4` is a real failure; the other four are a cascade.

##### What
- Relax `ti_4`'s connect-timeout upper bound `1000L -> 3000L`.
- Close the parent's listening socket before asserting on the child result so a `ti_4` failure can no longer leak the shared server port.

##### Why ?
- `ti_4` sets `TCP_USER_TIMEOUT=200ms` and asserts the failed `connect()` returns in `elapsed_ms < 1000`. XLIO (like Linux) only evaluates `TCP_USER_TIMEOUT` at retransmission ticks, and the initial RTO is `TCP_INITIAL_RTO_MS = 1000` (RFC 6298), so the abort lands at ~1s, not 200ms. CI observed `elapsed_ms = 1437` -> the `< 1000` bound is unsatisfiable and flaps red. This is expected stack behavior, not a product bug, so the test bound is what is wrong.
- The `ti_4` parent ran `close(l_fd)` *after* `ASSERT_EQ(0, wait_fork(pid))`. When the child fails, the `ASSERT` returns early and leaks the listening socket, which keeps holding the shared server port. Every later `bind()` (`ti_5`, `tcp_with_fifo`) then fails with `EADDRINUSE`, turning one real failure into five.

##### How ?
- Raise the upper bound to `3000L` - above the 1s initial RTO, below the next retransmit at initial + fallback RTO (~4s) - so the test still proves `TCP_USER_TIMEOUT` fired early without depending on sub-second timing.
- Capture `wait_fork()`'s return, `close(l_fd)`, then assert, so cleanup always runs.

## Verification (lab, dor03, mlx5 172.24.0.1/172.24.1.1)
- RED: forcing `ti_4` to fail reproduces the exact CI cascade locally (5 failures, same lines 296/312/360/757).
- GREEN (leak fix only): 5 -> 1 (cascade eliminated).
- GREEN (bound fix): 0 failures; `ti_4`/`ti_5` stable 6/6 repeats; full CI `test-basic` filter 168/168.
- 0 build warnings; clang-format (repo `style.conf`) clean; `contrib/jenkins_tests/commit.sh` passes.

## Change type
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [X] Tests
- [ ] Other

## Check list
- [X] Code follows the style de facto guidelines of this project
- [X] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [X] Test has been added (if possible)