### PR TITLE
issue: 5165660 Configure json-c at configure time instead of make time

### DIFF
--- a/contrib/jenkins_tests/build.sh
+++ b/contrib/jenkins_tests/build.sh
@@ -13,15 +13,22 @@ cd ${build_dir}
 # Set symbolic links to default build and install
 ln -s "${build_dir}/0/install" "${install_dir}"
 
+# Regression test against json-c configure-time detection failures: -Werror in
+# CFLAGS used to break the AC_CHECK_FUNCS probes (e.g. the deprecated K&R
+# strdup() check) and misdetect libc functions as missing.
+werror_cflags="-g -Werror -Werror=implicit-function-declaration -Werror-implicit-function-declaration -O2"
+
 declare -A build_list
 build_list['debug']="--enable-opt-log=no --enable-debug"
 build_list['nginx-off']="--enable-nginx=no"
 build_list['envoy-on']="--enable-nginx=yes"
 build_list['static-on']="--enable-static --disable-shared"
+build_list['werror']="CFLAGS=\"${werror_cflags}\""
 build_list['default']=""
 
 build_tap=${WORKSPACE}/${prefix}/build.tap
-echo "1..${#build_list[@]}" > $build_tap
+# +1 for the exported-CFLAGS build below
+echo "1..$((${#build_list[@]} + 1))" > $build_tap
 
 test_id=0
 
@@ -35,6 +42,15 @@ for build_name in "${!build_list[@]}"; do
     test_id=$((test_id+1))
 done
 
+# Same flags, but exported into the environment instead of passed to configure.
+# A global CFLAGS can have a different effect than the configure argument, for
+# example when Makefile.am invokes ./configure (json-c) manually.
+mkdir -p ${build_dir}/${test_id}
+cd ${build_dir}/${test_id}
+test_exec="env CFLAGS=\"${werror_cflags}\" bash -c '${WORKSPACE}/configure --prefix=${build_dir}/${test_id}/install ${jenkins_test_custom_configure} && make ${make_opt} && make install'"
+do_check_result "$test_exec" "$test_id" "werror-env" "$build_tap" "${build_dir}/build-${test_id}"
+cd ${build_dir}
+test_id=$((test_id+1))
 
 echo "[${0##*/}]..................exit code = $rc"
 exit $rc

--- a/contrib/jenkins_tests/build.sh
+++ b/contrib/jenkins_tests/build.sh
@@ -18,38 +18,43 @@ ln -s "${build_dir}/0/install" "${install_dir}"
 # strdup() check) and misdetect libc functions as missing.
 werror_cflags="-g -Werror -Werror=implicit-function-declaration -Werror-implicit-function-declaration -O2"
 
+# Ordered list of builds. 'default' must stay first, so that it is built with
+# test_id=0 and matches the ${build_dir}/0/install symbolic link above.
+# The first build is executed by further stages, such as gtest.sh and test.sh
+build_names=('default' 'debug' 'nginx-off' 'envoy-on' 'static-on' 'werror')
+
 declare -A build_list
+build_list['default']=""
 build_list['debug']="--enable-opt-log=no --enable-debug"
 build_list['nginx-off']="--enable-nginx=no"
 build_list['envoy-on']="--enable-nginx=yes"
 build_list['static-on']="--enable-static --disable-shared"
 build_list['werror']="CFLAGS=\"${werror_cflags}\""
-build_list['default']=""
 
 build_tap=${WORKSPACE}/${prefix}/build.tap
 # +1 for the exported-CFLAGS build below
-echo "1..$((${#build_list[@]} + 1))" > $build_tap
+echo "1..$((${#build_names[@]} + 1))" > "$build_tap"
 
 test_id=0
 
-for build_name in "${!build_list[@]}"; do
+for build_name in "${build_names[@]}"; do
     build_option="${build_list[$build_name]}"
-    mkdir -p ${build_dir}/${test_id}
-    cd ${build_dir}/${test_id}
+    mkdir -p "${build_dir}/${test_id}"
+    cd "${build_dir}/${test_id}"
     test_exec="${WORKSPACE}/configure --prefix=${build_dir}/${test_id}/install $build_option $jenkins_test_custom_configure && make $make_opt install"
     do_check_result "$test_exec" "$test_id" "$build_name" "$build_tap" "${build_dir}/build-${test_id}"
