### PR TITLE
[CI] issue:INFINIOPS-772 Update secret scan image

### DIFF
--- a/.ci/matrix_job.yaml
+++ b/.ci/matrix_job.yaml
@@ -147,7 +147,7 @@ runs_on_dockers:
      category: 'tool',
      build_args: '--no-cache --target build',
     }
-  - {name: 'secret-scan', url: '${registry_host}/toolbox/secret_scan:0.0.27', arch: 'x86_64', tag: '0.0.27', category: 'tool'}
+  - {name: 'secret-scan', url: '${registry_host}/swx-storage/tools/secret_scan:devops-stable', arch: 'x86_64', tag: 'devops-stable', category: 'tool'}
 
   - {
      file: '.ci/dockerfiles/Dockerfile.ubuntu22.04',


### PR DESCRIPTION
## Description

Update the secret-scan container reference to use the maintained image location and stable DevOps tag.

##### What

Use the relocated secret-scan image with the `devops-stable` tag.

##### Why ?

The secret scanner moved from the versioned toolbox image to the maintained `swx-storage/tools` location.

Related issue: INFINIOPS-772.

##### How ?

Update the secret-scan entry in `.ci/matrix_job.yaml`. The scan command and CI behavior remain unchanged.

## Change type

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the security scanning environment to use the latest stable scanning image.
  * Secret scanning continues to run with the existing pipeline configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->