### PR TITLE
issue: 4830545 Link with libdpcp statically

### DIFF
--- a/.ci/dockerfiles/Dockerfile.ctyunos23.01
+++ b/.ci/dockerfiles/Dockerfile.ctyunos23.01
@@ -39,7 +39,7 @@ RUN printf '%s\n' \
     cat /etc/yum.repos.d/ctyunos.repo && \
     dnf clean all
 
-RUN dnf --releasever=23.01 install -y autoconf automake make libtool json-c-devel git gcc-c++ \
+RUN dnf --releasever=23.01 install -y cmake autoconf automake make libtool json-c-devel git gcc-c++ \
     openssl-devel util-linux sudo rpm-build curl \
  && dnf clean all \
  && rm -rf /var/cache/dnf

--- a/.ci/dockerfiles/Dockerfile.ol9.4
+++ b/.ci/dockerfiles/Dockerfile.ol9.4
@@ -15,7 +15,7 @@ RUN sed -i 's|\$WEBREPO_URL|'"${WEBREPO_URL}"'|g' /etc/yum.repos.d/*.repo && \
 RUN yum install yum-utils \
  && yum-config-manager --add-repo https://dl.fedoraproject.org/pub/epel/9/Everything/aarch64/ \
  && yum install -y --nogpgcheck \
-    autoconf automake make libtool git gcc-c++ libtool json-c-devel \
+    cmake autoconf automake make libtool git gcc-c++ libtool json-c-devel \
     clang rdma-core-devel openssl-devel glib2-devel libnl3-devel \
     python3-pip sudo rpm-build gtest-devel meson ninja-build \
     libzip-devel libpcap-devel jsoncpp-devel curl \

--- a/.ci/dockerfiles/Dockerfile.rhel8.6
+++ b/.ci/dockerfiles/Dockerfile.rhel8.6
@@ -18,7 +18,7 @@ FROM core as static
 ARG _LOGIN=svc-nbu-swx-media
 
 RUN yum makecache && \
-    yum install -y yum-utils clang-tools-extra-21.1.8 sudo curl autoconf automake make libtool \
+    yum install -y cmake yum-utils clang-tools-extra-21.1.8 sudo curl autoconf automake make libtool \
     libnl3-devel libnl3 rdma-core-devel rdma-core openssl-devel bc && \
     yum-config-manager --add-repo https://archives.fedoraproject.org/pub/archive/epel/7/x86_64/ && \
     yum --nogpgcheck install -y cppcheck && \
@@ -49,7 +49,7 @@ RUN sed -i "s#http://webrepo#http://${WEBREPO_URL}#" /etc/yum.repos.d/* && \
     yum makecache
 
 RUN yum install --allowerasing -y \
-    git autoconf automake libtool gcc \
+    cmake git autoconf automake libtool gcc \
     sudo gcc-c++ libibverbs-devel json-c-devel rdma-core \
     librdmacm unzip patch wget make \
     libnl3-devel openssl-devel rpm-build net-tools
@@ -57,7 +57,7 @@ RUN yum install --allowerasing -y \
 
 FROM harbor.mellanox.com/hpcx/$ARCH/rhel8.6/base as build
 
-RUN yum install -y json-c-devel openssl-devel curl
+RUN yum install -y cmake json-c-devel openssl-devel curl
 
 # Install DOCA
 COPY .ci/scripts/doca_install.sh /tmp/doca_install.sh

--- a/.ci/dockerfiles/Dockerfile.rhel9.6
+++ b/.ci/dockerfiles/Dockerfile.rhel9.6
@@ -20,7 +20,7 @@ FROM core AS static
 
 RUN dnf install -y dnf-utils \
  && dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm \
- && dnf install --allowerasing -y cppcheck csbuild clang-tools-extra sudo curl autoconf automake make libtool \
+ && dnf install --allowerasing -y cmake cppcheck csbuild clang-tools-extra sudo curl autoconf automake make libtool \
     libnl3-devel libnl3 rdma-core-devel rdma-core openssl-devel bc python3-pip \
  && dnf clean all \
  && rm -rf /var/cache/dnf
@@ -31,7 +31,7 @@ RUN pip3 install -U pip --no-cache-dir \
 
 FROM core AS build
 
-RUN dnf install --allowerasing -y json-c-devel openssl-devel curl \
+RUN dnf install --allowerasing -y cmake json-c-devel openssl-devel curl \
     git autoconf automake make libtool gcc-c++ rpm-build \
  && dnf clean all \
  && rm -rf /var/cache/dnf

--- a/.ci/dockerfiles/Dockerfile.ubuntu22.04
+++ b/.ci/dockerfiles/Dockerfile.ubuntu22.04
@@ -2,7 +2,7 @@ ARG ARCH=x86_64
 FROM harbor.mellanox.com/hpcx/$ARCH/ubuntu22.04/base AS build
 
 RUN apt-get update \
- && apt-get install -y libjson-c-dev libssl-dev curl \
+ && apt-get install -y cmake libjson-c-dev libssl-dev curl \
  && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install DOCA

--- a/.ci/dockerfiles/Dockerfile.ubuntu24.04
+++ b/.ci/dockerfiles/Dockerfile.ubuntu24.04
@@ -2,7 +2,7 @@ ARG ARCH=x86_64
 FROM harbor.mellanox.com/hpcx/$ARCH/ubuntu22.04/base AS build
 
 RUN apt-get update \
- && apt-get install -y libjson-c-dev libssl-dev curl \
+ && apt-get install -y cmake libjson-c-dev libssl-dev curl \
  && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install DOCA

--- a/.ci/pipeline/release_matrix_job.yaml
+++ b/.ci/pipeline/release_matrix_job.yaml
@@ -57,15 +57,6 @@ runs_on_dockers:
     }
 
 steps:
-  - name: Build-dpcp
-    parallel: false
-    containerSelector:
-      - "{name: 'rhel8.6'}"
-    run: |
-      git clone git@github.com:Mellanox/libdpcp.git libdpcp
-      cd libdpcp
-      ./autogen.sh && ./configure --prefix=/usr && sudo make install
-
   - name: Release
     parallel: false
     containerSelector:

--- a/.ci/scripts/compile_ultra_api_test.sh
+++ b/.ci/scripts/compile_ultra_api_test.sh
@@ -7,14 +7,12 @@ source "${WORKSPACE}/contrib/jenkins_tests/globals.sh"
 ulimit -l unlimited
 mkdir -p "${ULTRA_API_LOGS_DIR}"
 
-# Install dpcp
 do_check_env
-do_check_dpcp opt_value
 
 # Prepare libxlio
 ./autogen.sh
-./configure --with-dpcp=${opt_value}
+./configure
 make ${make_opt} install
 
 # compile xlio_ultra_api_ping_pong example
-gcc -I/usr/local/include -L/usr/local/lib -L${opt_value} -o xlio_ultra_api_ping_pong examples/xlio_ultra_api_ping_pong.c -libverbs
+gcc -I/usr/local/include -L/usr/local/lib -o xlio_ultra_api_ping_pong examples/xlio_ultra_api_ping_pong.c -libverbs

--- a/.ci/set_env.sh
+++ b/.ci/set_env.sh
@@ -13,12 +13,12 @@ apt-get update
 cd /etc/xlio_pkg/xlio
 rm -rf libxlio/
 
-git clone https://github.com/Mellanox/libxlio.git 
+git clone --recurse-submodules https://github.com/Mellanox/libxlio.git 
 
 cd libxlio/
 git checkout $BRTG
 
-`QA_RPATHS=0x0002 PRJ_RELEASE=${BUILD_ID} contrib/build_pkg.sh -s -b -a "configure_options=--with-dpcp --disable-nginx --disable-utls" &`
+`QA_RPATHS=0x0002 PRJ_RELEASE=${BUILD_ID} contrib/build_pkg.sh -s -b -a "configure_options=--disable-nginx --disable-utls" &`
 
 PUBLISH="/hpc/noarch/xlio_artifacts/"
 PKGDIR="/etc/xlio_pkg/xlio/libxlio/pkg/packages/"

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "submodules/libdpcp"]
+	path = submodules/libdpcp
+	url = https://github.com/Mellanox/libdpcp.git

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,81 @@
 SUBDIRS := third_party src tools docs/man
-
-
 DIST_SUBDIRS := third_party src tests tools docs/man
+
+.PHONY: tests libdpcp-install
+
+# Build and install dpcp only if it is the built-in one.
+# So we do not put submodules/libdpcp in SUBDIRS, instead we do this:
+if BUILD_BUILTIN_DPCP
+
+# Invoke CMake before every build and let it decide whether DPCP is up to date.
+BUILT_SOURCES = libdpcp-install
+
+if BUILTIN_DPCP_STATIC
+DPCP_INSTALL_ARTIFACT = $(DPCP_INSTALL_DIR)/lib/libdpcp.a
+else
+DPCP_INSTALL_ARTIFACT = $(DPCP_INSTALL_DIR)/lib/libdpcp.so
+endif
+DPCP_INSTALL_HEADER = $(DPCP_INSTALL_DIR)/include/mellanox/dpcp.h
+
+libdpcp-install:
+	@test -f "$(DPCP_BUILD_DIR)/CMakeCache.txt" || { echo "Error: libdpcp at $(DPCP_BUILD_DIR) is not configured."; exit 1; }
+	+$(CMAKE) --build "$(DPCP_BUILD_DIR)" --target dpcp
+	cd "$(DPCP_BUILD_DIR)" && DESTDIR= $(CMAKE) \
+		"-DCMAKE_INSTALL_PREFIX=$(DPCP_INSTALL_DIR)" -P cmake_install.cmake
+if BUILTIN_DPCP_STATIC
+	$(MKDIR_P) "$(DPCP_INSTALL_DIR)/lib"
+	cmp -s "$(DPCP_BUILD_DIR)/libdpcp.a" "$(DPCP_INSTALL_DIR)/lib/libdpcp.a" || \
+		cp -f "$(DPCP_BUILD_DIR)/libdpcp.a" "$(DPCP_INSTALL_DIR)/lib/libdpcp.a"
+endif
+	@test -e "$(DPCP_INSTALL_ARTIFACT)" || { echo "Error: libdpcp library was not installed."; exit 1; }
+	@test -f "$(DPCP_INSTALL_HEADER)" || { echo "Error: libdpcp headers were not installed."; exit 1; }
+
+clean-local:
+	@if test -f "$(DPCP_BUILD_DIR)/CMakeCache.txt"; then \
+		$(CMAKE) --build "$(DPCP_BUILD_DIR)" --target clean; \
+	fi
+	rm -rf "$(DPCP_INSTALL_DIR)"
+
+if DPCP_CMAKE_IN_SOURCE
+distclean-local:
+	find "$(DPCP_SOURCE_DIR)" -type d -name CMakeFiles -prune -exec rm -rf {} \;
+	find "$(DPCP_SOURCE_DIR)" -type f \
+		\( -name CMakeCache.txt -o -name cmake_install.cmake -o -name install_manifest.txt \) -delete
+	find "$(DPCP_SOURCE_DIR)" -type f -name Makefile \
+		! -path "$(DPCP_SOURCE_DIR)/.ci/Makefile" -delete
+	rm -rf "$(DPCP_SOURCE_DIR)/install" "$(DPCP_SOURCE_DIR)/mock_include"
+else
+distclean-local:
+	rm -rf "$(DPCP_BUILD_DIR)"
+	rm -rf "$(DPCP_SOURCE_DIR)/src/api/CMakeFiles"
+	rm -f "$(DPCP_SOURCE_DIR)/src/api/Makefile" \
+		"$(DPCP_SOURCE_DIR)/src/api/cmake_install.cmake"
+endif
+
+endif  # of BUILD_BUILTIN_DPCP
+
+DPCP_DIST_SOURCE_DIR = $(abs_top_srcdir)/submodules/libdpcp
+
+dist-hook:
+	rm -rf "$(distdir)/submodules/libdpcp"
+	$(MKDIR_P) "$(distdir)/submodules/libdpcp"
+	@dpcp_git_root=`git -C "$(DPCP_DIST_SOURCE_DIR)" rev-parse --show-toplevel 2>/dev/null || true`; \
+	if test "x$$dpcp_git_root" = "x$(DPCP_DIST_SOURCE_DIR)"; then \
+		git -C "$(DPCP_DIST_SOURCE_DIR)" archive --format=tar HEAD | \
+			tar -xf - -C "$(distdir)/submodules/libdpcp"; \
+	else \
+		cp -fpR "$(DPCP_DIST_SOURCE_DIR)/." "$(distdir)/submodules/libdpcp"; \
+		rm -f "$(distdir)/submodules/libdpcp/.git"; \
+		rm -rf "$(distdir)/submodules/libdpcp/build" \
+			"$(distdir)/submodules/libdpcp/install" \
+			"$(distdir)/submodules/libdpcp/mock_include"; \
+		find "$(distdir)/submodules/libdpcp" -type d -name CMakeFiles \
+			-prune -exec rm -rf {} \;; \
+		find "$(distdir)/submodules/libdpcp" -type f \
+			\( -name CMakeCache.txt -o -name cmake_install.cmake -o -name install_manifest.txt \) -delete; \
+		find "$(distdir)/submodules/libdpcp" -type f -name Makefile \
+			! -path "$(distdir)/submodules/libdpcp/.ci/Makefile" -delete; \
+	fi
 
 noinst_SCRIPTS = \
 	$(wildcard contrib/scripts/*)
@@ -12,9 +86,6 @@ EXTRA_DIST = \
 	LICENSE \
 	CHANGES \
 	README
-
-
-.PHONY: tests
 
 mydocdir = $(if $(docdir),$(docdir),${datadir}/doc/$(distdir))
 mydoc_DATA = README CHANGES

--- a/README.md
+++ b/README.md
@@ -41,39 +41,51 @@ Please visit [DOCA website](https://developer.nvidia.com/networking/doca) for mo
 ##### DPCP
 
 DPCP (Direct Packet Control Plane) is mandatory to run XLIO.
-Repository: [libdpcp](https://github.com/Mellanox/libdpcp.git)
 
-```sh
-$ ./autogen.sh
-$ ./configure --prefix=/where/to/install
-$ make -j
-$ make install
-```
+XLIO utilises libdpcp as a git submodule, by that specifying a built-in DPCP version.
+The built-in DPCP is configured and built with CMake as part of the XLIO build.
+
+Note that if git is installed, and the root directory looks like a git directory, running ./autogen.sh runs
+'git submodule update --init --recursive', so there is no need to run it explicitly.
+Otherwise, you need to run that git command after cloning, or use 'git clone --recurse-submodules' when cloning.
+
+By default libdpcp is linked statically into libxlio, this can be changed to dynamic linkage by running the 
+libxlio `./configure` script with the `--enable-dpcp-shared` flag.
+
+To link against an external DPCP version, run libxlio's `./configure` with the `--with-dpcp=/path/to/dpcp/install`
+flag. In this case, libdpcp is not built as part of the XLIO build.
+Alternatively, if some non-standard flags are needed for the DPCP build, run libxlio's `./configure` with the
+`--with-dpcp-flags='-DOPTION=VALUE ...'` flag. It allows passing additional options to the built-in libdpcp CMake 
+configuration. This option cannot be combined with `--with-dpcp`.
+
+After pulling libxlio, which might trigger an update of the libdpcp submodule, it is advised to clean libdpcp
+to protect against the unlikely case that old libdpcp artifacts remain and interfere with the build.
 
 ##### Tools
 
-Autoconf, Automake, libtool, unzip, patch, libnl-devel (netlink 3)
+Autoconf, Automake, libtool, cmake, unzip, patch, libnl-devel (netlink 3)
 
 #### Compiling XLIO
 
-Run the following commands from within the directory at the top of the tree:
+Building XLIO is done like this:
 
 ```sh
-$ ./autogen.sh
-$ ./configure --prefix=/where/to/install --with-dpcp=/where/dpcp/installed --enable-utls
-$ make -j
-$ make install
+./autogen.sh
+./configure --prefix=/where/to/install
+make -j
+make install
 ```
---enable-utls : Enables uTLS HW offload for supported NVIDIA HW.
+Commonly used flags for `./configure`:
 
-#### Compiling XLIO using preinstalled dpcp
+- `--disable-utls` : Disables uTLS HW offload for supported NVIDIA HW.
+- `--enable-static --disable-shared` : Build XLIO as a static library and not as a shared object.
 
-```sh
-$ ./autogen.sh
-$ ./configure --prefix=/where/to/install --with-dpcp --enable-utls
-$ make -j
-$ make install
-```
+Summary of `./configure` flags related to dpcp:
+- `--with-dpcp=/where/dpcp/is/installed` : Use libdpcp from a pre-installed location. When this flag
+   is used, libdpcp is not built. It is assumed that it is already built and installed at the specified directory.
+- `--with-dpcp-flags='-DOPTION=VALUE ...'` : Pass additional options to the built-in libdpcp CMake configuration.
+   This option cannot be combined with `--with-dpcp`.
+- `--enable-dpcp-shared` : Link with dpcp dynamically instead of statically
 
 #### Configure
 See more [Options](./docs/configuration.md)

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,6 +1,17 @@
 #!/bin/sh
 
 set -e
+
+# Initialize git submodules if git is available and we're in a git repo
+if command -v git >/dev/null 2>&1 &&
+    git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    GIT_TOPLEVEL=$(git rev-parse --show-toplevel)
+    if test "$(cd "$GIT_TOPLEVEL" && pwd -P)" = "$(pwd -P)"; then
+        echo "Updating git submodules..."
+        git submodule update --init --recursive
+    fi
+fi
+
 rm -rf autom4te.cache
 mkdir -p config
 autoreconf -v --install || exit 1

--- a/config/m4/dpcp.m4
+++ b/config/m4/dpcp.m4
@@ -30,26 +30,97 @@ get_version_number()
 
 get_min_supported_version()
 {
-    echo 10158
+    echo 10161
 }
 
-AC_ARG_WITH([dpcp],
-    AS_HELP_STRING([--with-dpcp@<:@=DIR@:>@],
-                   [Search for dpcp headers and libraries in DIR @<:@default: /usr@:>@]),
-    [],
-    []
+AC_ARG_ENABLE([dpcp-shared],
+    AS_HELP_STRING([--enable-dpcp-shared],
+                   [Link libdpcp dynamically instead of statically @<:@default: static@:>@]),
+    [enable_dpcp_shared="$enableval"],
+    [enable_dpcp_shared=no]
 )
 
 if test "x$prj_cv_directverbs" != x3; then
     AC_MSG_ERROR([RDMA-core subsystem required])
 fi
 
-prj_cv_dpcp=0
-if test -z "$with_dpcp" || test "$with_dpcp" = "yes"; then
-    with_dpcp=/usr
+if test "x$enable_dpcp_shared" = "xyes"; then
+    DPCP_CMAKE_STATIC=OFF
+else
+    DPCP_CMAKE_STATIC=ON
 fi
 
-FUNC_CHECK_WITHDIR([dpcp], [$with_dpcp], [include/mellanox/dpcp.h])
+# Define conditional for building built-in libdpcp
+AM_CONDITIONAL([BUILD_BUILTIN_DPCP], [test "x$dpcp_explicitly_specified" != "xyes"])
+
+
+DPCP_SOURCE_DIR=
+DPCP_BUILD_DIR=
+DPCP_INSTALL_DIR=
+DPCP_CMAKE_IN_SOURCE=no
+
+if test "x$dpcp_explicitly_specified" = "xno"; then
+    if test ! -f "$srcdir/submodules/libdpcp/CMakeLists.txt"; then
+        AC_MSG_ERROR([$srcdir/submodules/libdpcp/CMakeLists.txt not found, did you run ./autogen.sh?
+                      This should have populated $srcdir/submodules/libdpcp by running 'git submodule update --init --recursive'.
+                      To use libdpcp from another location, specify --with-dpcp=DIR])
+    fi
+
+    AC_PATH_PROGS([CMAKE], [cmake3 cmake], [])
+    if test -z "$CMAKE"; then
+        AC_MSG_ERROR([CMake is required to configure the built-in libdpcp])
+    fi
+
+    dpcp_top_srcdir=`cd "$srcdir" && pwd`
+    DPCP_SOURCE_DIR="$dpcp_top_srcdir/submodules/libdpcp"
+    if test "x$dpcp_top_srcdir" = "x$ac_pwd"; then
+        DPCP_BUILD_DIR="$DPCP_SOURCE_DIR"
+        DPCP_CMAKE_IN_SOURCE=yes
+    else
+        DPCP_BUILD_DIR="$ac_pwd/submodules/libdpcp"
+    fi
+    DPCP_INSTALL_DIR="$DPCP_BUILD_DIR/install"
+    with_dpcp="$DPCP_INSTALL_DIR"
+
+    AS_MKDIR_P(["$DPCP_BUILD_DIR"])
+    AC_MSG_NOTICE([configuring built-in libdpcp with CMake])
+    AC_MSG_NOTICE([libdpcp source directory: $DPCP_SOURCE_DIR])
+    AC_MSG_NOTICE([libdpcp build directory: $DPCP_BUILD_DIR])
+    AC_MSG_NOTICE([libdpcp CMake flags: ${with_dpcp_flags:-none}])
+
+    (
+        cd "$DPCP_BUILD_DIR" || exit 1
+        set -f
+        set -- $with_dpcp_flags
+        set +f
+        CC="$CC" CXX="$CXX" "$CMAKE" "$[]@" \
+            "-DCMAKE_INSTALL_PREFIX:PATH=$DPCP_INSTALL_DIR" \
+            "-DCMAKE_INSTALL_LIBDIR:PATH=lib" \
+            "-DDPCP_STATIC:BOOL=$DPCP_CMAKE_STATIC" \
+            "$DPCP_SOURCE_DIR"
+    ) || AC_MSG_ERROR([failed to configure the built-in libdpcp with CMake])
+
+    DPCP_SUMMARY="built-in CMake (DPCP_STATIC=$DPCP_CMAKE_STATIC)"
+else
+    DPCP_SUMMARY="external ($with_dpcp)"
+fi
+DPCP_CMAKE_FLAGS_SUMMARY="${with_dpcp_flags:-none}"
+
+AC_SUBST([CMAKE])
+AC_SUBST([DPCP_SOURCE_DIR])
+AC_SUBST([DPCP_BUILD_DIR])
+AC_SUBST([DPCP_INSTALL_DIR])
+AC_SUBST([DPCP_CMAKE_STATIC])
+AC_SUBST([DPCP_CMAKE_FLAGS], ["$with_dpcp_flags"])
+AM_CONDITIONAL([BUILTIN_DPCP_STATIC], [test "x$dpcp_explicitly_specified" = "xno" && test "x$DPCP_CMAKE_STATIC" = "xON"])
+AM_CONDITIONAL([DPCP_CMAKE_IN_SOURCE], [test "x$DPCP_CMAKE_IN_SOURCE" = "xyes"])
+
+prj_cv_dpcp=0
+# Only check directory exists when --with-dpcp was explicitly specified
+if test "x$dpcp_explicitly_specified" = "xyes"; then
+    FUNC_CHECK_WITHDIR([dpcp], [$with_dpcp], [include/mellanox/dpcp.h])
+    with_dpcp=`cd "$with_dpcp" && pwd`
+fi
 
 prj_cv_dpcp_save_CPPFLAGS="$CPPFLAGS"
 prj_cv_dpcp_save_CXXFLAGS="$CXXFLAGS"
@@ -57,50 +128,130 @@ prj_cv_dpcp_save_CFLAGS="$CFLAGS"
 prj_cv_dpcp_save_LDFLAGS="$LDFLAGS"
 prj_cv_dpcp_save_LIBS="$LIBS"
 
-prj_cv_dpcp_CPPFLAGS="-I$with_dpcp/include"
-prj_cv_dpcp_LIBS="-ldpcp -lmlx5 -libverbs -lgcov"
-prj_cv_dpcp_LDFLAGS="-L$with_dpcp/lib -Wl,--rpath,$with_dpcp/lib"
-if test -d "$with_dpcp/lib64"; then
-    prj_cv_dpcp_LDFLAGS="-L$with_dpcp/lib64 -Wl,--rpath,$with_dpcp/lib64"
+# Make sure libdpcp install directory exists so that compilation checks will not fail due to missing include directory
+if test "x$dpcp_explicitly_specified" = "xno"; then
+    mkdir -p "$with_dpcp/include"
 fi
 
-CPPFLAGS="$prj_cv_dpcp_CPPFLAGS $CPPFLAGS"
-CXXFLAGS="-std=c++11 $CXXFLAGS"
-LDFLAGS="$prj_cv_dpcp_LDFLAGS $LDFLAGS"
-LIBS="$prj_cv_dpcp_LIBS $LIBS"
+prj_cv_dpcp_CPPFLAGS="-I$with_dpcp/include"
 
-AC_LANG_PUSH([C++])
-AC_CHECK_HEADER(
-    [mellanox/dpcp.h],
-    [AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <mellanox/dpcp.h>]],
-            [[dpcp::provider *provider;
-            dpcp::provider::get_instance(provider);]])],
-            [prj_cv_dpcp=1])
-    ])
-AC_LANG_POP()
+# Determine library directory
+if test "x$enable_dpcp_shared" = "xyes"; then
+    prj_cv_dpcp_libname="libdpcp.so"
+else
+    prj_cv_dpcp_libname="libdpcp.a"
+fi
 
-CPPFLAGS="$prj_cv_dpcp_save_CPPFLAGS"
-CXXFLAGS="$prj_cv_dpcp_save_CXXFLAGS"
-CFLAGS="$prj_cv_dpcp_save_CFLAGS"
-LDFLAGS="$prj_cv_dpcp_save_LDFLAGS"
-LIBS="$prj_cv_dpcp_save_LIBS"
-
-
-AC_MSG_CHECKING([for dpcp support])
-if test "$prj_cv_dpcp" -ne 0; then
-    CPPFLAGS="$CPPFLAGS $prj_cv_dpcp_CPPFLAGS"
-    LDFLAGS="$prj_cv_dpcp_LDFLAGS $LDFLAGS"
-    AC_SUBST([DPCP_LIBS], ["-ldpcp"])
-    dpcp_version_number=($(get_version_number))
-    min_supported_version=($(get_min_supported_version))
-
-    if test "$dpcp_version_number" -ge "$min_supported_version"; then
-        AC_DEFINE_UNQUOTED([DEFINED_DPCP_MIN], [$min_supported_version], [Define to DPCP version number (major * 10000 + minor * 100 + patch)])
-        AC_MSG_RESULT([yes])
-    else
-        AC_MSG_ERROR([found incompatible dpcp version $dpcp_version_number (min supported version $min_supported_version) ])
+if test "x$dpcp_explicitly_specified" = "xyes"; then
+    prj_cv_dpcp_libdir=
+    for dpcp_libdir in "$with_dpcp/lib" "$with_dpcp/lib64"; do
+        if test -f "$dpcp_libdir/$prj_cv_dpcp_libname"; then
+            prj_cv_dpcp_libdir="$dpcp_libdir"
+            break
+        fi
+    done
+    if test -z "$prj_cv_dpcp_libdir"; then
+        AC_MSG_ERROR([$prj_cv_dpcp_libname not found in $with_dpcp/lib or $with_dpcp/lib64])
     fi
 else
-    AC_MSG_ERROR([dpcp support requested but not present])
+    prj_cv_dpcp_libdir="$with_dpcp/lib"
+fi
+
+# Set up linking with dpcp based on static/dynamic choice
+prj_cv_dpcp_LIBS_COMMON="-lmlx5 -libverbs -lgcov"
+if test "x$enable_dpcp_shared" = "xyes"; then
+    # Dynamic linking
+    prj_cv_dpcp_SHARED_LIB="$prj_cv_dpcp_libdir/libdpcp.so"
+    prj_cv_dpcp_LIBS="-ldpcp $prj_cv_dpcp_LIBS_COMMON"
+    prj_cv_dpcp_LDFLAGS="-L$prj_cv_dpcp_libdir -Wl,--rpath,$prj_cv_dpcp_libdir"
+    prj_cv_dpcp_final_libs="-ldpcp"
+else
+    # Static linking (default)
+    prj_cv_dpcp_STATIC_LIB="$prj_cv_dpcp_libdir/libdpcp.a"
+    prj_cv_dpcp_LIBS="$prj_cv_dpcp_STATIC_LIB $prj_cv_dpcp_LIBS_COMMON"
+    prj_cv_dpcp_LDFLAGS=""
+    # When building XLIO as a static library, We set prj_cv_dpcp_final_libs empty because ar 
+    # cannot add a .a file into a .a file.
+    # Instead, we add the content of libdpcp.a into libxlio.a by using
+    # the rule for libxlio.la: in src/core/Makefile.am
+    if test "x$enable_static" = "xyes"; then
+        prj_cv_dpcp_final_libs=""
+    else
+        prj_cv_dpcp_final_libs="$prj_cv_dpcp_STATIC_LIB"
+    fi
+fi
+
+DPCP_LIB_DEPENDENCY=
+if test "x$dpcp_explicitly_specified" = "xno"; then
+    if test "x$enable_dpcp_shared" = "xyes"; then
+        DPCP_LIB_DEPENDENCY="$prj_cv_dpcp_SHARED_LIB"
+    else
+        DPCP_LIB_DEPENDENCY="$prj_cv_dpcp_STATIC_LIB"
+    fi
+fi
+AC_SUBST([DPCP_LIB_DEPENDENCY])
+
+# Export the static library path for use in src/core/Makefile.am (all-local rule)
+AC_SUBST([DPCP_STATIC_LIB], ["$prj_cv_dpcp_STATIC_LIB"])
+AM_CONDITIONAL([XLIO_AND_DPCP_ARE_STATIC], [test "x$prj_cv_dpcp_STATIC_LIB" != "x" && test "x$enable_static" = "xyes"])
+
+# Only run header/link checks if dpcp was explicitly specified
+# For built-in submodule, we skip these checks since it's not built yet
+if test "x$dpcp_explicitly_specified" = "xyes"; then
+    CPPFLAGS="$prj_cv_dpcp_CPPFLAGS $CPPFLAGS"
+    CXXFLAGS="-std=c++11 $CXXFLAGS"
+    LDFLAGS="$prj_cv_dpcp_LDFLAGS $LDFLAGS"
+    LIBS="$prj_cv_dpcp_LIBS $LIBS"
+
+    AC_LANG_PUSH([C++])
+    AC_CHECK_HEADER(
+        [mellanox/dpcp.h],
+        [AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <mellanox/dpcp.h>]],
+                [[dpcp::provider *provider;
+                dpcp::provider::get_instance(provider);]])],
+                [prj_cv_dpcp=1])
+        ])
+    AC_LANG_POP()
+
+    CPPFLAGS="$prj_cv_dpcp_save_CPPFLAGS"
+    CXXFLAGS="$prj_cv_dpcp_save_CXXFLAGS"
+    CFLAGS="$prj_cv_dpcp_save_CFLAGS"
+    LDFLAGS="$prj_cv_dpcp_save_LDFLAGS"
+    LIBS="$prj_cv_dpcp_save_LIBS"
+
+    AC_MSG_CHECKING([for dpcp support])
+    if test "$prj_cv_dpcp" -ne 0; then
+        CPPFLAGS="$CPPFLAGS $prj_cv_dpcp_CPPFLAGS"
+        LDFLAGS="$prj_cv_dpcp_LDFLAGS $LDFLAGS"
+        AC_SUBST([DPCP_LIBS], ["$prj_cv_dpcp_final_libs"])
+        dpcp_version_number=($(get_version_number))
+        min_supported_version=($(get_min_supported_version))
+
+        if test "$dpcp_version_number" -ge "$min_supported_version"; then
+            AC_DEFINE_UNQUOTED([DEFINED_DPCP_MIN], [$min_supported_version], [Define to DPCP version number (major * 10000 + minor * 100 + patch)])
+            if test "x$enable_dpcp_shared" = "xyes"; then
+                AC_MSG_RESULT([yes (dynamic linking)])
+            else
+                AC_MSG_RESULT([yes (static linking)])
+            fi
+        else
+            AC_MSG_ERROR([found incompatible dpcp version $dpcp_version_number (min supported version $min_supported_version) ])
+        fi
+    else
+        AC_MSG_ERROR([dpcp support requested but not present])
+    fi
+else
+    # Using built-in submodule - skip checks, assume dpcp will be built
+    AC_MSG_CHECKING([for dpcp support])
+    AC_MSG_RESULT([using built-in submodule (will be built)])
+    
+    # Set up paths for when it is built
+    CPPFLAGS="$CPPFLAGS $prj_cv_dpcp_CPPFLAGS"
+    LDFLAGS="$prj_cv_dpcp_LDFLAGS $LDFLAGS"
+    AC_SUBST([DPCP_LIBS], ["$prj_cv_dpcp_final_libs"])
+    
+    # Use a placeholder version - the real check happens at make time
+    min_supported_version=($(get_min_supported_version))
+    AC_DEFINE_UNQUOTED([DEFINED_DPCP_MIN], [$min_supported_version], [Define to DPCP version number (major * 10000 + minor * 100 + patch)])
 fi
 ])

--- a/config/m4/func.m4
+++ b/config/m4/func.m4
@@ -32,6 +32,8 @@ XLIO library
 ============================================================================
 Version: ${PRJ_LIBRARY_MAJOR}.${PRJ_LIBRARY_MINOR}.${PRJ_LIBRARY_REVISION}.${PRJ_LIBRARY_RELEASE}
 Git: ${GIT_VER}
+DPCP: ${DPCP_SUMMARY}
+DPCP CMake flags: ${DPCP_CMAKE_FLAGS_SUMMARY}
 
 EOF
 }

--- a/config/m4/utls.m4
+++ b/config/m4/utls.m4
@@ -20,7 +20,23 @@ AC_ARG_ENABLE([utls],
 )
 
 prj_cv_dpcp_1_1_44=0
-AS_IF([test "$prj_cv_dpcp" -ne 0],
+AS_IF([test "x$dpcp_explicitly_specified" = "xno"],
+    [
+    # Built-in DPCP is configured but not installed yet, so probe its source header.
+    prj_cv_utls_save_CPPFLAGS="$CPPFLAGS"
+    CPPFLAGS="-I$DPCP_SOURCE_DIR/src/api $CPPFLAGS"
+    AC_LANG_PUSH([C++])
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <dpcp.h>]],
+         [[dpcp::tis* _tis;
+           dpcp::tls_dek* _dek;
+           int tis_bit = (int)dpcp::TIS_ATTR_TLS;
+           (void)_tis; (void)_dek;
+           (void)tis_bit;]])],
+         [prj_cv_dpcp_1_1_44=1])
+    AC_LANG_POP()
+    CPPFLAGS="$prj_cv_utls_save_CPPFLAGS"
+    ],
+    [test "$prj_cv_dpcp" -ne 0],
     [
     AC_LANG_PUSH([C++])
     AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <mellanox/dpcp.h>]],

--- a/configure.ac
+++ b/configure.ac
@@ -93,8 +93,39 @@ m4_include([config/m4/nl.m4])
 m4_include([config/m4/prof.m4])
 m4_include([config/m4/compiler.m4])
 
-FUNC_CONFIGURE_INIT()
+AC_ARG_WITH([dpcp],
+    AS_HELP_STRING([--with-dpcp@<:@=DIR@:>@],
+                   [Search for dpcp headers and libraries in DIR @<:@default: /usr@:>@]),
+    [dpcp_explicitly_specified=yes],
+    [dpcp_explicitly_specified=no]
+)
 
+dpcp_enabled=yes
+case "$with_dpcp" in
+    yes)
+        with_dpcp=/usr
+        ;;
+    no)
+        dpcp_enabled=no
+        ;;
+esac
+
+AC_ARG_WITH([dpcp-flags],
+    AS_HELP_STRING([--with-dpcp-flags=FLAGS],
+                   [Pass additional FLAGS to the built-in libdpcp CMake configuration]),
+    [],
+    [with_dpcp_flags=""]
+)
+
+if test "x$dpcp_enabled" = "xno"; then
+    AC_MSG_ERROR([--without-dpcp is not supported; use the built-in DPCP or --with-dpcp=DIR])
+fi
+
+if test "x$dpcp_explicitly_specified" = "xyes" && test -n "$with_dpcp_flags"; then
+    AC_MSG_ERROR([--with-dpcp and --with-dpcp-flags are mutually exclusive])
+fi
+
+FUNC_CONFIGURE_INIT()
 
 dnl===-----------------------------------------------------------------------===
 dnl===

--- a/contrib/build_pkg.sh
+++ b/contrib/build_pkg.sh
@@ -98,7 +98,7 @@ echo ${pkg_label} "Putting output at ${pkg_outdir} ..."
 
 if [ -n "$opt_co" -a "$rc" -eq 0 ]; then
     echo ${pkg_label} "Getting ${opt_co} from ${pkg_url} ..."
-    git clone -b "$opt_co" --depth=1 ${pkg_url} ${pkg_indir}
+    git clone -b "$opt_co" --depth=1 --recurse-submodules ${pkg_url} ${pkg_indir}
     rc=$?
 fi
 
@@ -130,6 +130,11 @@ fi
 
 if [ ! -f ${pkg_tarball} ]; then
     echo ${pkg_label} echo "Failure: tarball does not exist at $PWD current rc=$rc (see: ${pkg_log})"
+    exit 1
+fi
+
+if ! tar -tzf ${pkg_tarball} | grep -q '/submodules/libdpcp/CMakeLists.txt$'; then
+    echo ${pkg_label} "Failure: tarball does not contain the bundled libdpcp sources (see: ${pkg_log})"
     exit 1
 fi
 

--- a/contrib/jenkins_tests/copyright-check-map.yaml
+++ b/contrib/jenkins_tests/copyright-check-map.yaml
@@ -5,6 +5,7 @@ general:
         - "\\.dockers.*"
         - "build.*"
         - "third_party\\.*"
+        - "submodules\\.*"
         - "contrib/jenkins_tests.*"
         - "contrib/valgrind.*"
         - "contrib/xlio-bench.*"

--- a/contrib/jenkins_tests/globals.sh
+++ b/contrib/jenkins_tests/globals.sh
@@ -311,56 +311,6 @@ do_version_check()
     }'
 }
 
-do_check_dpcp()
-{
-    local ret=0
-    local dpcp_dir="${WORKSPACE}/${prefix}/_dpcp-last"
-
-    echo "Checking dpcp usage"
-    mkdir -p "${dpcp_dir}"
-    pushd "${dpcp_dir}" > /dev/null 2>&1
-
-    libdpcp_path=${libdpcp_path:="https://github.com/Mellanox/libdpcp|master"}
-    libdpcp_repo=$(echo "${libdpcp_path}" | cut -d'|' -f1)
-    libdpcp_branch=$(echo "${libdpcp_path}" | cut -d'|' -f2)
-    libdpcp_commit=$(echo "${libdpcp_path}" | cut -d'|' -f3)
-    echo "dpcp repo: ${libdpcp_repo}"
-    echo "dpcp branch: ${libdpcp_branch}"
-    echo "dpcp commit: ${libdpcp_commit}"
-
-    set +e
-    if [ ! -d "${dpcp_dir}/install" ]; then
-        eval "timeout -s SIGKILL 30s git clone -b ${libdpcp_branch} ${libdpcp_repo} . "
-        ret=$?
-
-        if [ -z "${libdpcp_commit}" ] && [ $ret -eq 0 ]; then
-            libdpcp_commit=$(git describe --tags "$(git rev-list --tags --max-count=1)")
-            if [ -z "${libdpcp_commit}" ]; then
-                libdpcp_commit=$(git rev-parse --short HEAD)
-            fi
-        fi
-
-        if [ $ret -eq 0 ]; then
-            eval "git checkout ${libdpcp_commit}"
-            ret=$?
-        fi
-
-        if [ $ret -eq 0 ]; then
-            eval "./autogen.sh && ./configure --prefix=${dpcp_dir}/install && make $make_opt install"
-            ret=$?
-        fi
-    fi
-    set -e
-
-    popd > /dev/null 2>&1
-    if [ $ret -eq 0 ]; then
-        eval "$1=${dpcp_dir}/install"
-        echo "dpcp: ${dpcp_dir}/install"
-    else
-        echo "dpcp: no"
-    fi
-}
-
 #######################################################
 #
 main "$@"

--- a/contrib/jenkins_tests/unit_test.sh
+++ b/contrib/jenkins_tests/unit_test.sh
@@ -6,14 +6,11 @@ UNIT_TEST_DIR=${WORKSPACE}/tests/unit_tests
 JSON_C_DIR=${WORKSPACE}/third_party/json-c
 source $(dirname $0)/globals.sh
 
-# Install dpcp (required for unit tests)
 do_check_env
-
-do_check_dpcp opt_value
 
 # Prepare libxlio
 ./autogen.sh
-./configure --with-dpcp=${opt_value}
+./configure
 
 # Prepare json-c
 cd ${JSON_C_DIR}

--- a/contrib/scripts/libxlio.spec.in
+++ b/contrib/scripts/libxlio.spec.in
@@ -15,7 +15,7 @@ Group: System Environment/Libraries
 
 License: GPLv2 or BSD
 Url: https://github.com/Mellanox/%{name}
-Source0: %{url}/archive/%{version}/%{name}-%{version}.tar.gz
+Source0: %{name}-%{version}.tar.gz
 
 # library currently supports only the following architectures
 ExclusiveArch: x86_64 ppc64le ppc64 aarch64
@@ -32,8 +32,7 @@ BuildRequires: pkgconfig(libnl-3.0)
 BuildRequires: pkgconfig(libnl-route-3.0)
 %endif
 BuildRequires: make
-BuildRequires: dpcp >= 1.1.58
-Requires: dpcp >= 1.1.58
+BuildRequires: cmake >= 3.17
 
 %description
 libxlio is a LD_PRELOAD-able library that boosts performance of TCP and

--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -104,15 +104,6 @@ i=0
 if [ "$TARGET" == "all" -o "$TARGET" == "default" ]; then
     export jenkins_target="default"
     export prefix=${jenkins_test_custom_prefix}/${jenkins_target}
-    do_check_dpcp opt_value
-    if [ ! -z "${opt_value}" ]; then
-        target_list[$i]="default: --with-dpcp=${opt_value}"
-        i=$((i+1))
-    else
-        echo "Requested dpcp support can not be executed"
-		do_err "target: $TARGET"
-		exit 1
-    fi
 fi
 
 echo

--- a/debian/control
+++ b/debian/control
@@ -10,12 +10,12 @@ Build-Depends: debhelper (>= 7),
  librdmacm-dev,
  libssl-dev,
  libnl-route-3-dev | libnl-dev,
- dpcp (>= 1.1.58),
+ cmake (>= 3.17)
 Homepage: https://github.com/Mellanox-lab/libxlio
 
 Package: libxlio
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, dpcp (>= 1.1.58)
+Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: LD_PRELOAD-able library that boosts performance
  libxlio is a LD_PRELOAD-able library that boosts performance of TCP and
  UDP traffic. It allows application written over standard socket API to

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,19 +18,39 @@ This option manages  debugging information in the executable, such as the names 
 
 ### --enable-nginx
 
-This option allows to use the library with popular open source software for web serving, reverse proxying, caching, load balancing, media streaming, and more as NGINX.
+This option allows using the library with popular open source software for web serving, reverse proxying, caching, load balancing, media streaming, and more as NGINX.
 
 ### --enable-utls
 
 This option enables uTLS HW offload for supported NVIDIA HW.
 
-### --with-dpcp
+### --with-dpcp=<libdpcp-install-path>
 
-This option allows to use DPCP library for programming Infiniband devices.
-DPCP (Direct Packet Control Plane) is mandatory to enable advanced HW features for supported NVIDIA HW.
-This library should be installed on your system.
+DPCP (Direct Packet Control Plane) is a library for programming Infiniband devices.
+DPCP is mandatory to enable advanced HW features for supported NVIDIA HW.
+By default, libxlio configures the libdpcp submodule with CMake and installs it
+under `submodules/libdpcp/install` in the XLIO build tree.
+This option allows using a non-default location for libdpcp.
 
-Git repository: https://github.com/Mellanox/libdpcp
+DPCP Git repository: https://github.com/Mellanox/libdpcp
+
+### --with-dpcp-flags=<cmake-options>
+
+This option passes additional, whitespace-separated options to the initial
+CMake configuration of the built-in libdpcp. XLIO's required CMake options,
+including the install prefix and static/shared selection, take precedence.
+This option cannot be combined with `--with-dpcp`, because an external
+libdpcp is not configured or built by XLIO.
+
+Example:
+```sh
+./configure --with-dpcp-flags='-DCMAKE_BUILD_TYPE=Debug'
+```
+
+### --enable-dpcp-shared
+
+This option builds and links the built-in libdpcp as a shared library.
+By default, libdpcp is built statically and linked into libxlio.
 
 ### --with-ibprof
 

--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -50,7 +50,7 @@ DISTCLEANFILES = config/descriptor_providers/xlio_config_schema.h
 libxlio_la_CFLAGS = $(XLIO_STATIC_BUILD) $(XLIO_LTO) $(XLIO_PROFILE)
 libxlio_la_CXXFLAGS = $(XLIO_STATIC_BUILD) $(XLIO_LTO) $(XLIO_PROFILE)
 
-libxlio_la_LDFLAGS := $(XLIO_LTO) $(XLIO_PROFILE) -no-undefined \
+libxlio_la_LDFLAGS := $(XLIO_LTO) $(XLIO_PROFILE) -Wl,--exclude-libs,libdpcp.a -no-undefined \
 	-version-number @PRJ_LIBRARY_MAJOR@:@PRJ_LIBRARY_MINOR@:@PRJ_LIBRARY_REVISION@
 
 libxlio_la_LIBADD = \
@@ -64,7 +64,6 @@ libxlio_la_LIBADD = \
 	libconfig_parser.la
 
 dist_noinst_DATA = config/descriptor_providers/xlio_config_schema.json
-
 
 libxlio_la_SOURCES := \
 	dev/allocator.cpp \
@@ -368,4 +367,46 @@ libxlio_la_DEPENDENCIES = \
 	$(top_builddir)/src/core/netlink/libnetlink.la \
 	$(top_builddir)/src/core/infra/libinfra.la \
 	libconfig_parser.la \
-	$(LIBJSON_LIBS)
+	$(LIBJSON_LIBS) \
+	$(DPCP_LIB_DEPENDENCY)
+
+if XLIO_AND_DPCP_ARE_STATIC
+
+# Adding libdpcp.a into libxlio.so is easy - ar does this automatically.
+# For adding the .o files from libdpcp.a into libxlio.a, we need to use a trick, since
+# simply specifying libdpcp.a, or libdpcp.la, as a dependancy of libxlio, does not work.
+# After Automake links libxlio.la, extract the .o files from libdpcp.a and add them
+# to libxlio.a.
+# Extract each archive member occurrence separately so duplicate member names do
+# not overwrite each other. Rename every object before adding it to libxlio.a so
+# it cannot replace an XLIO object with the same member name.
+# Make the command fail if no DPCP object files were extracted.
+all-local: libxlio.la
+	@echo "Merging $(DPCP_STATIC_LIB) into .libs/libxlio.a ..."; \
+	cd .libs && rm -rf dpcp_objs && mkdir -p dpcp_objs && \
+	$(AR) t $(DPCP_STATIC_LIB) | \
+		awk '{ occurrences[$$0]++; print occurrences[$$0], $$0 }' > dpcp_objs/members && \
+	index=0; \
+	while read -r occurrence member; do \
+		index=$$((index + 1)); \
+		case "$$member" in \
+			*.o) ;; \
+			*) echo "Error: Non-object member $$member found in $(DPCP_STATIC_LIB)"; exit 1 ;; \
+		esac; \
+		object_dir=$$(printf "dpcp_objs/%04d" "$$index"); \
+		mkdir -p "$$object_dir" && \
+		(cd "$$object_dir" && $(AR) xN "$$occurrence" "$(DPCP_STATIC_LIB)" "$$member") && \
+		member_name=$${member##*/} && \
+		renamed_name=$$(printf "dpcp_%04d_%s" "$$index" "$$member_name") && \
+		mv "$$object_dir/$$member_name" "dpcp_objs/$$renamed_name" || exit 1; \
+	done < dpcp_objs/members && \
+	rm -f dpcp_objs/members && rm -rf dpcp_objs/[0-9][0-9][0-9][0-9] && \
+	if [ -n "$$(ls -A dpcp_objs/*.o 2>/dev/null)" ]; then \
+		$(AR) rcs libxlio.a dpcp_objs/*.o; \
+	else \
+		echo "Error: No object files extracted from $(DPCP_STATIC_LIB), look at src/core/.libs/dpcp_objs/"; \
+		false; \
+	fi && \
+	rm -rf dpcp_objs;
+
+endif

--- a/tests/build/test-libxlio-build
+++ b/tests/build/test-libxlio-build
@@ -1,0 +1,1109 @@
+#!/usr/bin/env python3
+"""
+Exercise XLIO build-system combinations from clone through make install.
+
+The script creates ./test-build in the current directory. The script may remain
+in the XLIO source tree; all clones, logs, build directories, and staged
+installs are created below ./test-build. If ./test-build already exists, the
+script fails.
+
+Example:
+    mkdir /tmp/xlio-build-tests
+    cd /tmp/xlio-build-tests
+    /path/to/libxlio/tests/build/test-libxlio-build -j 4
+
+Before running the matrix, the script clones and builds an external libdpcp
+under ./test-build/libdpcp. Its ./test-build/libdpcp/install prefix is used for
+--with-dpcp cases.
+
+By default, the repository URL and branch are read from the Git checkout
+containing this script. Set REPO_URL and/or BRANCH in the environment to
+override either value.
+"""
+
+import argparse
+import itertools
+import os
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+CASE_PREFIX = "libxlio-TEST"
+SHORT_CASE_COUNT = 10
+DPCP_REPOSITORY_URL = "https://github.com/Mellanox/libdpcp.git"
+DPCP_DUPLICATE_MEMBER_NAME = "dpcp_duplicate_member.o"
+DPCP_DUPLICATE_SYMBOLS = (
+    "xlio_test_dpcp_duplicate_member_one",
+    "xlio_test_dpcp_duplicate_member_two",
+)
+HEARTBEAT_INTERVAL_SECONDS = 30
+OUTPUT_LOCK = threading.Lock()
+
+
+class CaseFailure(RuntimeError):
+    pass
+
+
+class CaseReport(list):
+    def __init__(self, log_path):
+        super().__init__()
+        self.log_path = log_path
+
+    def append(self, line):
+        super().append(line)
+        with self.log_path.open("a", encoding="utf-8") as log:
+            log.write(f"{line}\n")
+
+    def extend(self, lines):
+        for line in lines:
+            self.append(line)
+
+
+@dataclass(frozen=True)
+class BuildCase:
+    layout: str
+    xlio_mode: str
+    dpcp_source: str
+    dpcp_link_mode: str
+    flags_mode: str
+    prefix_mode: str
+    utls_mode: str
+
+    @property
+    def name(self):
+        return "-".join(
+            (
+                self.layout,
+                self.xlio_mode,
+                self.dpcp_source,
+                self.dpcp_link_mode,
+                self.flags_mode,
+                self.prefix_mode,
+                self.utls_mode,
+            )
+        )
+
+
+@dataclass
+class CaseResult:
+    case: BuildCase
+    passed: bool
+    report: list
+
+
+def positive_int(value):
+    parsed = int(value)
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("must be at least 1")
+    return parsed
+
+
+def regex_pattern(value):
+    try:
+        return re.compile(value)
+    except re.error as error:
+        raise argparse.ArgumentTypeError(f"invalid regular expression: {error}")
+
+
+def format_duration(total_seconds):
+    total_seconds = int(total_seconds)
+    hours, remainder = divmod(total_seconds, 3600)
+    minutes, seconds = divmod(remainder, 60)
+    return f"{hours:02d}:{minutes:02d}:{seconds:02d}"
+
+
+def emit(lines):
+    if isinstance(lines, str):
+        lines = (lines,)
+    with OUTPUT_LOCK:
+        for line in lines:
+            print(line, flush=True)
+
+
+def command_text(args):
+    return "$ " + " ".join(shlex.quote(str(arg)) for arg in args)
+
+
+def cd_command_text(directory, args):
+    command = " ".join(shlex.quote(str(arg)) for arg in args)
+    return f"$ (cd {shlex.quote(str(directory))} && {command})"
+
+
+def require_command(command):
+    if shutil.which(command) is None:
+        raise CaseFailure(f"Required command not found: {command}")
+
+
+def git_value(repository, *arguments):
+    process = subprocess.run(
+        ("git", "-C", str(repository), *arguments),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+    if process.returncode != 0:
+        detail = process.stderr.strip() or "git command failed"
+        raise CaseFailure(detail)
+    return process.stdout.strip()
+
+
+def repository_settings():
+    repository_root_value = git_value(SCRIPT_DIR, "rev-parse", "--show-toplevel")
+    if not repository_root_value:
+        raise CaseFailure("Unable to determine the repository containing this script")
+    repository_root = Path(repository_root_value).resolve()
+
+    if "REPO_URL" in os.environ:
+        repository_url = os.environ["REPO_URL"]
+    else:
+        repository_url = git_value(
+            repository_root, "remote", "get-url", "origin"
+        )
+
+    if "BRANCH" in os.environ:
+        branch = os.environ["BRANCH"]
+    else:
+        branch = git_value(repository_root, "branch", "--show-current")
+        if not branch:
+            raise CaseFailure(
+                "The working repository has a detached HEAD; set BRANCH explicitly"
+            )
+
+    if not repository_url:
+        raise CaseFailure("REPO_URL is empty")
+    if not branch:
+        raise CaseFailure("BRANCH is empty")
+
+    return repository_url, branch
+
+
+def run_logged(args, cwd, log_path, environment, case_name):
+    display_command = cd_command_text(cwd, args)
+    emit(f"[{case_name}] running: {display_command}")
+
+    with log_path.open("a", encoding="utf-8") as log:
+        log.write(f"ACTION running: {display_command}\n")
+        log.flush()
+        process = subprocess.Popen(
+            [str(arg) for arg in args],
+            cwd=str(cwd),
+            env=environment,
+            stdout=log,
+            stderr=subprocess.STDOUT,
+        )
+        while True:
+            try:
+                return process.wait(timeout=HEARTBEAT_INTERVAL_SECONDS)
+            except subprocess.TimeoutExpired:
+                emit(
+                    f"[{case_name}] still running: {display_command} "
+                    f"(output: {log_path})"
+                )
+
+
+def run_captured(args, cwd, log_path, environment):
+    display_command = cd_command_text(cwd, args)
+    with log_path.open("a", encoding="utf-8") as log:
+        log.write(f"ACTION running: {display_command}\n")
+
+    process = subprocess.run(
+        [str(arg) for arg in args],
+        cwd=str(cwd),
+        env=environment,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        check=False,
+    )
+    with log_path.open("a", encoding="utf-8") as log:
+        log.write(process.stdout)
+    return process
+
+
+def prepare_external_dpcp(work_root, environment):
+    dpcp_dir = work_root / "libdpcp"
+    install_dir = dpcp_dir / "install"
+    log_path = work_root / "libdpcp-build.log"
+    setup_name = "external-dpcp"
+
+    if dpcp_dir.exists():
+        raise CaseFailure(
+            f"External DPCP directory already exists; remove it before rerunning: "
+            f"{dpcp_dir}"
+        )
+
+    log_path.write_text("", encoding="utf-8")
+    commands = (
+        (
+            ("git", "clone", DPCP_REPOSITORY_URL, dpcp_dir.name),
+            work_root,
+            "clone",
+        ),
+        (
+            (
+                "cmake",
+                "-S",
+                ".",
+                "-B",
+                "build-shared",
+                "-DCMAKE_INSTALL_PREFIX=install",
+            ),
+            dpcp_dir,
+            "configure shared build",
+        ),
+        (
+            ("cmake", "--build", "build-shared", "-j", "10"),
+            dpcp_dir,
+            "build shared library",
+        ),
+        (
+            ("cmake", "--install", "build-shared"),
+            dpcp_dir,
+            "install shared library",
+        ),
+        (
+            (
+                "cmake",
+                "-S",
+                ".",
+                "-B",
+                "build-static",
+                "-DCMAKE_INSTALL_PREFIX=install",
+                "-DDPCP_STATIC=ON",
+            ),
+            dpcp_dir,
+            "configure static build",
+        ),
+        (
+            ("cmake", "--build", "build-static", "-j", "10"),
+            dpcp_dir,
+            "build static library",
+        ),
+        (
+            ("cmake", "--install", "build-static"),
+            dpcp_dir,
+            "install static library",
+        ),
+    )
+
+    emit(
+        (
+            "Preparing external DPCP",
+            f"  Source: {DPCP_REPOSITORY_URL}",
+            f"  Directory: {dpcp_dir}",
+            f"  Build output: {log_path}",
+        )
+    )
+    for command, cwd, action in commands:
+        if run_logged(command, cwd, log_path, environment, setup_name) != 0:
+            raise CaseFailure(f"Failed to {action}; see {log_path}")
+
+    duplicate_objects = []
+    for index, symbol in enumerate(DPCP_DUPLICATE_SYMBOLS, start=1):
+        member_dir = dpcp_dir / f"duplicate-member-{index}"
+        member_dir.mkdir()
+        source_path = member_dir / "member.c"
+        object_path = member_dir / DPCP_DUPLICATE_MEMBER_NAME
+        source_path.write_text(
+            f"int {symbol}(void) {{ return {index}; }}\n",
+            encoding="utf-8",
+        )
+        if (
+            run_logged(
+                ("cc", "-c", source_path, "-o", object_path),
+                dpcp_dir,
+                log_path,
+                environment,
+                setup_name,
+            )
+            != 0
+        ):
+            raise CaseFailure(
+                f"Failed to compile duplicate DPCP member fixture; see {log_path}"
+            )
+        duplicate_objects.append(object_path)
+
+    static_library = find_dpcp_library(install_dir, "libdpcp.a")
+    if (
+        run_logged(
+            ("ar", "qs", static_library, *duplicate_objects),
+            dpcp_dir,
+            log_path,
+            environment,
+            setup_name,
+        )
+        != 0
+    ):
+        raise CaseFailure(
+            f"Failed to add duplicate DPCP member fixture; see {log_path}"
+        )
+
+    return install_dir
+
+
+def find_dpcp_library(prefix, library_name):
+    for library_dir in (prefix / "lib", prefix / "lib64"):
+        library = library_dir / library_name
+        if library.is_file():
+            return library
+    raise CaseFailure(f"{library_name} not found below {prefix}")
+
+
+def check_file(path, report):
+    report.append(f"  CHECK file exists: {path}")
+    if not path.is_file():
+        raise CaseFailure(f"Expected file not found: {path}")
+
+
+def check_absent(path, report):
+    report.append(f"  CHECK path does not exist: {path}")
+    if path.exists():
+        raise CaseFailure(f"Unexpected artifact exists: {path}")
+
+
+def archive_members(path, work_root, log_path, environment):
+    result = run_captured(
+        ("ar", "t", path),
+        work_root,
+        log_path,
+        environment,
+    )
+    if result.returncode != 0:
+        raise CaseFailure(f"ar failed for {path}")
+    return result.stdout.splitlines()
+
+
+def check_embedded_dpcp_objects(
+    xlio_library,
+    dpcp_library,
+    check_duplicate_fixture,
+    work_root,
+    log_path,
+    environment,
+    report,
+):
+    report.append(
+        f"  CHECK {xlio_library} contains every renamed object from {dpcp_library}"
+    )
+    dpcp_members = archive_members(
+        dpcp_library, work_root, log_path, environment
+    )
+    xlio_members = archive_members(
+        xlio_library, work_root, log_path, environment
+    )
+    expected_members = []
+    for index, member in enumerate(dpcp_members, start=1):
+        member_name = Path(member).name
+        if not member_name.endswith(".o"):
+            raise CaseFailure(
+                f"Unexpected non-object member in {dpcp_library}: {member}"
+            )
+        expected_members.append(
+            f"dpcp_{index:04d}_{member_name[:-2]}.o"
+        )
+
+    missing_members = [
+        member for member in expected_members if member not in xlio_members
+    ]
+    if missing_members:
+        raise CaseFailure(
+            f"{xlio_library} is missing renamed DPCP member "
+            f"{missing_members[0]}"
+        )
+
+    if check_duplicate_fixture:
+        report.append(
+            f"  CHECK both occurrences of {DPCP_DUPLICATE_MEMBER_NAME} "
+            f"retain their symbols"
+        )
+        nm_result = run_captured(
+            ("nm", "-g", "--defined-only", xlio_library),
+            work_root,
+            log_path,
+            environment,
+        )
+        if nm_result.returncode != 0:
+            raise CaseFailure(f"nm failed for {xlio_library}")
+        for symbol in DPCP_DUPLICATE_SYMBOLS:
+            if re.search(rf"\b{re.escape(symbol)}$", nm_result.stdout, re.M) is None:
+                raise CaseFailure(
+                    f"{xlio_library} is missing symbol {symbol} from a "
+                    f"duplicate DPCP member"
+                )
+
+
+def snapshot_mtimes(paths):
+    return {path: path.stat().st_mtime_ns for path in paths}
+
+
+def touch_after_artifacts(source, artifacts):
+    newest_mtime = max(path.stat().st_mtime_ns for path in artifacts)
+    while True:
+        source.touch()
+        if source.stat().st_mtime_ns > newest_mtime:
+            return
+        time.sleep(0.05)
+
+
+def check_artifacts_updated(before, report):
+    for path, old_mtime in before.items():
+        report.append(f"  CHECK artifact was rebuilt: {path}")
+        if path.stat().st_mtime_ns <= old_mtime:
+            raise CaseFailure(f"Artifact was not rebuilt: {path}")
+
+
+def create_cases():
+    dimensions = (
+        ("in-tree", "out"),
+        ("shared", "static"),
+        ("built-in", "external"),
+        ("static", "shared"),
+        ("no-flags", "flags"),
+        ("default-prefix", "prefix"),
+        ("without-utls", "with-utls"),
+    )
+    return [BuildCase(*values) for values in itertools.product(*dimensions)]
+
+
+def run_case(
+    case,
+    work_root,
+    repository_url,
+    branch,
+    external_dpcp_prefix,
+    make_jobs,
+    environment,
+):
+    case_dir_name = f"{CASE_PREFIX}-{case.name}"
+    case_dir = work_root / case_dir_name
+    case_log = work_root / f"{case_dir_name}.log"
+    stage_dir = case_dir / "stage"
+    xlio_prefix = case_dir / "xlio-install"
+    expect_configure_failure = (
+        case.dpcp_source == "external" and case.flags_mode == "flags"
+    )
+
+    if case.layout == "in-tree":
+        build_dir = case_dir
+        display_build_dir = Path(case_dir_name)
+        configure_command = "./configure"
+        dpcp_build_dir = case_dir / "submodules/libdpcp"
+    else:
+        build_dir = case_dir / "out"
+        display_build_dir = Path(case_dir_name) / "out"
+        configure_command = "../configure"
+        dpcp_build_dir = build_dir / "submodules/libdpcp"
+
+    configure_args = []
+    if case.dpcp_source == "external":
+        configure_args.append(f"--with-dpcp={external_dpcp_prefix}")
+    if case.xlio_mode == "static":
+        configure_args.extend(("--enable-static", "--disable-shared"))
+    if case.dpcp_link_mode == "shared":
+        configure_args.append("--enable-dpcp-shared")
+    if case.flags_mode == "flags":
+        configure_args.append("--with-dpcp-flags=-DCMAKE_BUILD_TYPE=Debug")
+    if case.prefix_mode == "prefix":
+        configure_args.append(f"--prefix={xlio_prefix}")
+    if case.utls_mode == "with-utls":
+        configure_args.append("--enable-utls")
+
+    clone_command = ("git", "clone", repository_url, case_dir_name)
+    checkout_command = ("git", "checkout", branch)
+    autogen_command = ("./autogen.sh",)
+    configure_args_full = (configure_command, *configure_args)
+    make_command = ("make", "-C", str(build_dir), f"-j{make_jobs}", "install")
+    if case.prefix_mode == "default-prefix":
+        make_command = (*make_command, f"DESTDIR={stage_dir}")
+
+    case_log.write_text("", encoding="utf-8")
+    report = CaseReport(case_log)
+    report.extend([
+        "",
+        f"=== {case.name} ===",
+        "Commands:",
+        f"  {command_text(clone_command)}",
+        f"  {cd_command_text(case_dir_name, checkout_command)}",
+        f"  {cd_command_text(case_dir_name, autogen_command)}",
+    ])
+    if case.layout == "out":
+        report.append(f"  {command_text(('mkdir', '-p', display_build_dir))}")
+    report.append(f"  {cd_command_text(display_build_dir, configure_args_full)}")
+    if expect_configure_failure:
+        report.append(
+            "  EXPECT configure to reject --with-dpcp with --with-dpcp-flags"
+        )
+    else:
+        report.append(f"  {command_text(make_command)}")
+    report.append(f"  Build output: {case_log}")
+    emit(report)
+    report.clear()
+
+    try:
+        if case_dir.exists():
+            raise CaseFailure(
+                f"Case directory already exists; remove it before rerunning: {case_dir}"
+            )
+        if (
+            run_logged(
+                clone_command, work_root, case_log, environment, case.name
+            )
+            != 0
+        ):
+            raise CaseFailure(f"Clone failed; see {case_log}")
+        if (
+            run_logged(
+                checkout_command, case_dir, case_log, environment, case.name
+            )
+            != 0
+        ):
+            raise CaseFailure(f"Branch checkout failed; see {case_log}")
+        if (
+            run_logged(
+                autogen_command, case_dir, case_log, environment, case.name
+            )
+            != 0
+        ):
+            raise CaseFailure(f"autogen.sh failed; see {case_log}")
+
+        if case.layout == "out":
+            build_dir.mkdir(parents=True)
+
+        configure_status = run_logged(
+            configure_args_full,
+            build_dir,
+            case_log,
+            environment,
+            case.name,
+        )
+
+        if expect_configure_failure:
+            report.extend(
+                (
+                    "Checks after configure:",
+                    "  CHECK configure rejects mutually exclusive dpcp options",
+                )
+            )
+            if configure_status == 0:
+                raise CaseFailure(
+                    "configure unexpectedly accepted --with-dpcp "
+                    "with --with-dpcp-flags"
+                )
+            configure_log = case_log.read_text(encoding="utf-8", errors="replace")
+            expected_error = (
+                "--with-dpcp and --with-dpcp-flags are mutually exclusive"
+            )
+            if expected_error not in configure_log:
+                raise CaseFailure(
+                    f"configure failed for an unexpected reason; see {case_log}"
+                )
+            check_absent(dpcp_build_dir / "CMakeCache.txt", report)
+            check_absent(dpcp_build_dir / "install", report)
+            with case_log.open("a", encoding="utf-8") as log:
+                log.write(f"RESULT PASS: {case.name}\n")
+            return CaseResult(case, True, report)
+
+        if configure_status != 0:
+            raise CaseFailure(f"configure failed; see {case_log}")
+        if (
+            run_logged(
+                make_command, work_root, case_log, environment, case.name
+            )
+            != 0
+        ):
+            raise CaseFailure(f"make install failed; see {case_log}")
+
+        if case.prefix_mode == "prefix":
+            xlio_install_root = xlio_prefix
+        else:
+            xlio_install_root = stage_dir / "usr/local"
+
+        report.append("Checks after build:")
+        if case.xlio_mode == "static":
+            xlio_library = xlio_install_root / "lib/libxlio.a"
+            check_file(xlio_library, report)
+
+            if case.dpcp_link_mode == "static":
+                dpcp_library = (
+                    dpcp_build_dir / "install/lib/libdpcp.a"
+                    if case.dpcp_source == "built-in"
+                    else find_dpcp_library(external_dpcp_prefix, "libdpcp.a")
+                )
+                check_embedded_dpcp_objects(
+                    xlio_library,
+                    dpcp_library,
+                    case.dpcp_source == "external",
+                    work_root,
+                    case_log,
+                    environment,
+                    report,
+                )
+            else:
+                report.append(
+                    f"  CHECK {xlio_library} contains unresolved references "
+                    "to libdpcp symbols"
+                )
+                nm_result = run_captured(
+                    ("nm", "-C", "-u", xlio_library),
+                    work_root,
+                    case_log,
+                    environment,
+                )
+                if nm_result.returncode != 0:
+                    raise CaseFailure(f"nm failed for {xlio_library}")
+                if "dpcp::" not in nm_result.stdout:
+                    raise CaseFailure(
+                        f"No unresolved DPCP symbols found in {xlio_library}"
+                    )
+        else:
+            report.append(
+                f"  CHECK installed libxlio.so exists under "
+                f"{xlio_install_root / 'lib'}"
+            )
+            shared_libraries = sorted(
+                (xlio_install_root / "lib").glob("libxlio.so*")
+            )
+            if not shared_libraries:
+                raise CaseFailure(
+                    f"Installed libxlio.so not found below "
+                    f"{xlio_install_root / 'lib'}"
+                )
+            xlio_library = shared_libraries[0]
+
+            report.append(
+                f"  CHECK {xlio_library} does not export DPCP symbols"
+            )
+            nm_result = run_captured(
+                ("nm", "-D", "--defined-only", "-C", xlio_library),
+                work_root,
+                case_log,
+                environment,
+            )
+            if nm_result.returncode != 0:
+                raise CaseFailure(f"nm failed for {xlio_library}")
+            dpcp_exports = [
+                line for line in nm_result.stdout.splitlines() if "dpcp::" in line
+            ]
+            if dpcp_exports:
+                raise CaseFailure(
+                    f"{xlio_library} exports {len(dpcp_exports)} DPCP symbols; "
+                    f"first export: {dpcp_exports[0]}"
+                )
+
+            ldd_result = run_captured(
+                ("ldd", xlio_library), work_root, case_log, environment
+            )
+            if ldd_result.returncode != 0:
+                raise CaseFailure(f"ldd failed for {xlio_library}")
+
+            if case.dpcp_link_mode == "shared":
+                report.append(
+                    f"  CHECK ldd reports a resolved libdpcp.so dependency "
+                    f"for {xlio_library}"
+                )
+                if re.search(r"libdpcp\.so", ldd_result.stdout) is None:
+                    raise CaseFailure(
+                        f"ldd does not report a libdpcp.so dependency "
+                        f"for {xlio_library}"
+                    )
+                if re.search(
+                    r"libdpcp\.so.*not found", ldd_result.stdout
+                ) is not None:
+                    raise CaseFailure(
+                        f"ldd reports that libdpcp.so cannot be resolved "
+                        f"for {xlio_library}"
+                    )
+            else:
+                report.append(
+                    f"  CHECK ldd reports no libdpcp.so dependency "
+                    f"for {xlio_library}"
+                )
+                if re.search(r"libdpcp\.so", ldd_result.stdout) is not None:
+                    raise CaseFailure(
+                        f"Unexpected dynamic libdpcp dependency in {xlio_library}"
+                    )
+
+        if case.dpcp_source == "built-in":
+            cache_path = dpcp_build_dir / "CMakeCache.txt"
+            check_file(cache_path, report)
+            check_file(
+                dpcp_build_dir / "install/include/mellanox/dpcp.h", report
+            )
+            cache = cache_path.read_text(encoding="utf-8", errors="replace")
+
+            if case.dpcp_link_mode == "shared":
+                check_file(dpcp_build_dir / "libdpcp.so", report)
+                check_file(dpcp_build_dir / "install/lib/libdpcp.so", report)
+                report.append("  CHECK CMake cache contains DPCP_STATIC=OFF")
+                if "DPCP_STATIC:BOOL=OFF" not in cache:
+                    raise CaseFailure(
+                        "Built-in DPCP was not configured as a shared library"
+                    )
+            else:
+                check_file(dpcp_build_dir / "libdpcp.a", report)
+                check_file(dpcp_build_dir / "install/lib/libdpcp.a", report)
+                report.append("  CHECK CMake cache contains DPCP_STATIC=ON")
+                if "DPCP_STATIC:BOOL=ON" not in cache:
+                    raise CaseFailure(
+                        "Built-in DPCP was not configured as a static library"
+                    )
+
+            if case.flags_mode == "flags":
+                report.append(
+                    "  CHECK CMake cache contains CMAKE_BUILD_TYPE=Debug"
+                )
+                if "CMAKE_BUILD_TYPE:STRING=Debug" not in cache:
+                    raise CaseFailure("CMAKE_BUILD_TYPE=Debug was not forwarded")
+            else:
+                report.append(
+                    "  CHECK CMake cache does not set CMAKE_BUILD_TYPE=Debug"
+                )
+                if "CMAKE_BUILD_TYPE:STRING=Debug" in cache:
+                    raise CaseFailure(
+                        "CMAKE_BUILD_TYPE unexpectedly equals Debug"
+                    )
+        else:
+            check_absent(dpcp_build_dir / "CMakeCache.txt", report)
+            check_absent(dpcp_build_dir / "install", report)
+
+        if case.dpcp_source == "built-in":
+            dpcp_extension = "so" if case.dpcp_link_mode == "shared" else "a"
+            dpcp_libraries = (
+                dpcp_build_dir / f"libdpcp.{dpcp_extension}",
+                dpcp_build_dir / "install/lib" / f"libdpcp.{dpcp_extension}",
+            )
+            dpcp_source = case_dir / "submodules/libdpcp/src/dpcp/dpcp.cpp"
+            check_file(dpcp_source, report)
+            dpcp_mtimes = snapshot_mtimes(dpcp_libraries)
+            xlio_mtime = snapshot_mtimes((xlio_library,))
+
+            report.append("Checks after touching a DPCP source file:")
+            report.append(f"  ACTION touch: {dpcp_source}")
+            touch_after_artifacts(
+                dpcp_source, (*dpcp_libraries, xlio_library)
+            )
+            if (
+                run_logged(
+                    make_command, work_root, case_log, environment, case.name
+                )
+                != 0
+            ):
+                raise CaseFailure(
+                    f"make install after touching DPCP failed; see {case_log}"
+                )
+            check_artifacts_updated(dpcp_mtimes, report)
+            check_artifacts_updated(xlio_mtime, report)
+
+        xlio_source = case_dir / "src/core/sock/sockinfo.cpp"
+        check_file(xlio_source, report)
+        xlio_mtime = snapshot_mtimes((xlio_library,))
+
+        report.append("Checks after touching an XLIO source file:")
+        report.append(f"  ACTION touch: {xlio_source}")
+        touch_after_artifacts(xlio_source, (xlio_library,))
+        if (
+            run_logged(
+                make_command, work_root, case_log, environment, case.name
+            )
+            != 0
+        ):
+            raise CaseFailure(
+                f"make install after touching XLIO failed; see {case_log}"
+            )
+        check_artifacts_updated(xlio_mtime, report)
+
+        with case_log.open("a", encoding="utf-8") as log:
+            log.write(f"RESULT PASS: {case.name}\n")
+        return CaseResult(case, True, report)
+    except (CaseFailure, OSError) as error:
+        report.append(f"ERROR: {error}")
+        with case_log.open("a", encoding="utf-8") as log:
+            log.write(f"RESULT FAIL: {case.name}\n")
+        return CaseResult(case, False, report)
+
+
+def print_result(result):
+    status = "PASS" if result.passed else "FAIL"
+    emit((*result.report, f"{status}: {result.case.name}"))
+
+
+def print_progress(completed, total, failures):
+    remaining = total - completed
+    emit(
+        (
+            f"Progress: case {completed} of {total}, "
+            f"{remaining} cases remaining",
+            f"Failures so far: {failures}",
+        )
+    )
+
+
+def print_estimated_time(completed, total, started_at):
+    elapsed = time.monotonic() - started_at
+    remaining = total - completed
+    estimated_time_left = elapsed * remaining / completed
+    emit(f"Estimated runtime left: {format_duration(estimated_time_left)}")
+
+
+def print_failed_cases(failed_results, work_root):
+    if not failed_results:
+        return
+
+    lines = ("", "Failed cases:")
+    for result in failed_results:
+        case_log = work_root / f"{CASE_PREFIX}-{result.case.name}.log"
+        lines += (f"  {result.case.name}: {case_log}",)
+    emit(lines)
+
+
+def validate_environment():
+    for command in ("ar", "cc", "cmake", "git", "make", "ldd", "nm"):
+        require_command(command)
+
+
+def validate_external_dpcp(external_dpcp_prefix):
+    header = external_dpcp_prefix / "include/mellanox/dpcp.h"
+    if not header.is_file():
+        raise CaseFailure(
+            f"libdpcp header was not installed by the external build: {header}"
+        )
+
+    library_dirs = (
+        external_dpcp_prefix / "lib",
+        external_dpcp_prefix / "lib64",
+    )
+    if not any((directory / "libdpcp.a").is_file() for directory in library_dirs):
+        raise CaseFailure(
+            "Static libdpcp archive was not installed by the external build"
+        )
+    if not any((directory / "libdpcp.so").exists() for directory in library_dirs):
+        raise CaseFailure(
+            "Shared libdpcp library was not installed by the external build"
+        )
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "-j",
+        "--jobs",
+        type=positive_int,
+        metavar="N",
+        help="run N test cases concurrently",
+    )
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="list test names (optionally filtered by --filter), then exit",
+    )
+    parser.add_argument(
+        "--filter",
+        type=regex_pattern,
+        metavar="REGEX",
+        help="run only tests whose names match REGEX",
+    )
+    parser.add_argument(
+        "--short",
+        action="store_true",
+        help="run 10 representative cases covering both states of every option",
+    )
+    return parser.parse_args()
+
+
+def main():
+    if hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(line_buffering=True, write_through=True)
+    if hasattr(sys.stderr, "reconfigure"):
+        sys.stderr.reconfigure(line_buffering=True, write_through=True)
+
+    args = parse_arguments()
+    work_root = Path.cwd() / "test-build"
+    run_started_at = time.monotonic()
+    environment = os.environ.copy()
+    environment.pop("CMAKE_BUILD_TYPE", None)
+    all_cases = create_cases()
+    if args.short:
+        half = SHORT_CASE_COUNT // 2
+        # The last five cases complement the first five in every binary
+        # dimension, so each state of every option is represented.
+        all_cases = all_cases[:half] + all_cases[-half:]
+    cases = (
+        [case for case in all_cases if args.filter.search(case.name)]
+        if args.filter
+        else all_cases
+    )
+
+    if work_root.exists():
+        print(
+            f"ERROR: Build directory already exists; remove it before rerunning: "
+            f"{work_root}",
+            file=sys.stderr,
+            flush=True,
+        )
+        return 1
+
+    if not cases:
+        print(
+            "ERROR: No test names match --filter",
+            file=sys.stderr,
+            flush=True,
+        )
+        return 1
+
+    if args.list:
+        emit(case.name for case in cases)
+        return 0
+
+    if args.jobs is None:
+        emit(
+            "Tip: use -j N to run test cases concurrently; "
+            "continuing sequentially."
+        )
+
+    try:
+        validate_environment()
+        repository_url, branch = repository_settings()
+    except CaseFailure as error:
+        print(f"ERROR: {error}", file=sys.stderr, flush=True)
+        emit(f"Total runtime: {format_duration(time.monotonic() - run_started_at)}")
+        return 1
+
+    cpu_count = os.cpu_count() or 1
+    if args.jobs:
+        make_jobs = args.jobs
+    elif "JOBS" in os.environ:
+        try:
+            make_jobs = positive_int(os.environ["JOBS"])
+        except (ValueError, argparse.ArgumentTypeError):
+            print(
+                "ERROR: JOBS must be a positive integer",
+                file=sys.stderr,
+                flush=True,
+            )
+            return 1
+    else:
+        make_jobs = cpu_count
+
+    try:
+        work_root.mkdir()
+    except FileExistsError:
+        print(
+            f"ERROR: Build directory already exists; remove it before rerunning: "
+            f"{work_root}",
+            file=sys.stderr,
+            flush=True,
+        )
+        return 1
+    except OSError as error:
+        print(
+            f"ERROR: Unable to create build directory {work_root}: {error}",
+            file=sys.stderr,
+            flush=True,
+        )
+        return 1
+
+    total = len(cases)
+    summary = (
+        f"Repository: {repository_url}",
+        f"Branch: {branch}",
+        f"Build directory: {work_root}",
+        f"Tests selected: {total}",
+    )
+    if args.jobs is None:
+        summary += (f"Running {total} tests sequentially",)
+    else:
+        summary += (
+            f"Running {total} tests with {args.jobs} concurrent workers "
+            f"and make -j{make_jobs} per test",
+        )
+    emit(summary)
+
+    try:
+        external_dpcp_prefix = prepare_external_dpcp(work_root, environment)
+        validate_external_dpcp(external_dpcp_prefix)
+    except CaseFailure as error:
+        print(f"ERROR: {error}", file=sys.stderr, flush=True)
+        emit(f"Total runtime: {format_duration(time.monotonic() - run_started_at)}")
+        return 1
+
+    passed = 0
+    failed = 0
+    completed = 0
+    failed_results = []
+    tests_started_at = time.monotonic()
+
+    if args.jobs is None:
+        for case in cases:
+            case_started_at = time.monotonic()
+            result = run_case(
+                case,
+                work_root,
+                repository_url,
+                branch,
+                external_dpcp_prefix,
+                make_jobs,
+                environment,
+            )
+            case_elapsed = time.monotonic() - case_started_at
+            completed += 1
+            passed += int(result.passed)
+            failed += int(not result.passed)
+            if not result.passed:
+                failed_results.append(result)
+
+            print_result(result)
+            print_progress(completed, total, failed)
+            emit(f"Case runtime: {format_duration(case_elapsed)}")
+            print_estimated_time(completed, total, tests_started_at)
+
+        emit(
+            (
+                "",
+                f"Verification summary: {passed} passed, {failed} failed",
+            )
+        )
+    else:
+        with ThreadPoolExecutor(max_workers=args.jobs) as executor:
+            futures = {
+                executor.submit(
+                    run_case,
+                    case,
+                    work_root,
+                    repository_url,
+                    branch,
+                    external_dpcp_prefix,
+                    make_jobs,
+                    environment,
+                ): case
+                for case in cases
+            }
+            for future in as_completed(futures):
+                result = future.result()
+                completed += 1
+                passed += int(result.passed)
+                failed += int(not result.passed)
+                if not result.passed:
+                    failed_results.append(result)
+
+                print_result(result)
+                print_progress(completed, total, failed)
+                print_estimated_time(completed, total, tests_started_at)
+
+        emit(("", f"Verification summary: {passed} passed, {failed} failed"))
+
+    print_failed_cases(failed_results, work_root)
+    emit(f"Total runtime: {format_duration(time.monotonic() - run_started_at)}")
+    return int(failed != 0)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Description
- Add libdpcp as a git submodule under submodules/libdpcp
- Used this built-in version of libdpcp for building libxlio, unless --with-dpcp is specified
- Modify autoconf files to build libdpcp using cmake
- Link with libdpcp statically by default
- Add --enable-dpcp-dynamic configure flag for dynamic DPCP linking to allow for keeping the old behavior (static linking is now the default)
- Add --with-dpcp-flags to allow specifying flags for libdpcp cmake when using the built-in dpcp
- Change default DPCP path to <optional-build-dir>/submodules/libdpcp/install
- Update README.md with new build instructions
- Added tests/build/test-libxlio-build.sh to test all build combinations

##### Why ?
From now on, users of libxlio get libdpcp automatically, both when building it (git submodule) and when running it (linked statically). This removes many potential mistakes which wasted a lot of time and effort

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [X] Code follows the style de facto guidelines of this project
- [X] Comments have been inserted in hard to understand places
- [X] Documentation has been updated (if necessary)
- [X] Test has been added (if possible)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - DPCP can now be built automatically as part of XLIO, reducing the need for a separately installed dependency.
  - Added options to use an external DPCP installation, pass custom build flags, and choose static or shared DPCP linking.
  - Source setups can automatically initialize required submodules.

- **Documentation**
  - Expanded build and configuration guidance, including DPCP options, defaults, and advanced hardware feature requirements.

- **Packaging**
  - Updated distribution metadata to build DPCP locally with CMake rather than requiring a separate runtime package.

- **Tests**
  - Added coverage for multiple build layouts, linking modes, installation paths, and DPCP configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->