### PR TITLE
issue: 4670255 Resolve potential gtest hang

### DIFF
--- a/src/core/sock/sock-extra.cpp
+++ b/src/core/sock/sock-extra.cpp
@@ -8,8 +8,11 @@
 #include "config.h"
 #endif
 
+#include <exception>
+
 #include <util/sys_vars.h>
 #include <util/libxlio.h>
+#include <util/xlio_exception.h>
 #include <vlogger/vlogger.h>
 #include <dev/buffer_pool.h>
 #include <event/event_handler_manager_local.h>
@@ -114,6 +117,24 @@ struct xlio_api_t *extra_api()
  * XLIO Ultra API
  */
 
+/*
+ * The Ultra API is a C API, so an exception must never cross its ABI boundary. Object
+ * constructors can throw std::bad_alloc (allocating members, containers, internal objects)
+ * and xlio_error (for example, sockinfo() throws when epoll_create(2) fails with EMFILE).
+ * Translate such an exception into an errno value for the caller.
+ *
+ * xlio_error carries the original errno, which is more specific than a generic ENOMEM.
+ */
+static int errno_from_exception(const std::exception &e)
+{
+    const xlio_error *xlio_err = dynamic_cast<const xlio_error *>(&e);
+
+    if (xlio_err && xlio_err->errnum) {
+        return xlio_err->errnum;
+    }
+    return ENOMEM;
+}
+
 extern "C" int xlio_init_ex(const struct xlio_init_attr *attr)
 {
     if (g_init_global_ctors_done) {
@@ -155,9 +176,12 @@ extern "C" int xlio_poll_group_create(const struct xlio_poll_group_attr *attr,
         return -1;
     }
 
-    poll_group *grp = new poll_group(*attr);
-    if (!grp) {
-        errno = ENOMEM;
+    poll_group *grp;
+    try {
+        grp = new poll_group(*attr);
+    } catch (const std::exception &e) {
+        __log_dbg("xlio_poll_group_create: cannot create a group (%s)", e.what());
+        errno = errno_from_exception(e);
         return -1;
     }
 
@@ -208,8 +232,18 @@ extern "C" int xlio_socket_create(const struct xlio_socket_attr *attr, xlio_sock
         return -1;
     }
 
-    sockinfo_tcp *si = new sockinfo_tcp(fd, attr->domain);
+    /*
+     * TODO: sockinfo_tcp() can throw an exception, for example, std::bad_alloc from an
+     * allocating member or xlio_error when epoll_create(2) fails with EMFILE. Such an
+     * exception escapes this C API and the fd is leaked. Catching it is not enough to fix
+     * the leak: whether ~sockinfo() has already closed the fd depends on which member
+     * threw and on the deferred_close logic, so the caller cannot tell whether closing the
+     * fd here is a leak fix or a double close. This requires sockinfo to guarantee that
+     * the fd is untouched unless construction of the most-derived object completed.
+     */
+    sockinfo_tcp *si = new (std::nothrow) sockinfo_tcp(fd, attr->domain);
     if (!si) {
+        SYSCALL(close, fd);
         errno = ENOMEM;
         return -1;
     }
@@ -256,8 +290,19 @@ extern "C" int xlio_socket_setsockopt(xlio_socket_t sock, int level, int optname
 {
     sockinfo_tcp *si = reinterpret_cast<sockinfo_tcp *>(sock);
     int errno_save = errno;
+    int rc;
 
-    int rc = si->setsockopt(level, optname, optval, optlen);
+    /*
+     * setsockopt() throws xlio_unsupported_api for an unimplemented option when
+     * XLIO_EXCEPTION_HANDLING is configured to do so. Don't let it cross the C ABI.
+     */
+    try {
+        rc = si->setsockopt(level, optname, optval, optlen);
+    } catch (const std::exception &e) {
+        __log_dbg("xlio_socket_setsockopt: %s", e.what());
+        errno = ENOTSUP;
+        return -1;
+    }
     if (rc == 0) {
         errno = errno_save;
     }

--- a/tests/gtest/common/base.cc
+++ b/tests/gtest/common/base.cc
@@ -109,7 +109,8 @@ test_base::test_base()
     }
 
     m_efd_signal = 0;
-    m_efd = eventfd(m_efd_signal, 0);
+    /* Every read is guarded by poll(), and the drain of barrier_fork_wait() must not block. */
+    m_efd = eventfd(m_efd_signal, EFD_NONBLOCK);
 
     m_break_signal = 0;
 }
@@ -326,29 +327,154 @@ int test_base::wait_fork(int pid)
     }
 }
 
-void test_base::barrier_fork(int pid, bool sync_parent)
+/* Monotonic milliseconds, immune to the wall clock steps of the test machine. */
+static uint64_t barrier_time_msec(void)
+{
+    struct timespec ts;
+
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+
+    return static_cast<uint64_t>(ts.tv_sec) * 1000U + ts.tv_nsec / 1000000U;
+}
+
+int test_base::kill_fork(int pid)
+{
+    int status = 0;
+
+    if (0 >= pid) {
+        return (-1);
+    }
+    if (0 > kill(pid, SIGKILL) && ESRCH != errno) {
+        log_error("failed kill() errno: %s\n", strerror(errno));
+        return (-1);
+    }
+    while (0 > waitpid(pid, &status, 0)) {
+        if (EINTR == errno) {
+            continue;
+        }
+        /* The child was already reaped, it is gone all the same. */
+        if (ECHILD != errno) {
+            log_error("failed waitpid() errno: %s\n", strerror(errno));
+            return (-1);
+        }
+        break;
+    }
+
+    return 0;
+}
+
+bool test_base::peer_alive(pid_t pid)
+{
+    siginfo_t si;
+
+    memset(&si, 0, sizeof(si));
+    /* WNOWAIT leaves the child in a waitable state, so a later wait_fork() still reports its
+     * real exit status. kill(pid, 0) is not usable here, a zombie still answers it. */
+    if (0 > waitid(P_PID, pid, &si, WEXITED | WNOWAIT | WNOHANG)) {
+        /* ECHILD means the process is not our child anymore, i.e. it is gone. Treat any other
+         * error as alive and let the deadline bound the wait. */
+        return (ECHILD != errno);
+    }
+
+    return (0 == si.si_pid);
+}
+
+bool test_base::barrier_read()
+{
+    ssize_t ret = read(m_efd, &m_efd_signal, sizeof(m_efd_signal));
+
+    if (0 > ret) {
+        if (EAGAIN != errno && EINTR != errno) {
+            log_error("failed read() errno: %s\n", strerror(errno));
+        }
+        return false;
+    }
+    if (0 == m_efd_signal) {
+        return false;
+    }
+    m_efd_signal = 0;
+
+    return true;
+}
+
+bool test_base::barrier_fork_wait(int pid)
+{
+    /* The peer of a waiting parent is the child <pid>, the peer of a waiting child is the
+     * process which forked it. */
+    const bool is_child = (0 == pid);
+    const uint64_t deadline = barrier_time_msec() + TEST_BARRIER_TIMEOUT_SEC * 1000ULL;
+    pid_t peer = pid;
+    bool peer_lost = false;
+
+    if (is_child) {
+        peer = getppid();
+        prctl(PR_SET_PDEATHSIG, SIGTERM);
+        /* Close the window where the parent dies before PDEATHSIG is armed. */
+        peer_lost = (getppid() != peer);
+    }
+
+    while (!peer_lost) {
+        struct pollfd pfd;
+
+        pfd.fd = m_efd;
+        pfd.events = POLLIN;
+        pfd.revents = 0;
+
+        int rc = poll(&pfd, 1, TEST_BARRIER_TICK_MSEC);
+        if (0 > rc && EINTR != errno) {
+            log_error("failed poll() errno: %s\n", strerror(errno));
+            ADD_FAILURE() << "barrier_fork(): poll() failed, errno " << errno;
+            m_break_signal++;
+            return false;
+        }
+        if (0 < rc && barrier_read()) {
+            return true;
+        }
+
+        peer_lost = (is_child ? (getppid() != peer) : !peer_alive(peer));
+        if (!peer_lost && barrier_time_msec() >= deadline) {
+            ADD_FAILURE() << "barrier_fork(): " << (is_child ? "child" : "parent")
+                          << " gave up after " << TEST_BARRIER_TIMEOUT_SEC << "s, peer " << peer
+                          << " is alive but didn't signal the barrier";
+            if (!is_child) {
+                /* Unwedge the child without reaping it, so that the wait_fork() of the test
+                 * still completes and reports the SIGKILL. */
+                kill(peer, SIGKILL);
+            }
+            m_break_signal++;
+            return false;
+        }
+    }
+
+    /* The peer may have signalled the barrier just before it exited. */
+    if (barrier_read()) {
+        return true;
+    }
+    ADD_FAILURE() << "barrier_fork(): " << (is_child ? "child" : "parent") << " lost peer " << peer
+                  << ", it exited without signalling the barrier";
+    m_break_signal++;
+
+    return false;
+}
+
+bool test_base::barrier_fork(int pid, bool sync_parent)
 {
     ssize_t ret;
 
     m_break_signal = 0;
     if ((0 == pid && !sync_parent) || (0 != pid && sync_parent)) {
-        prctl(PR_SET_PDEATHSIG, SIGTERM);
-        do {
-            ret = read(m_efd, &m_efd_signal, sizeof(m_efd_signal));
-            if (ret == -1 && errno == EINTR) {
-                continue;
-            }
-        } while (0 == m_efd_signal);
-        m_efd_signal = 0;
-        ret = write(m_efd, &m_efd_signal, sizeof(m_efd_signal));
-    } else {
-        signal(SIGCHLD, handle_signal);
-        m_efd_signal++;
-        ret = write(m_efd, &m_efd_signal, sizeof(m_efd_signal));
+        return barrier_fork_wait(pid);
     }
-    if (ret != sizeof(m_efd_signal)) {
+
+    signal(SIGCHLD, handle_signal);
+    m_efd_signal++;
+    ret = write(m_efd, &m_efd_signal, sizeof(m_efd_signal));
+    if (ret != static_cast<ssize_t>(sizeof(m_efd_signal))) {
         log_error("write() failed\n");
+        return false;
     }
+
+    return true;
 }
 
 void test_base::handle_signal(int signo)

--- a/tests/gtest/common/base.cc
+++ b/tests/gtest/common/base.cc
@@ -13,6 +13,56 @@ uint16_t test_base::m_port = 0;
 int test_base::m_family = PF_INET;
 int test_base::m_break_signal = 0;
 
+/* Pid of the process that runs the test binary. Set by fork_guard_init(). */
+static pid_t g_main_pid;
+
+/*
+ * Terminates a forked child that escaped its test body. Doesn't touch the gtest state and
+ * doesn't use stdio, both belong to the parent process.
+ */
+static void fork_escape_exit(const char *test_case_name, const char *test_name)
+{
+    char buf[256];
+    int len = snprintf(buf, sizeof(buf),
+                       "[  FORK  ] pid %d escaped its test body and reached %s.%s, terminating\n",
+                       static_cast<int>(getpid()), test_case_name, test_name);
+
+    if (len > 0) {
+        size_t n =
+            (static_cast<size_t>(len) < sizeof(buf) ? static_cast<size_t>(len) : sizeof(buf) - 1);
+        ssize_t ret = write(STDERR_FILENO, buf, n);
+        UNREFERENCED_PARAMETER(ret);
+    }
+    _exit(GTEST_FORK_ESCAPE_STATUS);
+}
+
+class fork_escape_guard : public testing::EmptyTestEventListener {
+    virtual void OnTestStart(const testing::TestInfo &test_info)
+    {
+        if (getpid() == g_main_pid) {
+            return;
+        }
+        /* The event is delivered before the fixture of the next test is constructed, so the
+         * child is stopped before it touches a socket, a port or a counter. */
+        fork_escape_exit(test_info.test_case_name(), test_info.name());
+    }
+    virtual void OnTestProgramEnd(const testing::UnitTest &unit_test)
+    {
+        UNREFERENCED_PARAMETER(unit_test);
+        if (getpid() != g_main_pid) {
+            /* A child that escaped on the last test of the run. Terminate it before the
+             * reporting listeners overwrite the TAP and XML output files of the parent. */
+            fork_escape_exit("", "end of the test program");
+        }
+    }
+};
+
+void fork_guard_init(void)
+{
+    g_main_pid = getpid();
+    testing::UnitTest::GetInstance()->listeners().Append(new fork_escape_guard());
+}
+
 static void convert_and_copy_address(const sockaddr_store_t &source, sockaddr_store_t &dest,
                                      sa_family_t target_family)
 {
@@ -258,7 +308,11 @@ int test_base::wait_fork(int pid)
     }
     if (WIFEXITED(status)) {
         const int exit_status = WEXITSTATUS(status);
-        if (exit_status != 0) {
+        if (exit_status == GTEST_FORK_ESCAPE_STATUS) {
+            log_error("child process %d escaped its test body, likely a fatal assertion "
+                      "returned from the test body and skipped the exit() call\n",
+                      pid);
+        } else if (exit_status != 0) {
             log_trace("non-zero exit status: %d from waitpid() errno: %s\n", exit_status,
                       strerror(errno));
         }

--- a/tests/gtest/common/base.h
+++ b/tests/gtest/common/base.h
@@ -36,6 +36,23 @@
 
 #define SOCK_STR(x) sockaddr2str(reinterpret_cast<const sockaddr *>(&x), sizeof(x)).c_str()
 
+/*
+ * Exit status of a forked child that escaped its test body, see fork_guard_init(). It must not
+ * collide with the exit(testing::Test::HasFailure()) statuses used by the child processes.
+ */
+#define GTEST_FORK_ESCAPE_STATUS 111
+
+/*
+ * Safety net for the forked tests. Records the pid of the main process and appends a listener
+ * that terminates any process which starts a test it doesn't own, i.e. a child that returned
+ * from its test body instead of calling exit().
+ *
+ * Call it from main() after all the reporting listeners are appended and before
+ * RUN_ALL_TESTS(): the End events are delivered in the reverse order of registration, so the
+ * guard must be the last listener to be notified before the reporting ones.
+ */
+void fork_guard_init(void);
+
 class test_base_sock {
 public:
     virtual int get_sock_type() const = 0;

--- a/tests/gtest/common/base.h
+++ b/tests/gtest/common/base.h
@@ -53,6 +53,14 @@
  */
 void fork_guard_init(void);
 
+/*
+ * Upper bound for a single barrier_fork() wait. Deliberately generous: tests can be slow
+ * (TIME_WAIT, drains, migrate pacing). The death of the peer is detected within a tick, the
+ * deadline only backstops a peer which is alive but wedged.
+ */
+#define TEST_BARRIER_TIMEOUT_SEC 120
+#define TEST_BARRIER_TICK_MSEC   100
+
 class test_base_sock {
 public:
     virtual int get_sock_type() const = 0;
@@ -79,6 +87,7 @@ public:
     static int sock_noblock(int fd);
     static int event_wait(struct epoll_event *event);
     static int wait_fork(int pid);
+    static int kill_fork(int pid);
     static void handle_signal(int signo);
 
 protected:
@@ -88,7 +97,8 @@ protected:
     virtual void cleanup();
     virtual void init();
     bool barrier();
-    void barrier_fork(int pid = 0, bool sync_parent = false);
+    /* Returns false if the peer was lost, i.e. it died or missed the deadline. */
+    bool barrier_fork(int pid, bool sync_parent = false);
     bool child_fork_exit() { return m_break_signal; }
     bool test_mapped_ipv4() const;
 
@@ -103,6 +113,9 @@ protected:
 
 private:
     static void *thread_func(void *arg);
+    bool barrier_fork_wait(int pid);
+    bool barrier_read();
+    static bool peer_alive(pid_t pid);
 
     pthread_barrier_t m_barrier;
     int m_efd;

--- a/tests/gtest/main.cc
+++ b/tests/gtest/main.cc
@@ -12,6 +12,7 @@
 #include "common/def.h"
 #include "common/log.h"
 #include "common/sys.h"
+#include "common/base.h"
 
 static int _set_config(int argc, char **argv);
 static int _def_config(void);
@@ -38,6 +39,9 @@ int main(int argc, char **argv)
 
     _def_config();
     _set_config(argc, argv);
+
+    /* Must be the last appended listener, see fork_guard_init(). */
+    fork_guard_init();
 
     return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
## Description
Improve gtests with a fork():

- During group/socket allocation, don't throw bad_alloc and return ENOMEM instead
- Catch child processes that returned from a test case instead of exit()
- Improve barrier_fork() to avoid hang when the child process dies

Read commit messages for details.

##### What
Improve gtests with a fork(). Handle multiple failure scenarios, so gtest fails properly instead of being stuck.

##### Why ?
Bugfixes/improvement of gtests.

##### How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc._

## Change type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of memory allocation failures during socket and polling setup, returning an appropriate error instead of terminating unexpectedly.

* **Tests**
  * Strengthened process-based test stability with timeout handling, peer monitoring, cleanup, and safer synchronization.
  * Added safeguards to prevent child processes from continuing into unrelated test callbacks after forking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->