### PR TITLE
[CI] fix blackduck git safe.directory in CI pipeline

### DIFF
--- a/.ci/blackduck_source.sh
+++ b/.ci/blackduck_source.sh
@@ -1,5 +1,9 @@
 #!/bin/bash -Exel
 
+export GIT_CONFIG_COUNT=1
+export GIT_CONFIG_KEY_0=safe.directory
+export GIT_CONFIG_VALUE_0="${WORKSPACE}"
+
 topdir=$(git rev-parse --show-toplevel)
 cd "$topdir"
 


### PR DESCRIPTION
  INFINIOPS-726

## Description
fix blackduck git safe.directory in CI pipeline

##### What
Add git safe.directory config before blackduck scan step

##### Why ?
The blackduck scan was failing because git rejected the repo
directory as unsafe due to ownership mismatch inside the container

##### How ?
Prepend git config --local --add safe.directory "${PWD}" to the
blackduck source script invocation in release_matrix_job.yaml

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the CI workflow to pre-configure Git’s safety settings for the working directory before executing Git commands. This helps prevent automated runs from failing due to “unsafe directory” checks, improving stability and reducing interruption during repository analysis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->