-    cd ${build_dir}
+    cd "${build_dir}"
     test_id=$((test_id+1))
 done
 
 # Same flags, but exported into the environment instead of passed to configure.
 # A global CFLAGS can have a different effect than the configure argument, for
 # example when Makefile.am invokes ./configure (json-c) manually.
-mkdir -p ${build_dir}/${test_id}
-cd ${build_dir}/${test_id}
+mkdir -p "${build_dir}/${test_id}"
+cd "${build_dir}/${test_id}"
 test_exec="env CFLAGS=\"${werror_cflags}\" bash -c '${WORKSPACE}/configure --prefix=${build_dir}/${test_id}/install ${jenkins_test_custom_configure} && make ${make_opt} && make install'"
 do_check_result "$test_exec" "$test_id" "werror-env" "$build_tap" "${build_dir}/build-${test_id}"
-cd ${build_dir}
+cd "${build_dir}"
 test_id=$((test_id+1))
 
 echo "[${0##*/}]..................exit code = $rc"

--- a/contrib/jenkins_tests/compiler.sh
+++ b/contrib/jenkins_tests/compiler.sh
@@ -30,9 +30,6 @@ for compiler in $compiler_list; do
     [ ! -z "$module" ] && module unload "$module"
     cd ${compiler_dir}
     test_id=$((test_id+1))
-    pushd ${WORKSPACE}/third_party/json-c
-    make distclean
-    popd
 done
 
 echo "[${0##*/}]..................exit code = $rc"

--- a/third_party/Makefile.am
+++ b/third_party/Makefile.am
@@ -1,12 +1,1 @@
-SUBDIRS = json-c 
-
-# Ensure json-c is configured before make runs
-all-recursive: json-c-configure
-
-json-c-configure:
-	cd $(srcdir)/json-c && \
-	if [ ! -f Makefile ]; then \
-		./configure; \
-	fi
-
-.PHONY: json-c-configure 
+SUBDIRS = json-c

--- a/third_party/json-c/configure.ac
+++ b/third_party/json-c/configure.ac
@@ -46,6 +46,20 @@ m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
 # Checks for libraries.
 
+# Drop -Werror from json-c's feature tests and build.
+#
+# json-c's AC_CHECK_FUNCS probes trigger builtin-declaration-mismatch and
+# implicit-function-declaration warnings what fails the probes compilation with
+# -Werror in CFLAGS. So standard libc functions get misdetected as missing (e.g.
+# strdup, which then breaks strdup_compat.h). XLIO's top-level configure
+# propagates its CFLAGS which may include -Werror.
+# The pattern covers all the -Werror spellings: bare -Werror, -Werror=<warning>
+# and the deprecated -Werror-implicit-function-declaration alias.
+# This assignment is local to json-c's own configure process, so it does not
+# affect XLIO or any other subdir.
+CFLAGS=`echo "$CFLAGS" | sed -e 's/-Werror[[^[:space:]]]*//g'`
+CPPFLAGS=`echo "$CPPFLAGS" | sed -e 's/-Werror[[^[:space:]]]*//g'`
+
 # Checks for header files.
 AM_PROG_CC_C_O
 AC_PROG_CC_C99


### PR DESCRIPTION
## Description

third_party/Makefile.am ran json-c's ./configure from a make rule, in the source tree ($(srcdir)/json-c) and with no arguments. This defeated VPATH builds: json-c was configured in the shared source directory rather than the per-build build directory.

With json-c configured through AC_CONFIG_SUBDIRS, the parent CFLAGS -- which may include -Werror -- are propagated into its sub-configure. json-c's AC_CHECK_FUNCS probes emit legacy K&R declarations such as "char strdup ();", which under -Werror fail to compile.

##### What

* Configure json-c at configure time instead of make time
* Strip -Werror from json-c configure checks

##### Why ?

Allow to build XLIO in separate non-root directories and in parallel. Propagate flags to json-c configure.

## Change type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build configuration when strict compiler warning settings are enabled.
  * Prevented warning-as-error settings from interfering with feature and header detection.
  * Simplified third-party component build setup for more reliable configuration.

* **Tests**
  * Added regression coverage for builds using strict warning flags, including flags supplied through the environment.
  * Streamlined compiler test cleanup steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->