### PR TITLE
issue: 5170344 Fix IB HCA core clock unit scaling in time converter

### DIFF
--- a/src/core/dev/time_converter_ib_ctx.cpp
+++ b/src/core/dev/time_converter_ib_ctx.cpp
@@ -27,7 +27,7 @@
 
 time_converter_ib_ctx::time_converter_ib_ctx(struct ibv_context *ctx,
                                              ts_conversion_mode_t ctx_time_converter_mode,
-                                             uint64_t hca_core_clock)
+                                             uint64_t hca_core_clock_khz)
     : m_p_ibv_context(ctx)
     , m_ctx_parmeters_id(0)
 {
@@ -37,7 +37,7 @@ time_converter_ib_ctx::time_converter_ib_ctx(struct ibv_context *ctx,
             &m_ctx_convert_parmeters[m_ctx_parmeters_id];
 
         m_converter_status = TS_CONVERSION_MODE_RAW;
-        current_parameters_set->hca_core_clock = hca_core_clock * USEC_PER_SEC;
+        current_parameters_set->hca_core_clock = hca_core_clock_khz * HZ_PER_KHZ;
 
         if (ctx_time_converter_mode != TS_CONVERSION_MODE_RAW) {
             if (sync_clocks(&current_parameters_set->sync_systime,
@@ -54,7 +54,7 @@ time_converter_ib_ctx::time_converter_ib_ctx(struct ibv_context *ctx,
         }
     }
 #else
-    NOT_IN_USE(hca_core_clock);
+    NOT_IN_USE(hca_core_clock_khz);
 #endif
     if (ctx_time_converter_mode != m_converter_status) {
         ibchtc_logwarn(

--- a/src/core/dev/time_converter_ib_ctx.h
+++ b/src/core/dev/time_converter_ib_ctx.h
@@ -14,7 +14,7 @@
 class time_converter_ib_ctx : public time_converter {
 public:
     time_converter_ib_ctx(struct ibv_context *ctx, ts_conversion_mode_t ctx_time_converter_mode,
-                          uint64_t hca_core_clock);
+                          uint64_t hca_core_clock_khz);
 
     virtual ~time_converter_ib_ctx() {};
 

--- a/src/utils/clock.h
+++ b/src/utils/clock.h
@@ -20,6 +20,8 @@
 #define NSEC_PER_SEC  1000000000L
 #define FSEC_PER_SEC  1000000000000000L
 
+#define HZ_PER_KHZ 1000L
+
 /*
  * Convenience macros for operations on timevals
  */


### PR DESCRIPTION
## Description

time_converter_ib_ctx scaled the NIC core clock frequency with the wrong factor, corrupting hardware timestamp to system time conversion.

The constructor receives ibv_device_attr_ex::hca_core_clock, which rdma-core reports in kHz. To store it as Hz it must be multiplied by 1000, but the code multiplied by USEC_PER_SEC (1,000,000), leaving the stored clock 1000x too large.

The USEC_PER_SEC factor was only correct for the legacy experimental verbs field (ibv_exp_device_attr::hca_core_clock, expressed in MHz). The migration to rdma-core changed the unit to kHz without updating the multiplier.

Effect: in calculate_delta() tv_sec = hw_time_diff / hca_core_clock comes out 1000x too small, so converted timestamps drift from the raw hardware time and the error grows linearly. TS_CONVERSION_MODE_RAW is affected for the lifetime of the converter; TS_CONVERSION_MODE_SYNC is affected until the periodic fix_hw_clock_deviation() recomputes the rate empirically.

The kHz-to-Hz scale is applied through a dedicated HZ_PER_KHZ constant instead of the coincidentally-equal MSEC_PER_SEC, and the constructor parameter is renamed hca_core_clock_khz to document the input unit.

##### What
Fix time_converter_ib_ctx inaccuracy.

##### Why ?
Bugfix: fix time_converter_ib_ctx inaccuracy.

## Change type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hardware clock conversion for more accurate timestamp handling.
  * Clarified clock-rate units to ensure values provided in kHz are interpreted correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->