### PR TITLE
issue: 4810385 Fixinig HW RX TLS Resync

### DIFF
--- a/src/core/dev/cq_mgr_rx_regrq.cpp
+++ b/src/core/dev/cq_mgr_rx_regrq.cpp
@@ -12,7 +12,7 @@
 #include "cq_mgr_rx_inl.h"
 #include "hw_queue_rx.h"
 #include "ring_simple.h"
-
+#include "proto/tls.h"
 #include <netinet/ip6.h>
 
 #define MODULE_NAME "cq_mgr_rx_regrq"
@@ -113,6 +113,10 @@ void cq_mgr_rx_regrq::cqe_to_mem_buff_desc(struct xlio_mlx5_cqe *cqe,
         p_rx_wc_buf_desc->sz_data = ntohl(cqe->byte_cnt);
 #ifdef DEFINED_UTLS
         p_rx_wc_buf_desc->rx.tls_decrypted = (cqe->pkt_info >> 3) & 0x3;
+        if (unlikely(p_rx_wc_buf_desc->rx.tls_decrypted == TLS_RX_RESYNC)) {
+            // The branch prevents another cache line to be fetched.
+            ++(m_p_cq_stat->n_rx_tls_resync);
+        }
 #endif /* DEFINED_UTLS */
         p_rx_wc_buf_desc->rx.timestamps.hw_raw = ntohll(cqe->timestamp);
         uint32_t sop_rxdrop_qpn_flowtag_h_byte = ntohl(cqe->sop_rxdrop_qpn_flowtag);

--- a/src/core/dev/cq_mgr_rx_strq.cpp
+++ b/src/core/dev/cq_mgr_rx_strq.cpp
@@ -13,6 +13,7 @@
 #include "hw_queue_rx.h"
 #include "ring_simple.h"
 #include <cinttypes>
+#include "proto/tls.h"
 
 #define MODULE_NAME "cq_mgr_rx_strq"
 
@@ -233,6 +234,10 @@ inline bool cq_mgr_rx_strq::strq_cqe_to_mem_buff_desc(struct xlio_mlx5_cqe *cqe,
               (cqe->hds_ip_ext & MLX5_CQE_L3_OK));
 #ifdef DEFINED_UTLS
         _hot_buffer_stride->rx.tls_decrypted = (cqe->pkt_info >> 3) & 0x3;
+        if (unlikely(_hot_buffer_stride->rx.tls_decrypted == TLS_RX_RESYNC)) {
+            // The branch prevents another cache line to be fetched.
+            ++(m_p_cq_stat->n_rx_tls_resync);
+        }
 #endif /* DEFINED_UTLS */
         if (cqe->lro_num_seg > 1) {
             lro_update_hdr(cqe, _hot_buffer_stride);

--- a/src/core/dev/hw_queue_tx.cpp
+++ b/src/core/dev/hw_queue_tx.cpp
@@ -1009,6 +1009,7 @@ int hw_queue_tx::tls_context_setup_rx(xlio_tir *tir, const xlio_tls_info *info,
 
 void hw_queue_tx::tls_resync_rx(xlio_tir *tir, const xlio_tls_info *info, uint32_t hw_resync_tcp_sn)
 {
+    // In case of Multi-Resync, we avoid fence and in worst case will get another resync.
     tls_post_static_params_wqe(tir, info, tir->get_tirn(), tir->get_dek_id(), hw_resync_tcp_sn,
                                false, false);
 }

--- a/src/core/dev/rfs_uc_tcp_gro.cpp
+++ b/src/core/dev/rfs_uc_tcp_gro.cpp
@@ -10,6 +10,7 @@
 #include "dev/ring_simple.h"
 #include <netinet/ip6.h>
 #include <sock/sockinfo_tcp.h>
+#include <proto/tls.h>
 
 #define MODULE_NAME "rfs_uc_tcp_gro"
 
@@ -64,6 +65,15 @@ bool rfs_uc_tcp_gro::rx_dispatch_packet(mem_buf_desc_t *p_rx_pkt_mem_buf_desc_in
     struct tcphdr *p_tcp_h = p_rx_pkt_mem_buf_desc_info->rx.tcp.p_tcp_h;
     uint16_t explicit_hdr_len; // L3 header size is not included in IPv6 payload field.
     uint16_t tot_len;
+
+#ifdef DEFINED_UTLS
+    // Do not allow packets with HW TLS RX Resync into GRO.
+    // To avoid the need to propogate that information to the socket.
+    // The resync flag could be on any packet inside a big GRO.
+    if (p_rx_pkt_mem_buf_desc_info->rx.tls_decrypted == TLS_RX_RESYNC) {
+        goto out;
+    }
+#endif
 
     if (!m_b_active) {
         if (!m_b_reserved && m_p_gro_mgr->is_stream_max()) {

--- a/src/core/dev/rfs_uc_tcp_gro.cpp
+++ b/src/core/dev/rfs_uc_tcp_gro.cpp
@@ -67,9 +67,10 @@ bool rfs_uc_tcp_gro::rx_dispatch_packet(mem_buf_desc_t *p_rx_pkt_mem_buf_desc_in
     uint16_t tot_len;
 
 #ifdef DEFINED_UTLS
-    // Do not allow packets with HW TLS RX Resync into GRO.
-    // To avoid the need to propogate that information to the socket.
-    // The resync flag could be on any packet inside a big GRO.
+    /* Do not allow packets with HW TLS RX Resync into GRO.
+     * To avoid the need to propagate that information to the socket.
+     * The resync flag could be on any packet inside a big GRO.
+     */
     if (p_rx_pkt_mem_buf_desc_info->rx.tls_decrypted == TLS_RX_RESYNC) {
         goto out;
     }
@@ -126,9 +127,7 @@ bool rfs_uc_tcp_gro::rx_dispatch_packet(mem_buf_desc_t *p_rx_pkt_mem_buf_desc_in
             goto out;
         }
 
-        /* Flush gro packet immediately in case
-         * total number of agreggated packets exceeds limit
-         */
+        // Flush GRO packet immediately in case total number of aggregated packets exceeds limit
         if (m_gro_desc.buf_count >= m_n_buf_max) {
             flush_gro_desc(pv_fd_ready_array);
         }
@@ -284,7 +283,7 @@ bool rfs_uc_tcp_gro::tcp_check(mem_buf_desc_t *mem_buf_desc, tcphdr *p_tcp_h)
         return false;
     }
 
-    // Set pbc once here since in constructor we don't have sockinfo yet
+    // Set PCB once here since in constructor we don't have sockinfo yet
     if (unlikely(!m_pcb)) {
         sockinfo_tcp *sock = dynamic_cast<sockinfo_tcp *>(m_sinks_list[0]);
         if (unlikely(!sock)) {

--- a/src/core/sock/sockinfo_tcp.cpp
+++ b/src/core/sock/sockinfo_tcp.cpp
@@ -2679,7 +2679,10 @@ bool sockinfo_tcp::rx_input_cb(mem_buf_desc_t *p_rx_pkt_mem_buf_desc_info, void 
     sockinfo_tcp *sock = (sockinfo_tcp *)pcb->my_container;
 
 #ifdef DEFINED_UTLS
-    // We must keep the TLS RX Resync indication even if the stack rejects the packet.
+    /* We must keep the TLS RX Resync indication even if the stack rejects the packet.
+     * Note, TLS offload is not possible for a child socket here, because it's not accepted yet.
+     * We don't have to handle the child lock. Ultra API doesn't support HW TLS offload yet.
+     */
     if (p_rx_pkt_mem_buf_desc_info->rx.tls_decrypted == TLS_RX_RESYNC) {
         sock->get_ops()->incr_tls_rx_need_resync();
     }

--- a/src/core/sock/sockinfo_tcp.cpp
+++ b/src/core/sock/sockinfo_tcp.cpp
@@ -2677,6 +2677,14 @@ bool sockinfo_tcp::rx_input_cb(mem_buf_desc_t *p_rx_pkt_mem_buf_desc_info, void 
     lwip_pbuf_init_custom(p_rx_pkt_mem_buf_desc_info);
 
     sockinfo_tcp *sock = (sockinfo_tcp *)pcb->my_container;
+
+#ifdef DEFINED_UTLS
+    // We must keep the TLS RX Resync indication even if the stack rejects the packet.
+    if (p_rx_pkt_mem_buf_desc_info->rx.tls_decrypted == TLS_RX_RESYNC) {
+        sock->get_ops()->incr_tls_rx_need_resync();
+    }
+#endif
+
     if (sock == this) {
         L3_level_tcp_input((pbuf *)p_rx_pkt_mem_buf_desc_info, pcb);
     } else {

--- a/src/core/sock/sockinfo_ulp.cpp
+++ b/src/core/sock/sockinfo_ulp.cpp
@@ -13,6 +13,71 @@
 #include <errno.h>
 #include <sys/socket.h>
 
+// ------------------------------------------------------------------------------------------------
+// HW TLS RX Resync
+// ------------------------------------------------------------------------------------------------
+// HW TLS RX Resync happnes when HW looses tracking of the TLS records. It can be due to out of
+// order packets or retransmissions. HW generates a resync flag on the CQE of the packet where
+// it lost tracking. Once HW lost tracking it moves to a Searching mode where it looks for next
+// TLS record magic number.
+// Once HW finds that magic number it stores the found TCP seq no in the static HW TLS RX context.
+// Application should fetch that TCP seq no via get-psv WQE and read that TCP seq.
+// Application should verify if that TCP seq no belongs to a TLS record and approve that via
+// set-psv WQE. However, it is not enough just to approve the TCP seq no, in the set-psv WQE
+// the application should also state what is the correct TLS record number that belongs to that
+// TCP seq no. HW will try to authenticate next record using the record number. And only if it
+// succedes it will resume offloading.
+// HW context contains two parameters:
+// MLX5E_TLS_PROGRESS_PARAMS_RECORD_TRACKER_STATE:
+// - MLX5E_TLS_PROGRESS_PARAMS_RECORD_TRACKER_STATE_START -
+//   The state at the beggining of the TLS session - Set by a progress WQE.
+// - MLX5E_TLS_PROGRESS_PARAMS_RECORD_TRACKER_STATE_TRACKING -
+//   HW is locked on the TLS stream while offloading or not. In the resync process
+//   HW may find the next record magic number but untill we approve it and it can authenticate
+//   the next record it will not offload bubt continue tracking.
+// - MLX5E_TLS_PROGRESS_PARAMS_RECORD_TRACKER_STATE_SEARCHING -
+//   HW lost tracking of the TLS stream and is now searching for next record magic number.
+//   In this state HW is not offloading.
+// MLX5E_TLS_PROGRESS_PARAMS_AUTH_STATE
+// - MLX5E_TLS_PROGRESS_PARAMS_AUTH_STATE_NO_OFFLOAD -
+//   HW is not offloading whether it is now tracking, searching or starting.
+// - MLX5E_TLS_PROGRESS_PARAMS_AUTH_STATE_OFFLOAD -
+//   HW is offloading. And obviously tracking (The desired state).
+// - MLX5E_TLS_PROGRESS_PARAMS_AUTH_STATE_AUTHENTICATION -
+//   We approved the HW found TCP seqno but the HW now in process of authenticating the next record.
+//   No offload at this stage. If authentication succeeds, HW will move to Offload state.
+//   If it fails, it will not offload (Not described in PRM).
+// Resync special cases:
+// HW generates resync request then we generate get-psv WQE
+// Case 1 - HW is still searching (MLX5E_TLS_PROGRESS_PARAMS_RECORD_TRACKER_STATE_SEARCHING)
+//          Nothing to do at this stage. We should generate another get-psv to try again.
+// Case 2 - HW is tracking
+// Case 2.1 HW returns the found seqno that belongs to a record that we alrady have parsed
+//          We approve the HW with static param WQE.
+// Case 2.2 HW returns a TCP seqno that does not belong to a known record
+// - Case 2.2.1 We still didn't parse/read to that record - We will try to recheck when we parse
+//              to that TCP seq no.
+// - Case 2.2.2 We already parsed beyond the given TCP seqno. We retry with another get-psv
+//              (Not described well in PRM).
+// Case 2.3 Multi-Resync (Not described in PRM - From Observations)
+// - Case 2.3.1 HW completes the get-psv wqe with info but immediately looses tracking again
+//              before we could read the result. HW should generate another resync request (Not
+//              described in PRM). Once we receive the result, we still do not know that it lost
+//              tracking again, we should procced as normal. We will approve with outdated TCP seqno
+//              which will not match the HW context.
+// - Case 2.3.2 HW looses tracking and finds new magic number before it completes out first get-psv.
+//              Since get-psv is performed on the TX queue, there is n o sync between get-psv and RX
+//              packets. HW will generate a resync and complete out get-psv with the new TCP seqno.
+//              We will receive the new TCPseq no and approve. But then we get another resync
+//              request. We send get-psv and will receive TRACKING and OFFLOAD state as result. We
+//              should igonre this result as the HW already offloads.
+// - Case 2.3.3 Same as 2.3.2, but our second get-psv returns AUTHENTICATION state, since the HW
+//              may still be in trying to authenticate next record. We should ignore this result
+//              and if auth fails, we should get another resync request eventually, being HW
+//              sending another resync if TCP seqno match but auth fails or being it loosing
+//              tracking eventually.
+// ------------------------------------------------------------------------------------------------
+
 #define MODULE_NAME "si_ulp"
 
 #define si_ulp_logdbg  __log_info_dbg
@@ -369,7 +434,6 @@ sockinfo_tcp_ops_tls::sockinfo_tcp_ops_tls(sockinfo_tcp *sock)
     m_refused_data = nullptr;
     m_rx_rule = nullptr;
     m_rx_psv_buf = nullptr;
-    m_rx_resync_recno = 0;
 }
 
 sockinfo_tcp_ops_tls::~sockinfo_tcp_ops_tls()
@@ -635,6 +699,11 @@ int sockinfo_tcp_ops_tls::setsockopt(int __level, int __optname, const void *__o
                                                        &rx_comp_callback, this);
                 if (unlikely(rc != 0)) {
                     m_p_tx_ring->credits_return(SQ_CREDITS_TLS_RX_CONTEXT);
+                } else {
+                    m_rx_next_rec_tcp_seq = next_seqno_rx;
+                    m_recno_tcp_seq.emplace_back(m_next_recno_rx, m_rx_next_rec_tcp_seq);
+                    si_ulp_logdbg("TLS RX initial record num: %" PRIu64 " TCP sqeno %" PRIu32,
+                                  m_next_recno_rx, m_rx_next_rec_tcp_seq);
                 }
             } else {
                 si_ulp_logdbg("No available space in SQ to create TLS RX context");
@@ -1260,9 +1329,6 @@ int sockinfo_tcp_ops_tls::tls_rx_encrypt(struct pbuf *plist)
 
 err_t sockinfo_tcp_ops_tls::recv(struct pbuf *p)
 {
-    bool resync_requested = false;
-    err_t err;
-
     if (m_rx_bufs.empty()) {
         m_rx_offset = 0;
     }
@@ -1272,9 +1338,6 @@ err_t sockinfo_tcp_ops_tls::recv(struct pbuf *p)
         mem_buf_desc_t *pdesc = reinterpret_cast<mem_buf_desc_t *>(p);
         struct pbuf *ptmp = p->next;
 
-        if (unlikely(pdesc->rx.tls_decrypted == TLS_RX_RESYNC)) {
-            resync_requested = true;
-        }
         pdesc->rx.n_frags = 1;
         p->tot_len = p->len;
         p->next = nullptr;
@@ -1282,23 +1345,20 @@ err_t sockinfo_tcp_ops_tls::recv(struct pbuf *p)
         p = ptmp;
     }
 
-    if (unlikely(resync_requested && !m_rx_psv_buf) &&
+    if (unlikely((!m_pending_resync_seqno) && (m_tls_rx_need_resync) && !m_rx_psv_buf) &&
         m_p_tx_ring->credits_get(SQ_CREDITS_TLS_RX_GET_PSV)) {
         /* If we fail to request credits we will retry resync flow with the next incoming packet. */
         m_rx_psv_buf = m_p_sock->tcp_tx_mem_buf_alloc(PBUF_RAM);
         m_rx_psv_buf->lwip_pbuf.payload =
             (void *)(((uintptr_t)m_rx_psv_buf->p_buffer + 63U) >> 6U << 6U);
         uint8_t *payload = (uint8_t *)m_rx_psv_buf->lwip_pbuf.payload;
-        if (likely(m_rx_psv_buf->sz_buffer >= (size_t)(payload - m_rx_psv_buf->p_buffer + 64))) {
-            memset(m_rx_psv_buf->lwip_pbuf.payload, 0, 64);
-            m_rx_resync_recno = m_next_recno_rx;
-            m_p_tx_ring->tls_get_progress_params_rx(m_p_tir, payload, LKEY_TX_DEFAULT);
-            if (m_p_sock->get_sock_stats()) {
-                ++m_p_sock->get_sock_stats()->tls_counters.n_tls_rx_resync;
-            }
-        }
+        // We always should have sz_buffer bigger than 64 since it must be at least MTU.
+        memset(m_rx_psv_buf->lwip_pbuf.payload, 0, 64);
+        m_p_tx_ring->tls_get_progress_params_rx(m_p_tir, payload, LKEY_TX_DEFAULT);
+        IF_STATS_OB(m_p_sock, ++(TLS_STATS(m_p_sock).n_tls_rx_resync_attempt));
     }
 
+    err_t err;
     if (unlikely(m_refused_data)) {
         err =
             sockinfo_tcp::rx_lwip_cb((void *)m_p_sock, m_p_sock->get_pcb(), m_refused_data, ERR_OK);
@@ -1483,6 +1543,13 @@ check_single_record:
     }
 
     ++m_next_recno_rx;
+    m_rx_next_rec_tcp_seq += m_rx_rec_len;
+    if (m_tls_rx_need_resync) {
+        m_recno_tcp_seq.emplace_back(m_next_recno_rx, m_rx_next_rec_tcp_seq);
+        if (m_pending_resync_seqno) {
+            rx_comp_callback(this);
+        }
+    }
 
     tcp_recved(m_p_sock->get_pcb(), m_tls_rec_overhead, true);
     if (likely(pres)) {
@@ -1541,14 +1608,30 @@ err_t sockinfo_tcp_ops_tls::rx_lwip_cb(void *arg, struct tcp_pcb *tpcb, struct p
 
 uint64_t sockinfo_tcp_ops_tls::find_recno(uint32_t seqno)
 {
-    /*
-     * TODO Find proper record number for specific seqno.
-     * Current implementation is a speculation. We need to track TCP seqno
-     * of TLS records to provide correct record number and verify that the
-     * seqno points to a TLS header.
-     */
-    NOT_IN_USE(seqno);
-    return m_rx_resync_recno;
+    while (!m_recno_tcp_seq.empty()) {
+        auto item = m_recno_tcp_seq.front();
+        if (item.second == seqno) {
+            m_recno_tcp_seq.pop_front();
+            return item.first;
+        }
+
+        if (TCP_SEQ_LT(item.second, seqno)) {
+            m_recno_tcp_seq.pop_front();
+        } else {
+            break;
+        }
+    }
+
+    return 0U;
+}
+
+void sockinfo_tcp_ops_tls::rx_resync_success()
+{
+    if (!(--m_tls_rx_need_resync)) {
+        m_recno_tcp_seq.clear();
+    }
+
+    IF_STATS_OB(m_p_sock, ++(TLS_STATS(m_p_sock).n_tls_rx_resync_success));
 }
 
 /* static */
@@ -1556,27 +1639,61 @@ void sockinfo_tcp_ops_tls::rx_comp_callback(void *arg)
 {
     sockinfo_tcp_ops_tls *utls = reinterpret_cast<sockinfo_tcp_ops_tls *>(arg);
 
-    if (utls->m_rx_psv_buf) {
-        /* Resync flow, GET_PSV is completed. */
+    utls->m_p_sock->lock_tcp_con();
+
+    if (utls->m_rx_psv_buf) { // Resync flow, GET_PSV is completed.
         struct xlio_tls_progress_params *params =
-            (struct xlio_tls_progress_params *)utls->m_rx_psv_buf->lwip_pbuf.payload;
+            reinterpret_cast<struct xlio_tls_progress_params *>(
+                utls->m_rx_psv_buf->lwip_pbuf.payload);
         uint32_t resync_seqno = be32toh(params->hw_resync_tcp_sn);
         int tracker = params->state >> 6U;
         int auth = (params->state >> 4U) & 0x3U;
-        if (tracker == TLS_TRACKER_TRACKING && auth == TLS_AUTH_NO_OFFLOAD) {
-            if (utls->m_p_tx_ring->credits_get(SQ_CREDITS_TLS_RX_RESYNC)) {
+        utls->m_pending_resync_seqno = false;
+
+        if (tracker == TLS_TRACKER_TRACKING) {
+            // The HW is tracking the stream (TLS record Magic number found)
+            if (auth == TLS_AUTH_NO_OFFLOAD) { // The HW not offloading yet.
                 uint64_t recno_be64 = htobe64(utls->find_recno(resync_seqno));
-                memcpy(utls->m_tls_info_rx.rec_seq, &recno_be64, TLS_AES_GCM_REC_SEQ_LEN);
-                utls->m_p_tx_ring->tls_resync_rx(utls->m_p_tir, &utls->m_tls_info_rx, resync_seqno);
+                if (recno_be64) { // We found a TLS record for the reported TCP sequence
+                    if (utls->m_p_tx_ring->credits_get(SQ_CREDITS_TLS_RX_RESYNC)) {
+                        memcpy(utls->m_tls_info_rx.rec_seq, &recno_be64, TLS_AES_GCM_REC_SEQ_LEN);
+                        utls->m_p_tx_ring->tls_resync_rx(utls->m_p_tir, &utls->m_tls_info_rx,
+                                                         resync_seqno);
+                        utls->rx_resync_success();
+                    } else { // No TX credits - We will retry RX resync with the next incoming
+                             // packet.
+                        utls->m_pending_resync_seqno = true;
+                        vlog_printf(VLOG_DEBUG, "Skip TLS RX resync due to full SQ\n");
+                    }
+                } else if (utls->m_recno_tcp_seq.empty()) {
+                    // We still have not parsed to the point of HW reported TCP-seq.
+                    utls->m_pending_resync_seqno = true;
+                } else {
+                    // Wrong TCP Seq was found by the HW, since we parsed bayond the reported TCP
+                    // seq. See comment at top of this file.
+                    IF_STATS_OB(utls->m_p_sock,
+                                ++(TLS_STATS(utls->m_p_sock).n_tls_rx_resync_retry));
+                    vlog_printf(VLOG_DEBUG, "TLS RX Record number not found: seqno: %u\n",
+                                resync_seqno);
+                }
             } else {
-                /* We will retry RX resync with the next incoming packet. */
-                vlog_printf(VLOG_DEBUG, "Skip TLS RX resync due to full SQ\n");
+                // HW is already offloading or authenticating.
+                // Possible in case of multi Resync - See comment at top of this file.
+                utls->rx_resync_success();
             }
         } else {
-            /* TODO Investigate this case. It isn't described in PRM. */
+            // TLS_TRACKER_SEARCHING - HW still didnt find the Magic number.
+            // TLS_TRACKER_START - Should happen only upon session start but observed also later in
+            // the connection randomly. We have nothing to do in this case but to retry the psv
+            // until HW locks on a TLS record. See comment at top of this file.
+            IF_STATS_OB(utls->m_p_sock, ++(TLS_STATS(utls->m_p_sock).n_tls_rx_resync_long));
+            vlog_printf(VLOG_DEBUG, "TLS RX Not Tracking T: %d, A: %d\n", tracker, auth);
         }
-        utls->m_p_tx_ring->mem_buf_desc_return_single_to_owner_tx(utls->m_rx_psv_buf);
-        utls->m_rx_psv_buf = nullptr;
+
+        if (!utls->m_pending_resync_seqno) {
+            utls->m_p_tx_ring->mem_buf_desc_return_single_to_owner_tx(utls->m_rx_psv_buf);
+            utls->m_rx_psv_buf = nullptr;
+        }
     } else if (!utls->m_rx_rule) {
         /* Initial setup flow. */
         const flow_tuple_with_local_if &tuple = utls->m_p_sock->get_flow_tuple();
@@ -1585,5 +1702,7 @@ void sockinfo_tcp_ops_tls::rx_comp_callback(void *arg)
             vlog_printf(VLOG_ERROR, "TLS rule failed for %s\n", tuple.to_str().c_str());
         }
     }
+
+    utls->m_p_sock->unlock_tcp_con();
 }
 #endif /* DEFINED_UTLS */

--- a/src/core/sock/sockinfo_ulp.cpp
+++ b/src/core/sock/sockinfo_ulp.cpp
@@ -1609,9 +1609,9 @@ err_t sockinfo_tcp_ops_tls::rx_lwip_cb(void *arg, struct tcp_pcb *tpcb, struct p
 uint64_t sockinfo_tcp_ops_tls::find_recno(uint32_t seqno)
 {
     while (!m_recno_tcp_seq.empty()) {
-        auto item = m_recno_tcp_seq.front();
+        const auto &item = m_recno_tcp_seq.front();
         if (item.second == seqno) {
-            m_recno_tcp_seq.pop_front();
+            // Don't drop the item here, because we need for the retry if SQ is full.
             return item.first;
         }
 
@@ -1660,8 +1660,7 @@ void sockinfo_tcp_ops_tls::rx_comp_callback(void *arg)
                         utls->m_p_tx_ring->tls_resync_rx(utls->m_p_tir, &utls->m_tls_info_rx,
                                                          resync_seqno);
                         utls->rx_resync_success();
-                    } else { // No TX credits - We will retry RX resync with the next incoming
-                             // packet.
+                    } else { // No TX credits - We will retry RX resync with the next RX packet.
                         utls->m_pending_resync_seqno = true;
                         vlog_printf(VLOG_DEBUG, "Skip TLS RX resync due to full SQ\n");
                     }

--- a/src/core/sock/sockinfo_ulp.cpp
+++ b/src/core/sock/sockinfo_ulp.cpp
@@ -1384,13 +1384,17 @@ err_t sockinfo_tcp_ops_tls::recv(struct pbuf *p)
         m_p_tx_ring->credits_get(SQ_CREDITS_TLS_RX_GET_PSV)) {
         /* If we fail to request credits we will retry resync flow with the next incoming packet. */
         m_rx_psv_buf = m_p_sock->tcp_tx_mem_buf_alloc(PBUF_RAM);
-        m_rx_psv_buf->lwip_pbuf.payload =
-            (void *)(((uintptr_t)m_rx_psv_buf->p_buffer + 63U) >> 6U << 6U);
-        uint8_t *payload = (uint8_t *)m_rx_psv_buf->lwip_pbuf.payload;
-        // We always should have sz_buffer bigger than 64 since it must be at least MTU.
-        memset(m_rx_psv_buf->lwip_pbuf.payload, 0, 64);
-        m_p_tx_ring->tls_get_progress_params_rx(m_p_tir, payload, LKEY_TX_DEFAULT);
-        IF_STATS_OB(m_p_sock, ++(TLS_STATS(m_p_sock).n_tls_rx_resync_attempt));
+        if (m_rx_psv_buf) {
+            m_rx_psv_buf->lwip_pbuf.payload =
+                (void *)(((uintptr_t)m_rx_psv_buf->p_buffer + 63U) >> 6U << 6U);
+            uint8_t *payload = (uint8_t *)m_rx_psv_buf->lwip_pbuf.payload;
+            // We always should have sz_buffer bigger than 64 since it must be at least MTU.
+            memset(m_rx_psv_buf->lwip_pbuf.payload, 0, 64);
+            m_p_tx_ring->tls_get_progress_params_rx(m_p_tir, payload, LKEY_TX_DEFAULT);
+            IF_STATS_OB(m_p_sock, ++(TLS_STATS(m_p_sock).n_tls_rx_resync_attempt));
+        } else {
+            m_p_tx_ring->credits_return(SQ_CREDITS_TLS_RX_GET_PSV);
+        }
     }
 
     err_t err;

--- a/src/core/sock/sockinfo_ulp.cpp
+++ b/src/core/sock/sockinfo_ulp.cpp
@@ -1645,13 +1645,14 @@ err_t sockinfo_tcp_ops_tls::rx_lwip_cb(void *arg, struct tcp_pcb *tpcb, struct p
     return sockinfo_tcp::rx_lwip_cb(arg, tpcb, p, err);
 }
 
-uint64_t sockinfo_tcp_ops_tls::find_recno(uint32_t seqno)
+bool sockinfo_tcp_ops_tls::find_recno(uint32_t seqno, uint64_t &recno)
 {
     while (!m_recno_tcp_seq.empty()) {
         const auto &item = m_recno_tcp_seq.front();
         if (item.second == seqno) {
             // Don't drop the item here, because we need for the retry if SQ is full.
-            return item.first;
+            recno = item.first;
+            return true;
         }
 
         if (TCP_SEQ_LT(item.second, seqno)) {
@@ -1661,7 +1662,7 @@ uint64_t sockinfo_tcp_ops_tls::find_recno(uint32_t seqno)
         }
     }
 
-    return 0U;
+    return false;
 }
 
 void sockinfo_tcp_ops_tls::rx_resync_success()
@@ -1692,9 +1693,10 @@ void sockinfo_tcp_ops_tls::rx_comp_callback(void *arg)
         if (tracker == TLS_TRACKER_TRACKING) {
             // The HW is tracking the stream (TLS record Magic number found)
             if (auth == TLS_AUTH_NO_OFFLOAD) { // The HW not offloading yet.
-                uint64_t recno_be64 = htobe64(utls->find_recno(resync_seqno));
-                if (recno_be64) { // We found a TLS record for the reported TCP sequence
+                uint64_t recno = 0;
+                if (utls->find_recno(resync_seqno, recno)) {
                     if (utls->m_p_tx_ring->credits_get(SQ_CREDITS_TLS_RX_RESYNC)) {
+                        uint64_t recno_be64 = htobe64(recno);
                         memcpy(utls->m_tls_info_rx.rec_seq, &recno_be64, TLS_AES_GCM_REC_SEQ_LEN);
                         utls->m_p_tx_ring->tls_resync_rx(utls->m_p_tir, &utls->m_tls_info_rx,
                                                          resync_seqno);

--- a/src/core/sock/sockinfo_ulp.cpp
+++ b/src/core/sock/sockinfo_ulp.cpp
@@ -430,6 +430,7 @@ sockinfo_tcp_ops_tls::sockinfo_tcp_ops_tls(sockinfo_tcp *sock)
     m_rx_offset = 0;
     m_rx_rec_len = 0;
     m_rx_rec_rcvd = 0;
+    m_rx_next_rec_tcp_seq = 0;
     m_rx_sm = TLS_RX_SM_HEADER;
     m_refused_data = nullptr;
     m_rx_rule = nullptr;
@@ -702,6 +703,12 @@ int sockinfo_tcp_ops_tls::setsockopt(int __level, int __optname, const void *__o
                 } else {
                     m_rx_next_rec_tcp_seq = next_seqno_rx;
                     m_recno_tcp_seq.emplace_back(m_next_recno_rx, m_rx_next_rec_tcp_seq);
+                    /* See the "Initial value:" paragraph in the "Counter bookkeeping" section
+                     * at the top. Set the initial value here instead of the constructor, because
+                     * tls_rx_consume_ready_packets() during setsockopt() can interfere with the
+                     * resync flow otherwise.
+                     */
+                    m_tls_rx_need_resync = 1U;
                     si_ulp_logdbg("TLS RX initial record num: %" PRIu64 " TCP sqeno %" PRIu32,
                                   m_next_recno_rx, m_rx_next_rec_tcp_seq);
                 }

--- a/src/core/sock/sockinfo_ulp.cpp
+++ b/src/core/sock/sockinfo_ulp.cpp
@@ -13,70 +13,98 @@
 #include <errno.h>
 #include <sys/socket.h>
 
-// ------------------------------------------------------------------------------------------------
-// HW TLS RX Resync
-// ------------------------------------------------------------------------------------------------
-// HW TLS RX Resync happnes when HW looses tracking of the TLS records. It can be due to out of
-// order packets or retransmissions. HW generates a resync flag on the CQE of the packet where
-// it lost tracking. Once HW lost tracking it moves to a Searching mode where it looks for next
-// TLS record magic number.
-// Once HW finds that magic number it stores the found TCP seq no in the static HW TLS RX context.
-// Application should fetch that TCP seq no via get-psv WQE and read that TCP seq.
-// Application should verify if that TCP seq no belongs to a TLS record and approve that via
-// set-psv WQE. However, it is not enough just to approve the TCP seq no, in the set-psv WQE
-// the application should also state what is the correct TLS record number that belongs to that
-// TCP seq no. HW will try to authenticate next record using the record number. And only if it
-// succedes it will resume offloading.
-// HW context contains two parameters:
-// MLX5E_TLS_PROGRESS_PARAMS_RECORD_TRACKER_STATE:
-// - MLX5E_TLS_PROGRESS_PARAMS_RECORD_TRACKER_STATE_START -
-//   The state at the beggining of the TLS session - Set by a progress WQE.
-// - MLX5E_TLS_PROGRESS_PARAMS_RECORD_TRACKER_STATE_TRACKING -
-//   HW is locked on the TLS stream while offloading or not. In the resync process
-//   HW may find the next record magic number but untill we approve it and it can authenticate
-//   the next record it will not offload bubt continue tracking.
-// - MLX5E_TLS_PROGRESS_PARAMS_RECORD_TRACKER_STATE_SEARCHING -
-//   HW lost tracking of the TLS stream and is now searching for next record magic number.
-//   In this state HW is not offloading.
-// MLX5E_TLS_PROGRESS_PARAMS_AUTH_STATE
-// - MLX5E_TLS_PROGRESS_PARAMS_AUTH_STATE_NO_OFFLOAD -
-//   HW is not offloading whether it is now tracking, searching or starting.
-// - MLX5E_TLS_PROGRESS_PARAMS_AUTH_STATE_OFFLOAD -
-//   HW is offloading. And obviously tracking (The desired state).
-// - MLX5E_TLS_PROGRESS_PARAMS_AUTH_STATE_AUTHENTICATION -
-//   We approved the HW found TCP seqno but the HW now in process of authenticating the next record.
-//   No offload at this stage. If authentication succeeds, HW will move to Offload state.
-//   If it fails, it will not offload (Not described in PRM).
-// Resync special cases:
-// HW generates resync request then we generate get-psv WQE
-// Case 1 - HW is still searching (MLX5E_TLS_PROGRESS_PARAMS_RECORD_TRACKER_STATE_SEARCHING)
-//          Nothing to do at this stage. We should generate another get-psv to try again.
-// Case 2 - HW is tracking
-// Case 2.1 HW returns the found seqno that belongs to a record that we alrady have parsed
-//          We approve the HW with static param WQE.
-// Case 2.2 HW returns a TCP seqno that does not belong to a known record
-// - Case 2.2.1 We still didn't parse/read to that record - We will try to recheck when we parse
-//              to that TCP seq no.
-// - Case 2.2.2 We already parsed beyond the given TCP seqno. We retry with another get-psv
-//              (Not described well in PRM).
-// Case 2.3 Multi-Resync (Not described in PRM - From Observations)
-// - Case 2.3.1 HW completes the get-psv wqe with info but immediately looses tracking again
-//              before we could read the result. HW should generate another resync request (Not
-//              described in PRM). Once we receive the result, we still do not know that it lost
-//              tracking again, we should procced as normal. We will approve with outdated TCP seqno
-//              which will not match the HW context.
-// - Case 2.3.2 HW looses tracking and finds new magic number before it completes out first get-psv.
-//              Since get-psv is performed on the TX queue, there is n o sync between get-psv and RX
-//              packets. HW will generate a resync and complete out get-psv with the new TCP seqno.
-//              We will receive the new TCPseq no and approve. But then we get another resync
-//              request. We send get-psv and will receive TRACKING and OFFLOAD state as result. We
-//              should igonre this result as the HW already offloads.
-// - Case 2.3.3 Same as 2.3.2, but our second get-psv returns AUTHENTICATION state, since the HW
-//              may still be in trying to authenticate next record. We should ignore this result
-//              and if auth fails, we should get another resync request eventually, being HW
-//              sending another resync if TCP seqno match but auth fails or being it loosing
-//              tracking eventually.
-// ------------------------------------------------------------------------------------------------
+/* ------------------------------------------------------------------------------------------------
+ * HW TLS RX Resync
+ * ------------------------------------------------------------------------------------------------
+ * HW TLS RX Resync happens when HW looses tracking of the TLS records. It can be due to out of
+ * order packets or retransmissions. HW generates a resync flag on the CQE of the packet where
+ * it lost tracking. Once HW lost tracking it moves to a Searching mode where it looks for next
+ * TLS record magic number.
+ * Once HW finds that magic number it stores the found TCP seq no in the static HW TLS RX context.
+ * Application should fetch that TCP seq no via get-psv WQE and read that TCP seq.
+ * Application should verify if that TCP seq no belongs to a TLS record and approve that via
+ * set-psv WQE. However, it is not enough just to approve the TCP seq no, in the set-psv WQE
+ * the application should also state what is the correct TLS record number that belongs to that
+ * TCP seq no. HW will try to authenticate next record using the record number. And only if it
+ * succeeds it will resume offloading.
+ *
+ * HW context contains two parameters:
+ * MLX5E_TLS_PROGRESS_PARAMS_RECORD_TRACKER_STATE:
+ * - MLX5E_TLS_PROGRESS_PARAMS_RECORD_TRACKER_STATE_START -
+ *   The state at the beggining of the TLS session - Set by a progress WQE.
+ * - MLX5E_TLS_PROGRESS_PARAMS_RECORD_TRACKER_STATE_TRACKING -
+ *   HW is locked on the TLS stream while offloading or not. In the resync process
+ *   HW may find the next record magic number but until we approve it and it can authenticate
+ *   the next record it will not offload but continue tracking.
+ * - MLX5E_TLS_PROGRESS_PARAMS_RECORD_TRACKER_STATE_SEARCHING -
+ *   HW lost tracking of the TLS stream and is now searching for next record magic number.
+ *   In this state HW is not offloading.
+ * MLX5E_TLS_PROGRESS_PARAMS_AUTH_STATE
+ * - MLX5E_TLS_PROGRESS_PARAMS_AUTH_STATE_NO_OFFLOAD -
+ *   HW is not offloading whether it is now tracking, searching or starting.
+ * - MLX5E_TLS_PROGRESS_PARAMS_AUTH_STATE_OFFLOAD -
+ *   HW is offloading. And obviously tracking (The desired state).
+ * - MLX5E_TLS_PROGRESS_PARAMS_AUTH_STATE_AUTHENTICATION -
+ *   We approved the HW found TCP seqno but the HW now in process of authenticating the next record.
+ *   No offload at this stage. If authentication succeeds, HW will move to Offload state.
+ *   If it fails, it will not offload (Not described in PRM).
+ *
+ * Resync special cases:
+ * HW generates resync request then we generate get-psv WQE
+ * Case 1 - HW is still searching (MLX5E_TLS_PROGRESS_PARAMS_RECORD_TRACKER_STATE_SEARCHING)
+ *          Nothing to do at this stage. We should generate another get-psv to try again.
+ * Case 2 - HW is tracking
+ * Case 2.1 HW returns the found seqno that belongs to a record that we already have parsed
+ *          We approve the HW with static params WQE.
+ * Case 2.2 HW returns a TCP seqno that does not belong to a known record
+ * Case 2.2.1 We still didn't parse/read to that record - We will try to recheck when we parse
+ *            to that TCP seq no.
+ * Case 2.2.2 We already parsed beyond the given TCP seqno. We retry with another get-psv
+ *            (Not described well in PRM).
+ * Case 2.3 Multi-Resync (Not described in PRM - From Observations)
+ * Case 2.3.1 HW completes the get-psv wqe with info but immediately looses tracking again
+ *            before we could read the result. HW should generate another resync request (Not
+ *            described in PRM). Once we receive the result, we still do not know that it lost
+ *            tracking again, we should proceed as normal. We will approve with outdated TCP seqno
+ *            which will not match the HW context.
+ * Case 2.3.2 HW loses tracking and finds new magic number before it completes the first get-psv.
+ *            Since get-psv is performed on the TX queue, there is no sync between get-psv and RX
+ *            packets. HW will generate a resync and complete the first get-psv with the new TCP
+ *            seqno. We will receive the new TCP seqno and approve. But then we get another resync
+ *            request. We send get-psv and will receive TRACKING and OFFLOAD state as result. We
+ *            should ignore this result as the HW already offloads.
+ * Case 2.3.3 Same as 2.3.2, but our second get-psv returns AUTHENTICATION state, since the HW
+ *            may still be in trying to authenticate next record. We should ignore this result
+ *            and if auth fails, we should get another resync request eventually, being HW
+ *            sending another resync if TCP seqno match but auth fails or being it loosing
+ *            tracking eventually.
+ *
+ * ------------------------------------------------------------------------------------------------
+ * Counter bookkeeping (m_tls_rx_need_resync)
+ * ------------------------------------------------------------------------------------------------
+ * m_tls_rx_need_resync counts the HW resync requests we still owe a GET_PSV/approval cycle.
+ * - Increment: once per TLS_RX_RESYNC CQE. The flag is edge-triggered - HW raises it once per
+ *   resync request and then continues with TLS_RX_ENCRYPTED CQEs while searching.
+ * - Decrement: once per GET_PSV completion that finds the HW back in TRACKING - either because
+ *   we posted an approving resync (record found) or because the HW is already offloading/
+ *   authenticating (multi-resync reconciliation, cases 2.3.x). recv() keeps issuing GET_PSV
+ *   WQEs, one at a time while the counter is non-zero.
+ *
+ * Convergence: recv() keeps issuing GET_PSVs while the counter is non-zero, and every outcome
+ * is either a decrement or a non-destructive retry, so the flow drains to 0 in a finite number
+ * of RX CQEs once the HW returns to TRACKING. The non-decrementing outcomes lose no state:
+ * find_recno() only peeks the matched record and the entry is consumed (pop_front) after the
+ * resync has been posted, so a searching/start, record-not-yet-parsed, record-parsed-beyond, or
+ * no-SQ-credits result re-derives the same record on a later GET_PSV instead of stranding the
+ * request. The only non-converging case is the HW never re-locking (persistent loss), there
+ * records keep decrypting on the SW fallback by design.
+ *
+ * Initial value: the counter is armed to 1 right after the RX TLS context is programmed (see
+ * setsockopt()). This is a deliberate simplification: it costs one extra "startup" resync per
+ * connection, in return the same TCP seqno tracking path is reused from the very first offloaded
+ * record. HW TLS RX offload begins in an un-synchronized state, so tracking must run from the
+ * beginning.
+ */
 
 #define MODULE_NAME "si_ulp"
 
@@ -1675,7 +1703,7 @@ void sockinfo_tcp_ops_tls::rx_comp_callback(void *arg)
                     // We still have not parsed to the point of HW reported TCP-seq.
                     utls->m_pending_resync_seqno = true;
                 } else {
-                    // Wrong TCP Seq was found by the HW, since we parsed bayond the reported TCP
+                    // Wrong TCP Seq was found by the HW, since we parsed beyond the reported TCP
                     // seq. See comment at top of this file.
                     IF_STATS_OB(utls->m_p_sock,
                                 ++(TLS_STATS(utls->m_p_sock).n_tls_rx_resync_retry));
@@ -1688,10 +1716,11 @@ void sockinfo_tcp_ops_tls::rx_comp_callback(void *arg)
                 utls->rx_resync_success();
             }
         } else {
-            // TLS_TRACKER_SEARCHING - HW still didnt find the Magic number.
-            // TLS_TRACKER_START - Should happen only upon session start but observed also later in
-            // the connection randomly. We have nothing to do in this case but to retry the psv
-            // until HW locks on a TLS record. See comment at top of this file.
+            /* TLS_TRACKER_SEARCHING - HW still didn't find the Magic number.
+             * TLS_TRACKER_START - Should happen only upon session start but observed also later in
+             * the connection randomly. We have nothing to do in this case but to retry the psv
+             * until HW locks on a TLS record. See comment at top of this file.
+             */
             IF_STATS_OB(utls->m_p_sock, ++(TLS_STATS(utls->m_p_sock).n_tls_rx_resync_long));
             vlog_printf(VLOG_DEBUG, "TLS RX Not Tracking T: %d, A: %d\n", tracker, auth);
         }

--- a/src/core/sock/sockinfo_ulp.h
+++ b/src/core/sock/sockinfo_ulp.h
@@ -11,7 +11,8 @@
 #include "proto/dst_entry.h" /* xlio_send_attr */
 #include "proto/tls.h" /* xlio_tls_info */
 #include "lwip/err.h" /* err_t */
-
+#include <utility>
+#include <deque>
 #include <stdint.h>
 
 /*
@@ -35,6 +36,7 @@ public:
     virtual ssize_t tx(xlio_tx_call_attr_t &tx_arg);
     virtual int postrouting(struct pbuf *p, struct tcp_seg *seg, xlio_send_attr &attr);
     virtual bool handle_send_ret(ssize_t ret, struct tcp_seg *seg);
+    virtual void incr_tls_rx_need_resync() {}
 
     virtual err_t recv(struct pbuf *p)
     {
@@ -73,7 +75,7 @@ public:
     ssize_t tx(xlio_tx_call_attr_t &tx_arg) override;
     int postrouting(struct pbuf *p, struct tcp_seg *seg, xlio_send_attr &attr) override;
     bool handle_send_ret(ssize_t ret, struct tcp_seg *seg) override;
-
+    void incr_tls_rx_need_resync() override { ++m_tls_rx_need_resync; }
     void get_record_buf(mem_buf_desc_t *&buf, uint8_t *&data, bool is_zerocopy);
 
 private:
@@ -82,7 +84,7 @@ private:
 
     int send_alert(uint8_t alert_type);
     void terminate_session_fatal(uint8_t alert_type);
-
+    void rx_resync_success();
     err_t tls_rx_consume_ready_packets();
     err_t recv(struct pbuf *p) override;
     void copy_by_offset(uint8_t *dst, uint32_t offset, uint32_t len);
@@ -130,12 +132,6 @@ private:
     struct xlio_tls_info m_tls_info_tx;
     struct xlio_tls_info m_tls_info_rx;
 
-    /* Whether offload is configured. */
-    bool m_is_tls_tx;
-    bool m_is_tls_rx;
-    /* TLS record overhead (header + trailer). Different across versions. */
-    uint32_t m_tls_rec_overhead;
-
     /* TX specific fields */
     xlio_tis *m_p_tis;
 
@@ -155,6 +151,8 @@ private:
     void *m_p_evp_cipher;
     void *m_p_cipher_ctx;
 
+    /* Track records and TCP seq for TLS RX resyncs */
+    std::deque<std::pair<uint64_t, uint32_t>> m_recno_tcp_seq;
     /* List of RX buffers that contain unhandled records. */
     xlio_desc_list_t m_rx_bufs;
     /* Record number of current or incomplete TLS record. */
@@ -165,6 +163,10 @@ private:
     uint32_t m_rx_rec_len;
     /* Number of bytes received after m_rx_offset. */
     uint32_t m_rx_rec_rcvd;
+    /* Next Record TCP Sequence */
+    uint32_t m_rx_next_rec_tcp_seq;
+    /* TLS record overhead (header + trailer). Different across versions. */
+    uint32_t m_tls_rec_overhead;
     /* State machine for TLS RX stream. */
     enum tls_rx_state m_rx_sm;
     /* Refused data by sockinfo_tcp::rx_lwip_cb() to be retried. */
@@ -173,8 +175,13 @@ private:
     rfs_rule *m_rx_rule;
     /* Buffer to hold GET_PSV data during resync. */
     mem_buf_desc_t *m_rx_psv_buf;
-    /* Record number where resync request was received. */
-    uint64_t m_rx_resync_recno;
+    /* Track requested TLS RX resyncs */
+    uint16_t m_tls_rx_need_resync = 1U;
+    /* HW TCP resync seqno for pending parsing */
+    bool m_pending_resync_seqno = false;
+    /* Whether offload is configured. */
+    bool m_is_tls_tx;
+    bool m_is_tls_rx;
 };
 
 #endif /* DEFINED_UTLS */

--- a/src/core/sock/sockinfo_ulp.h
+++ b/src/core/sock/sockinfo_ulp.h
@@ -175,8 +175,10 @@ private:
     rfs_rule *m_rx_rule;
     /* Buffer to hold GET_PSV data during resync. */
     mem_buf_desc_t *m_rx_psv_buf;
-    /* Track requested TLS RX resyncs */
-    uint16_t m_tls_rx_need_resync = 1U;
+    /* Track requested TLS RX resyncs. Armed to 1 in setsockopt() after the RX context is
+     * programmed (see top-of-file comment); left 0 here so tls_rx_consume_ready_packets() doesn't
+     * call sockinfo_tcp_ops_tls::recv() before the context and record-tracking seed exist. */
+    uint16_t m_tls_rx_need_resync = 0U;
     /* HW TCP resync seqno for pending parsing */
     bool m_pending_resync_seqno = false;
     /* Whether offload is configured. */

--- a/src/core/sock/sockinfo_ulp.h
+++ b/src/core/sock/sockinfo_ulp.h
@@ -92,7 +92,7 @@ private:
     int tls_rx_decrypt(struct pbuf *plist);
     int tls_rx_encrypt(struct pbuf *plist);
 
-    uint64_t find_recno(uint32_t seqno);
+    bool find_recno(uint32_t seqno, uint64_t &recno);
 
     static err_t rx_lwip_cb(void *arg, struct tcp_pcb *tpcb, struct pbuf *p, err_t err);
     static void rx_comp_callback(void *arg);

--- a/src/core/util/xlio_stats.h
+++ b/src/core/util/xlio_stats.h
@@ -165,7 +165,10 @@ typedef struct {
     uint32_t n_tls_rx_records_mix_enc;
     uint32_t n_tls_rx_records_hw_auth_fail;
     uint32_t n_tls_rx_records_sw_dec_fail;
-    uint32_t n_tls_rx_resync;
+    uint32_t n_tls_rx_resync_attempt;
+    uint32_t n_tls_rx_resync_success;
+    uint32_t n_tls_rx_resync_retry;
+    uint32_t n_tls_rx_resync_long;
 } socket_tls_counters_t;
 #endif /* DEFINED_UTLS */
 
@@ -319,12 +322,13 @@ typedef struct {
     uint64_t n_rx_hw_pkt_drops;
     uint64_t n_rx_packet_count;
     uint64_t n_rx_consumed_rwqe_count;
-    uint64_t n_rx_sw_pkt_drops;
     uint64_t n_rx_lro_packets;
     uint64_t n_rx_lro_bytes;
     uint64_t n_rx_gro_packets;
     uint64_t n_rx_gro_bytes;
     uint64_t n_rx_gro_frags;
+    uint64_t n_rx_sw_pkt_drops;
+    uint32_t n_rx_tls_resync;
     uint32_t n_rx_sw_queue_len;
     uint32_t n_rx_drained_at_once_max;
     uint32_t n_buffer_pool_len;

--- a/src/core/util/xlio_stats.h
+++ b/src/core/util/xlio_stats.h
@@ -604,4 +604,25 @@ void print_netstat_like(socket_stats_t *p_si_stats, mc_grp_info_t *p_mc_grp_info
                         int pid);
 void print_netstat_like_headers(FILE *file);
 
+// Returns number of 'a' units per 'b' on average. Example: number of strides per packet.
+static inline double xlio_stats_ratio(uint64_t a, uint64_t b)
+{
+    return (b == 0) ? 0.0 : static_cast<double>(a) / static_cast<double>(b);
+}
+
+// Returns number of 'a' units per 'b' on average. Example: bytes per packet.
+static inline uint64_t xlio_stats_ratio_u64(uint64_t a, uint64_t b)
+{
+    return (b == 0) ? 0 : a / b;
+}
+
+// Returns percentage of 'a' units out of 'b'. Example: percentage of LRO packets.
+static inline double xlio_stats_percent(uint64_t a, uint64_t b)
+{
+    if (b == 0) {
+        return 0.0;
+    }
+    return static_cast<double>(a) * 100.0 / static_cast<double>(b);
+}
+
 #endif // XLIO_STATS_H

--- a/src/stats/stats_printer.cpp
+++ b/src/stats/stats_printer.cpp
@@ -252,9 +252,12 @@ void print_full_stats(socket_stats_t *p_si_stats, mc_grp_info_t *p_mc_grp_info, 
                 p_si_stats->tls_counters.n_tls_rx_records_sw_dec_fail, post_fix);
         b_any_activiy = true;
     }
-    if (p_si_stats->tls_counters.n_tls_rx_resync) {
-        fprintf(filename, "TLS Rx Resyncs: %u [total]%s\n",
-                p_si_stats->tls_counters.n_tls_rx_resync, post_fix);
+    if (p_si_stats->tls_counters.n_tls_rx_resync_attempt) {
+        fprintf(filename, "TLS Rx Resyncs: %u / %u / %u / %u [attempt/success/retry/long]%s\n",
+                p_si_stats->tls_counters.n_tls_rx_resync_attempt,
+                p_si_stats->tls_counters.n_tls_rx_resync_success,
+                p_si_stats->tls_counters.n_tls_rx_resync_retry,
+                p_si_stats->tls_counters.n_tls_rx_resync_long, post_fix);
     }
 #endif /* DEFINED_UTLS */
 

--- a/src/stats/stats_printer.cpp
+++ b/src/stats/stats_printer.cpp
@@ -159,12 +159,11 @@ void print_full_stats(socket_stats_t *p_si_stats, mc_grp_info_t *p_mc_grp_info, 
                 "Rx data packets: %" PRIu64 " / %u / %u / %u [bytes/packets/frags/chained]\n",
                 p_si_stats->counters.n_rx_bytes, p_si_stats->counters.n_rx_data_pkts,
                 p_si_stats->counters.n_rx_frags, p_si_stats->counters.n_gro);
-        if (p_si_stats->counters.n_rx_data_pkts) {
-            fprintf(filename, "Avg. aggr packet size: %" PRIu64 " fragments per packet: %.1f\n",
-                    p_si_stats->counters.n_rx_bytes / p_si_stats->counters.n_rx_data_pkts,
-                    static_cast<double>(p_si_stats->counters.n_rx_frags) /
-                        p_si_stats->counters.n_rx_data_pkts);
-        }
+        fprintf(
+            filename, "Avg. aggr packet size: %" PRIu64 " fragments per packet: %.1f\n",
+            xlio_stats_ratio_u64(p_si_stats->counters.n_rx_bytes,
+                                 p_si_stats->counters.n_rx_data_pkts),
+            xlio_stats_ratio(p_si_stats->counters.n_rx_frags, p_si_stats->counters.n_rx_data_pkts));
     }
     if (p_si_stats->counters.n_rx_os_bytes || p_si_stats->counters.n_rx_os_packets ||
         p_si_stats->counters.n_rx_os_eagain || p_si_stats->counters.n_rx_os_errors) {
@@ -191,12 +190,11 @@ void print_full_stats(socket_stats_t *p_si_stats, mc_grp_info_t *p_mc_grp_info, 
         b_any_activiy = true;
     }
     if (p_si_stats->counters.n_rx_poll_miss || p_si_stats->counters.n_rx_poll_hit) {
-        double rx_poll_hit = (double)p_si_stats->counters.n_rx_poll_hit;
-        double rx_poll_hit_percentage =
-            (rx_poll_hit / (rx_poll_hit + (double)p_si_stats->counters.n_rx_poll_miss)) * 100;
         fprintf(filename, "Rx poll: %u / %u (%2.2f%%) [miss/hit]\n",
                 p_si_stats->counters.n_rx_poll_miss, p_si_stats->counters.n_rx_poll_hit,
-                rx_poll_hit_percentage);
+                xlio_stats_percent(p_si_stats->counters.n_rx_poll_hit,
+                                   static_cast<uint64_t>(p_si_stats->counters.n_rx_poll_hit) +
+                                       p_si_stats->counters.n_rx_poll_miss));
         b_any_activiy = true;
     }
 

--- a/src/stats/stats_reader.cpp
+++ b/src/stats/stats_reader.cpp
@@ -270,8 +270,21 @@ void update_delta_stat(socket_stats_t *p_curr_stat, socket_stats_t *p_prev_stat)
     p_prev_stat->tls_counters.n_tls_rx_bytes =
         (p_curr_stat->tls_counters.n_tls_rx_bytes - p_prev_stat->tls_counters.n_tls_rx_bytes) /
         delay;
-    p_prev_stat->tls_counters.n_tls_rx_resync =
-        (p_curr_stat->tls_counters.n_tls_rx_resync - p_prev_stat->tls_counters.n_tls_rx_resync) /
+    p_prev_stat->tls_counters.n_tls_rx_resync_attempt =
+        (p_curr_stat->tls_counters.n_tls_rx_resync_attempt -
+         p_prev_stat->tls_counters.n_tls_rx_resync_attempt) /
+        delay;
+    p_prev_stat->tls_counters.n_tls_rx_resync_success =
+        (p_curr_stat->tls_counters.n_tls_rx_resync_success -
+         p_prev_stat->tls_counters.n_tls_rx_resync_success) /
+        delay;
+    p_prev_stat->tls_counters.n_tls_rx_resync_retry =
+        (p_curr_stat->tls_counters.n_tls_rx_resync_retry -
+         p_prev_stat->tls_counters.n_tls_rx_resync_retry) /
+        delay;
+    p_prev_stat->tls_counters.n_tls_rx_resync_long =
+        (p_curr_stat->tls_counters.n_tls_rx_resync_long -
+         p_prev_stat->tls_counters.n_tls_rx_resync_long) /
         delay;
 #endif /* DEFINED_UTLS */
 
@@ -428,6 +441,8 @@ void update_delta_cq_stat(cq_stats_t *p_curr_cq_stats, cq_stats_t *p_prev_cq_sta
         p_prev_cq_stats->n_rx_max_stirde_per_packet = p_curr_cq_stats->n_rx_max_stirde_per_packet;
         p_prev_cq_stats->n_rx_cqe_error =
             (p_curr_cq_stats->n_rx_cqe_error - p_prev_cq_stats->n_rx_cqe_error) / delay;
+        p_prev_cq_stats->n_rx_tls_resync =
+            (p_curr_cq_stats->n_rx_tls_resync - p_prev_cq_stats->n_rx_tls_resync) / delay;
     }
 }
 
@@ -603,6 +618,9 @@ void print_cq_stats(cq_instance_block_t *p_cq_inst_arr)
                 printf(
                     FORMAT_STATS_double, "GRO frags per packet:",
                     static_cast<double>(p_cq_stats->n_rx_gro_frags) / p_cq_stats->n_rx_gro_packets);
+            }
+            if (p_cq_stats->n_rx_tls_resync) {
+                printf("%-20s %u\n", "HW TLS RX Resync:", p_cq_stats->n_rx_tls_resync);
             }
         }
     }

--- a/src/stats/stats_reader.cpp
+++ b/src/stats/stats_reader.cpp
@@ -85,9 +85,8 @@ typedef enum { e_K = 1024, e_M = 1048576 } units_t;
 #define FORMAT_STATS_double  "%-20s %.1f\n"
 #define FORMAT_RING_PACKETS  "%-20s %zu / %zu [kilobytes/packets] %-3s\n"
 #define FORMAT_LRO_PACKETS                                                                         \
-    "%-20s %" PRIu64 " / %" PRIu64 " / %" PRIu64 " [avg-bytes/packets/%%total] %-3s\n"
-#define FORMAT_GRO_PACKETS                                                                         \
-    "%-20s %" PRIu64 " / %.1f / %" PRIu64 " [avg-bytes/avg-frags/%%total] %-3s\n"
+    "%-20s %" PRIu64 " / %" PRIu64 " / %.0f%% [avg-bytes/packets/%%total] %-3s\n"
+#define FORMAT_GRO_PACKETS     "%-20s %" PRIu64 " / %.1f / %.0f%% [avg-bytes/avg-frags/%%total] %-3s\n"
 #define FORMAT_RING_STRIDES    "%-20s %zu / %zu / %zu [total/max-per-packet/packets-per-rwqe] %-3s\n"
 #define FORMAT_RING_INTERRUPT  "%-20s %zu / %zu [requests/received] %-3s\n"
 #define FORMAT_RING_MODERATION "%-20s %u / %u [frames/usec period] %-3s\n"
@@ -603,24 +602,25 @@ void print_cq_stats(cq_instance_block_t *p_cq_inst_arr)
             printf(FORMAT_STATS_32bit, "Max strides/packet:",
                    static_cast<uint32_t>(p_cq_stats->n_rx_max_stirde_per_packet));
             printf(FORMAT_STATS_double, "Avg strides/packet:",
-                   p_cq_stats->n_rx_stride_count /
-                       static_cast<double>(p_cq_stats->n_rx_packet_count + 1U));
+                   xlio_stats_ratio(p_cq_stats->n_rx_stride_count, p_cq_stats->n_rx_packet_count));
             printf(FORMAT_STATS_double, "Avg packets/rwqe:",
-                   p_cq_stats->n_rx_packet_count /
-                       static_cast<double>(p_cq_stats->n_rx_consumed_rwqe_count + 1U));
+                   xlio_stats_ratio(p_cq_stats->n_rx_packet_count,
+                                    p_cq_stats->n_rx_consumed_rwqe_count));
             if (p_cq_stats->n_rx_lro_packets) {
-                printf(FORMAT_LRO_PACKETS,
-                       "Rx LRO:", p_cq_stats->n_rx_lro_bytes / p_cq_stats->n_rx_lro_packets,
-                       p_cq_stats->n_rx_lro_packets,
-                       (p_cq_stats->n_rx_lro_packets * 100U) / p_cq_stats->n_rx_packet_count,
-                       post_fix);
+                printf(
+                    FORMAT_LRO_PACKETS, "Rx LRO:",
+                    xlio_stats_ratio_u64(p_cq_stats->n_rx_lro_bytes, p_cq_stats->n_rx_lro_packets),
+                    p_cq_stats->n_rx_lro_packets,
+                    xlio_stats_percent(p_cq_stats->n_rx_lro_packets, p_cq_stats->n_rx_packet_count),
+                    post_fix);
             }
             if (p_cq_stats->n_rx_gro_packets) {
                 printf(
-                    FORMAT_GRO_PACKETS,
-                    "Rx GRO:", p_cq_stats->n_rx_gro_bytes / p_cq_stats->n_rx_gro_packets,
-                    static_cast<double>(p_cq_stats->n_rx_gro_frags) / p_cq_stats->n_rx_gro_packets,
-                    (p_cq_stats->n_rx_gro_frags * 100U) / p_cq_stats->n_rx_packet_count, post_fix);
+                    FORMAT_GRO_PACKETS, "Rx GRO:",
+                    xlio_stats_ratio_u64(p_cq_stats->n_rx_gro_bytes, p_cq_stats->n_rx_gro_packets),
+                    xlio_stats_ratio(p_cq_stats->n_rx_gro_frags, p_cq_stats->n_rx_gro_packets),
+                    xlio_stats_percent(p_cq_stats->n_rx_gro_packets, p_cq_stats->n_rx_packet_count),
+                    post_fix);
             }
             if (p_cq_stats->n_rx_tls_resync) {
                 printf("%-20s %u\n", "HW TLS RX Resync:", p_cq_stats->n_rx_tls_resync);
@@ -997,13 +997,11 @@ void print_full_iomux_stats(const char *func_name, iomux_func_stats_t *p_iomux_s
                    p_iomux_stats->n_iomux_rx_ready, post_fix);
         }
         if (p_iomux_stats->n_iomux_poll_miss + p_iomux_stats->n_iomux_poll_hit) {
-            double iomux_poll_hit = (double)p_iomux_stats->n_iomux_poll_hit;
-            double iomux_poll_hit_percentage =
-                (iomux_poll_hit / (iomux_poll_hit + (double)p_iomux_stats->n_iomux_poll_miss)) *
-                100;
             printf("Polls [miss/hit]%s: %u / %u (%2.2f%%)\n", post_fix,
                    p_iomux_stats->n_iomux_poll_miss, p_iomux_stats->n_iomux_poll_hit,
-                   iomux_poll_hit_percentage);
+                   xlio_stats_percent(p_iomux_stats->n_iomux_poll_hit,
+                                      static_cast<uint64_t>(p_iomux_stats->n_iomux_poll_hit) +
+                                          p_iomux_stats->n_iomux_poll_miss));
             if (p_iomux_stats->n_iomux_timeouts) {
                 printf("Timeouts%s: %u\n", post_fix, p_iomux_stats->n_iomux_timeouts);
             }

--- a/src/stats/stats_reader.cpp
+++ b/src/stats/stats_reader.cpp
@@ -79,11 +79,15 @@ typedef enum { e_K = 1024, e_M = 1048576 } units_t;
 #define TX_MEDIUM_VIEW " %-3s %-3s %10u %10u %" PRIu64 " %8u %7u %29s %7u %" PRIu64 " %7u %7u\n"
 #define CYCLES_SEPARATOR                                                                           \
     "-------------------------------------------------------------------------------\n"
-#define FORMAT_STATS_32bit     "%-20s %u\n"
-#define FORMAT_STATS_s_32bit   "%-20s %d\n"
-#define FORMAT_STATS_64bit     "%-20s %" PRIu64 " %-3s\n"
-#define FORMAT_STATS_double    "%-20s %.1f\n"
-#define FORMAT_RING_PACKETS    "%-20s %zu / %zu [kilobytes/packets] %-3s\n"
+#define FORMAT_STATS_32bit   "%-20s %u\n"
+#define FORMAT_STATS_s_32bit "%-20s %d\n"
+#define FORMAT_STATS_64bit   "%-20s %" PRIu64 " %-3s\n"
+#define FORMAT_STATS_double  "%-20s %.1f\n"
+#define FORMAT_RING_PACKETS  "%-20s %zu / %zu [kilobytes/packets] %-3s\n"
+#define FORMAT_LRO_PACKETS                                                                         \
+    "%-20s %" PRIu64 " / %" PRIu64 " / %" PRIu64 " [avg-bytes/packets/%%total] %-3s\n"
+#define FORMAT_GRO_PACKETS                                                                         \
+    "%-20s %" PRIu64 " / %.1f / %" PRIu64 " [avg-bytes/avg-frags/%%total] %-3s\n"
 #define FORMAT_RING_STRIDES    "%-20s %zu / %zu / %zu [total/max-per-packet/packets-per-rwqe] %-3s\n"
 #define FORMAT_RING_INTERRUPT  "%-20s %zu / %zu [requests/received] %-3s\n"
 #define FORMAT_RING_MODERATION "%-20s %u / %u [frames/usec period] %-3s\n"
@@ -605,19 +609,18 @@ void print_cq_stats(cq_instance_block_t *p_cq_inst_arr)
                    p_cq_stats->n_rx_packet_count /
                        static_cast<double>(p_cq_stats->n_rx_consumed_rwqe_count + 1U));
             if (p_cq_stats->n_rx_lro_packets) {
-                printf(FORMAT_RING_PACKETS,
-                       "Rx lro:", p_cq_stats->n_rx_lro_bytes / BYTES_TRAFFIC_UNIT,
-                       p_cq_stats->n_rx_lro_packets, post_fix);
+                printf(FORMAT_LRO_PACKETS,
+                       "Rx LRO:", p_cq_stats->n_rx_lro_bytes / p_cq_stats->n_rx_lro_packets,
+                       p_cq_stats->n_rx_lro_packets,
+                       (p_cq_stats->n_rx_lro_packets * 100U) / p_cq_stats->n_rx_packet_count,
+                       post_fix);
             }
             if (p_cq_stats->n_rx_gro_packets) {
-                printf(FORMAT_RING_PACKETS,
-                       "Rx GRO:", p_cq_stats->n_rx_gro_bytes / BYTES_TRAFFIC_UNIT,
-                       p_cq_stats->n_rx_gro_packets, post_fix);
-                printf(FORMAT_STATS_64bit, "Avg GRO packet size:",
-                       p_cq_stats->n_rx_gro_bytes / p_cq_stats->n_rx_gro_packets, post_fix);
                 printf(
-                    FORMAT_STATS_double, "GRO frags per packet:",
-                    static_cast<double>(p_cq_stats->n_rx_gro_frags) / p_cq_stats->n_rx_gro_packets);
+                    FORMAT_GRO_PACKETS,
+                    "Rx GRO:", p_cq_stats->n_rx_gro_bytes / p_cq_stats->n_rx_gro_packets,
+                    static_cast<double>(p_cq_stats->n_rx_gro_frags) / p_cq_stats->n_rx_gro_packets,
+                    (p_cq_stats->n_rx_gro_frags * 100U) / p_cq_stats->n_rx_packet_count, post_fix);
             }
             if (p_cq_stats->n_rx_tls_resync) {
                 printf("%-20s %u\n", "HW TLS RX Resync:", p_cq_stats->n_rx_tls_resync);


### PR DESCRIPTION
## Description
This PR continues work of #573. And includes its commits.

##### What
Fix HW TLS RX resync + small LRO/GRO stats improvement.

##### Why ?
Fixing the bug of loosing sync in HW TLS RX without being able to resume

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved hardware TLS receive resynchronization handling, including retries and multi-resync scenarios.
  * Added detailed TLS resynchronization statistics for attempts, successes, retries, and extended operations.
  * Added receive completion tracking for TLS resynchronization events.

* **Bug Fixes**
  * Prevented TLS resynchronization packets from being incorrectly combined during GRO processing.

* **Statistics**
  * Updated RX and CQ statistics displays with clearer TLS resynchronization reporting and safer percentage calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->