### PR TITLE
issue: 5180904 add cross-harness agent guidance for PR review

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,41 @@
+# AGENTS.md - libxlio
+
+Guidance for AI coding agents (and humans) working in this repository. This is the vendor-neutral [AGENTS.md](https://agents.md) entry point; `CLAUDE.md` is a symlink to it. Product overview and general contribution rules live in `README.md` and `docs/`.
+
+libxlio is NVIDIA's Accelerated IO (XLIO) user-space TCP/IP stack - a socket-API accelerator loaded via `LD_PRELOAD` that offloads TCP/UDP onto ConnectX / BlueField NICs (kernel bypass). Because it runs under real applications, subtle protocol bugs surface as application misbehavior, not as failing unit tests - review and test accordingly.
+
+## Build
+
+Requires the NVIDIA DOCA/OFED stack and `dpcp`.
+
+```sh
+./autogen.sh
+./configure --prefix=<install-dir> --with-dpcp --enable-utls
+make -j$(nproc)
+```
+
+- `--enable-utls` enables uTLS HW offload. Use profile flags (`--enable-debug`, `--with-asan`, ...) as needed; do not introduce a new build system.
+- The library that `LD_PRELOAD` uses after a build is `src/core/.libs/libxlio.so`, not a system-installed `/usr/lib64/libxlio.so`.
+
+## Test
+
+```sh
+make tests   # builds the gtest and unit_tests suites
+```
+
+- Suites: `tests/unit_tests/unit_tests` and `tests/gtest/gtest`.
+- Raw-packet paths need `CAP_NET_RAW`; without it some tests silently fall back and pass without exercising the real path - run with the capability and verify.
+- After a fresh checkout the first run can panic with `... -1/tasks` (an ODR issue in `mce_sys_var`); fix with `make clean && make -j`, not with env workarounds.
+
+## Contributing
+
+See `docs/contributing.md` and `docs/coding-style.md`. Commits require a DCO `Signed-off-by` (`git commit -s`) and a header of the form `issue: <number> <summary>` (<= 100 columns). Do not hand-edit `CHANGES` or other generated files.
+
+## Reviewing changes (AI or human)
+
+For any pull-request review, follow **`docs/agent/pr-review/review-guide.md`**. It defines the output/severity contract, the public-repo confidentiality rule (cite internal links, never paste confidential content into a public PR), the hardware-evidence bar for data-path changes, the coverage checklist, and two reference catalogs:
+
+- `docs/agent/pr-review/libvma-backport.md` - the libvma fork map (`src/core` <-> `src/vma`), shared vs XLIO-only areas, and the backport method.
+- `docs/agent/pr-review/tcp-deviations.md` - RFC-to-code map, XLIO's accepted deviations, and known Linux-kernel-TCP deviations.
+
+Scrutinize socket-API compatibility, TCP/UDP correctness, retransmission/RTO/timers, `fork`/`exec` and init-order (ODR), buffer/packet and DMA lifetime, offload (LRO/TSO/uTLS), locking/races, and performance. Do not change public socket behavior silently - gate a behavioral change behind a config knob or escalate it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/docs/agent/pr-review/libvma-backport.md
+++ b/docs/agent/pr-review/libvma-backport.md
@@ -1,0 +1,37 @@
+# libvma backport reference
+
+libxlio was forked from libvma (VMA). A correctness fix in shared code should usually be backported to keep the still-maintained libvma stack correct.
+
+## Lineage & maintenance
+
+- libxlio = initial version on top of **VMA 9.2.2** (`CHANGES`: RM #2405040).
+- libvma repo: `github.com/Mellanox/libvma`, **actively maintained** (commits into 2026).
+
+## Path map (critical - do not guess)
+
+libxlio renamed its own `src/vma/` tree to `src/core/` (`CHANGES`: RM #3064947 "Rename /vma directory with /core"). **libvma still uses `src/vma/`.** So:
+
+- libxlio `src/core/<X>`  ->  libvma `src/vma/<X>`
+- e.g. libxlio `src/core/lwip/tcp_in.c`  ->  libvma `src/vma/lwip/tcp_in.c`
+
+When porting to libvma, do not assume it mirrors the XLIO rename: libvma still uses `src/vma/lwip/`, not `src/core/lwip/`.
+
+## Shared vs XLIO-only
+
+- **Shared ancestry (backport candidates):** `lwip/` (TCP core), `sock/`, `proto/` (except TLS), `util/`, `event/`, `iomux/`, `netlink/`, `dev/` (non-dpcp parts), `ib/`, `infra/`.
+- **XLIO-only (do NOT backport):** `proto/tls*` and uTLS HW offload; anything referencing **dpcp**; DOCA; `config_printer` / `tuning_report`; `xlio_*`-named glue. libvma has no TLS offload and no dpcp.
+- Divergence is real: libvma additionally has `lwip/cc_cubic.*` (not present in XLIO); both keep the `TCP_CC_ALGO_MOD` CC abstraction; line numbers differ because the files drifted after the fork.
+
+## Method
+
+1. Map the path (`src/core` -> `src/vma`).
+2. **Verify the bug still exists in libvma's copy** - open the target file; it may have diverged. Do not assume.
+3. **Manual port, not `git cherry-pick`.** The path rename + drift make a clean cherry-pick fail; apply the minimal change by hand and reference the libxlio issue in the libvma commit message.
+4. Confirm any field the patch depends on exists in libvma (e.g. `pcb->nrtx` is present in libvma `src/vma/lwip/tcp.h`).
+5. Re-validate on libvma's own CI/tests - do not assume XLIO's hardware evidence transfers.
+
+## Decision
+
+- Correctness fix in shared code -> backport candidate (YES).
+- XLIO-only feature (uTLS / dpcp / DOCA) -> not applicable (NO).
+- Behavior/perf change gated on XLIO-specific offload -> usually NO / needs judgement.

--- a/docs/agent/pr-review/review-guide.md
+++ b/docs/agent/pr-review/review-guide.md
@@ -1,0 +1,43 @@
+# libxlio PR review guide
+
+How to review a pull request to libxlio (`Mellanox/libxlio`, public, branch `vNext`). Applies to an automated reviewer running in CI and to a human or agent reviewing locally. libxlio is `LD_PRELOAD`ed under real socket applications, so subtle protocol bugs surface as application misbehavior, not as failing unit tests.
+
+A capable reviewer already knows TCP and can read code; this guide exists to make reviews **consistent, complete, correctly formatted, and safe in a public repo**, and to supply XLIO-specific facts (the libvma fork map, XLIO's accepted RFC/Linux deviations) that a sandboxed CI runner may not be able to look up.
+
+## Output contract
+
+Every finding on one line: `severity | file:line | what & why | citation`. Severities:
+
+- `must-fix` - correctness / socket-API compatibility / security / protocol bug, or a data-path change missing its required hardware evidence.
+- `should-fix` - a real issue, not a merge blocker.
+- `question` - needs author intent (may be an intentional deviation).
+- `nit` - style / clarity.
+
+End with one verdict line: `merge` / `no-merge` / `needs-evidence`. Cite the RFC section, Linux behavior, or repo rule you invoke - do not assert a standard without a reference.
+
+## Non-negotiables
+
+1. **Public-repo confidentiality.** libxlio is public. When you consult an internal knowledge base, **cite the link only - never paste confidential text, internal host/rig names, ticket IDs, measured numbers, or internal decision records into the PR comment.** Write "contradicts internal design doc `<link>`", not its contents. Never post embargoed or unreleased detail to a public PR.
+2. **Evidence bar for data-path changes.** For any change to TCP/UDP behavior, retransmission / RTO / timers, congestion control, offload (LRO/TSO/uTLS), or buffer/packet lifetime: unit and gtest passing is **not** sufficient - require a reproduce-then-fix (RED-GREEN) result on real hardware. If it is absent, that point is `must-fix` and the verdict is `needs-evidence`.
+3. **No silent behavior/ABI change.** Flag any change to socket-API semantics or on-wire behavior that is not gated by a config knob or documented.
+
+## Coverage checklist (walk every time)
+
+For each changed hunk: socket-API compatibility; epoll/select/poll; blocking vs non-blocking; TCP/UDP correctness; retransmission / RTO / timers; fork/exec/thread and `LD_PRELOAD` init order (ODR); buffer & packet ownership and DMA-buffer lifetime; checksum/endian; offload (LRO/TSO/Striding-RQ, uTLS); lock ordering / races; error-path cleanup / leaks; performance regressions.
+
+Then the two XLIO-specific dimensions, using the catalogs below:
+
+- **libvma backport** - does the hunk touch code shared with libvma? See `libvma-backport.md`.
+- **RFC / Linux-TCP deviation** - does it introduce or rely on a deviation? Is it an *accepted* XLIO deviation (do not flag) or a new/unintended one (flag)? See `tcp-deviations.md`.
+
+## Reference catalogs
+
+- `libvma-backport.md` - fork lineage, the `src/core` <-> `src/vma` path map, shared vs XLIO-only areas, and the manual-port method. A sandboxed runner may not have a libvma checkout - trust this file over guessing the path.
+- `tcp-deviations.md` - RFC-to-code map, XLIO's accepted deviations (not bugs), and known Linux-kernel-TCP deviations (app-compat).
+
+## Red flags - stop and correct yourself
+
+- About to paste internal KB text / a host name / a ticket number / a measured number into a public comment -> cite the link instead.
+- About to approve a TCP / RTO / CC / offload change because "the code looks right", with no hardware evidence -> the verdict is `needs-evidence`.
+- About to state a libvma path from memory -> check `libvma-backport.md`. libvma uses `src/vma/...`, not `src/core/...` (the rename happened in libxlio).
+- About to flag a deviation as `must-fix` -> check `tcp-deviations.md`; if it is an accepted XLIO deviation, it is not a bug.

--- a/docs/agent/pr-review/tcp-deviations.md
+++ b/docs/agent/pr-review/tcp-deviations.md
@@ -1,0 +1,35 @@
+# XLIO TCP: RFC map, accepted deviations, Linux deviations
+
+XLIO's TCP core is lwIP-derived (`src/core/lwip/`). Use this to (a) find the governing RFC for a changed area, (b) avoid false-flagging an ACCEPTED deviation, (c) spot app-compat gaps vs Linux. A capable reviewer already knows the RFCs - the load-bearing part here is the *accepted-deviation* list (so you do not raise noise) and the exact code sites.
+
+## RFC -> code map
+
+- Core TCP state / sequence: RFC 793 / 1122 - `lwip/tcp.c`, `tcp_in.c`, `tcp_out.c`
+- RTT/RTO estimator (Van Jacobson) + Karn's algorithm: RFC 6298 - `tcp_in.c` (`tcp_receive` SRTT/RTO block), `tcp_impl.h` (clamp / initial-RTO helpers)
+- Congestion control: RFC 5681 - `lwip/cc_lwip.c` `lwip_cong_signal` (`CC_NDUPACK` = fast recovery §3.2; `CC_RTO` = loss response §3.1 (last para), cwnd -> 1 SMSS; `CC_ACK` = slow-start / congestion-avoidance)
+- Appropriate Byte Counting: RFC 3465 - `tcp.h` `tcp_calc_slow_start_increment` (cap 2*SMSS)
+- Initial window: RFC 3390 - `tcp.h` `tcp_calc_initial_cwnd`
+- Window scaling / timestamps / PAWS: RFC 1323 (superseded by 7323) - option handling in `tcp_in.c` / `tcp_out.c`
+- uTLS record / TLS 1.3 offload: RFC 8446 - `proto/tls.h` (XLIO-only)
+
+## ACCEPTED XLIO deviations - do NOT flag as bugs
+
+A PR that merely keeps or relies on these is fine; only flag if a change *breaks* them.
+
+- **Initial window = RFC 3390** `min(4*MSS, max(2*MSS, 4380))`, NOT Linux's IW10 (RFC 6928). Intentional (upstream lwIP). `tcp.h:92`.
+- **Initial ssthresh = infinite** (`0x7FFFFFFF`) - startup governed by cwnd, Linux-like. `tcp.h`.
+- **Initial RTO = 1000 ms** (RFC 6298 §2.1, compliant); RTO clamped to `[TCP_MIN_RTO_TICKS = 3 ticks, 0x7FFFU ticks]` (`opt.h`). Tick-quantized - not an aggressive sub-second min.
+- **RTT/RTO state uses legacy signed `s16_t` storage** - `tcp_clamp_rto_signed_ticks` guards the negative-wrap (see its TODO). Any RTT/RTO change must respect the `s16_t` range.
+- **quickack** is a supported XLIO opt-in knob that changes delayed-ACK behavior; enabling/using it is not a bug.
+- **Pluggable CC** (`TCP_CC_ALGO_MOD = 1`, default `cc_lwip`) - XLIO's default is the lwIP CC, not Linux CUBIC.
+
+## Known Linux-kernel-TCP deviations (app-compat radar)
+
+Applications are implicitly tuned to Linux behavior. Flag only if a PR makes XLIO diverge *further* in a way that breaks app expectations; merely `note` pre-existing ones.
+
+- Initial window: XLIO ~RFC 3390 vs Linux IW10.
+- Default CC: XLIO lwIP-CC vs Linux CUBIC; XLIO has no BBR.
+- Loss recovery: classic timer + dupack; no RACK-TLP and no F-RTO (RFC 5682) by default.
+- Delayed-ACK / quickack semantics differ from Linux `TCP_QUICKACK` / `tcp_delack`.
+- No `tcp_slow_start_after_idle`-style cwnd-restart-after-idle knob.
+- SACK (RFC 2018): not implemented (`cc.h`: `CC_SACK` is marked `/* Not yet. */`); Linux has it on by default.


### PR DESCRIPTION
## Description

##### What
Add vendor-neutral agent guidance (the [agents.md](https://agents.md) standard) so contributors using any AI coding assistant - or none - get the same build, test, and review guidance.

##### Why ?
Contributors increasingly use AI coding agents (Codex, Cursor, Claude, Copilot, ...), but this repo ships no machine-readable onboarding, so each agent reinvents - or gets wrong - the build/test steps, the review focus, and XLIO-specific facts such as the libvma fork relationship. `AGENTS.md` is a cross-vendor open standard (Agentic AI Foundation / Linux Foundation) read natively by most of these tools. Ref: 5180904.

##### How ?
- `AGENTS.md` (root): a lean, vendor-neutral entry point covering build, test, contributing, and review, pointing at `docs/` for detail. `CLAUDE.md` is a symlink to it (Claude Code reads `CLAUDE.md`, not `AGENTS.md`).
- `docs/agent/pr-review/` is the single source of truth referenced by `AGENTS.md`:
  - `review-guide.md` - the review output/severity contract, the public-repo confidentiality rule (cite internal links, never paste confidential content into a public PR), the hardware-evidence bar for data-path changes, and the coverage checklist.
  - `libvma-backport.md` - the libvma fork map (`src/core` <-> `src/vma`), shared vs XLIO-only areas, and the manual-port method.
  - `tcp-deviations.md` - an RFC-to-code map, XLIO's accepted deviations, and known Linux-kernel-TCP deviations.
- No code changes. Technical claims were verified against the current tree (lwIP CC/RTO in `src/core/lwip`, `opt.h`, `tcp.h`, `cc.h`).

## Change type
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [x] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [x] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)
