### PR TITLE
issue: 5176178 Grow TCP cwnd only when the sender is cwnd-limited

### DIFF
--- a/src/core/lwip/cc_lwip.c
+++ b/src/core/lwip/cc_lwip.c
@@ -81,25 +81,46 @@ static void lwip_ack_received(struct tcp_pcb *pcb, uint16_t type)
             pcb->cwnd += pcb->mss;
         }
     } else if (type == CC_ACK) {
-        if (pcb->cwnd < pcb->ssthresh) {
-            u32_t increase = tcp_calc_slow_start_increment(pcb->acked, pcb->mss);
-            if ((u32_t)(pcb->cwnd + increase) > pcb->cwnd) {
-                pcb->cwnd += increase;
-            }
-            LWIP_DEBUGF(TCP_CWND_DEBUG, ("tcp_receive: slow start cwnd %" U32_F "\n", pcb->cwnd));
-        } else {
-            u32_t increment = ((u32_t)pcb->mss * (u32_t)pcb->mss) / pcb->cwnd;
+        /* Congestion window validation (RFC 2861 Section 3, the rule behind
+         * Linux's tcp_is_cwnd_limited()): increase cwnd only if the window was
+         * full when the ACK arrived. On a loss-free, receive-window-limited
+         * flow the in-flight data stays below cwnd (the established-state
+         * ssthresh is effectively infinite, so such a flow lives in slow
+         * start), so ungated growth inflates cwnd on every ACK without bound -
+         * in slow start and congestion avoidance alike - and saturates,
+         * destabilizing the steady state. RFC 7661 (obsoletes 2861) allows
+         * growth more broadly (validated phase); this gate is conservative
+         * with respect to it. Utilization is measured as of before this ACK
+         * (see tcp_inflight_pre_ack). */
+        u32_t inflight_pre_ack = tcp_inflight_pre_ack(pcb->snd_nxt, pcb->lastack, pcb->acked);
 
-            if (increment == 0) {
-                increment = 1;
-            }
+        if (tcp_cwnd_may_grow(inflight_pre_ack, pcb->cwnd)) {
+            if (pcb->cwnd < pcb->ssthresh) {
+                u32_t increase = tcp_calc_slow_start_increment(pcb->acked, pcb->mss);
+                if ((u32_t)(pcb->cwnd + increase) > pcb->cwnd) {
+                    pcb->cwnd += increase;
+                }
+                LWIP_DEBUGF(TCP_CWND_DEBUG,
+                            ("tcp_receive: slow start cwnd %" U32_F "\n", pcb->cwnd));
+            } else {
+                /* Congestion avoidance. mss^2/cwnd truncates to 0 once cwnd >
+                 * mss^2; the floor at 1 (from 7c7981dc) keeps CA progressing and
+                 * must be kept - removing it reintroduces the original stall. It
+                 * is safe now that growth is gated on utilization above: the floor
+                 * can only fire when the flow is genuinely cwnd-limited. */
+                u32_t increment = ((u32_t)pcb->mss * (u32_t)pcb->mss) / pcb->cwnd;
 
-            u32_t new_cwnd = pcb->cwnd + increment;
-            if (new_cwnd > pcb->cwnd) {
-                pcb->cwnd = new_cwnd;
+                if (increment == 0) {
+                    increment = 1;
+                }
+
+                u32_t new_cwnd = pcb->cwnd + increment;
+                if (new_cwnd > pcb->cwnd) {
+                    pcb->cwnd = new_cwnd;
+                }
+                LWIP_DEBUGF(TCP_CWND_DEBUG,
+                            ("tcp_receive: congestion avoidance cwnd %" U32_F "\n", pcb->cwnd));
             }
-            LWIP_DEBUGF(TCP_CWND_DEBUG,
-                        ("tcp_receive: congestion avoidance cwnd %" U32_F "\n", pcb->cwnd));
         }
     }
 }

--- a/src/core/lwip/tcp.h
+++ b/src/core/lwip/tcp.h
@@ -108,6 +108,27 @@ static inline u32_t tcp_calc_slow_start_increment(u32_t acked, u16_t mss)
     return LWIP_MIN(acked, max_increment);
 }
 
+/* Congestion window validation (RFC 2861 Section 3): cwnd may be increased
+ * only if the window was full when the ACK arrived, i.e. the sender is
+ * cwnd-limited. Prevents unbounded per-ACK growth on flows that never use
+ * their window (application- or receive-window-limited). Same rule Linux
+ * enforces via tcp_is_cwnd_limited(); conservative w.r.t. RFC 7661. */
+static inline int tcp_cwnd_may_grow(u32_t flightsize, u32_t cwnd)
+{
+    return flightsize >= cwnd;
+}
+
+/* Reconstruct the in-flight bytes as of BEFORE this ACK. lwip_ack_received runs
+ * after lastack has advanced by acked, so (snd_nxt - lastack) understates the
+ * flightsize outstanding when the ACK arrived by exactly acked; adding it back
+ * yields the pre-ACK in-flight that the utilization gate must test. Wrap-safe:
+ * the window is bounded well under 2^31, so the unsigned subtraction is a small
+ * non-negative distance even across a seqno wrap. */
+static inline u32_t tcp_inflight_pre_ack(u32_t snd_nxt, u32_t lastack, u32_t acked)
+{
+    return (snd_nxt - lastack) + acked;
+}
+
 /** Function prototype for tcp accept callback functions. Called when a new
  * connection can be accepted on a listening pcb.
  *

--- a/tests/gtest/tcp/tcp_cc.cc
+++ b/tests/gtest/tcp/tcp_cc.cc
@@ -8,6 +8,32 @@
 
 #include "src/core/lwip/tcp.h"
 
+/* Congestion-window-validation gate (RM#5176178, RFC 2861 Section 3): cwnd
+ * grows only while the sender is cwnd-limited (in-flight >= cwnd). This is what
+ * stops the unbounded cwnd growth that destabilized the loss-free steady state. */
+TEST(tcp_cc, cwnd_may_grow_only_when_fully_utilized)
+{
+    EXPECT_FALSE(tcp_cwnd_may_grow(4096U, 1000000U)); /* in-flight << cwnd: no growth */
+    EXPECT_TRUE(tcp_cwnd_may_grow(1000000U, 1000000U)); /* in-flight == cwnd: growth */
+    EXPECT_TRUE(tcp_cwnd_may_grow(2000000U, 1000000U)); /* in-flight  > cwnd: growth */
+    EXPECT_FALSE(tcp_cwnd_may_grow(0U, 1U)); /* idle: no growth */
+}
+
+/* RM#5176178: the gate tests the PRE-ACK in-flight. lwip_ack_received runs after
+ * lastack advanced by acked, so tcp_inflight_pre_ack reconstructs the flightsize
+ * outstanding when the ACK arrived: (snd_nxt - lastack) + acked. */
+TEST(tcp_cc, inflight_pre_ack_reconstructs_flightsize)
+{
+    /* snd_nxt=10000, 5000 was outstanding, ACK covers 3000 -> lastack now 8000;
+     * pre-ACK in-flight was 10000-5000 = 5000. */
+    EXPECT_EQ(5000U, tcp_inflight_pre_ack(10000U, 8000U, 3000U));
+    /* full drain: everything outstanding is ACKed, so pre-ACK in-flight == acked. */
+    EXPECT_EQ(4000U, tcp_inflight_pre_ack(9000U, 9000U, 4000U));
+    /* seqno wrap: snd_nxt wrapped past 2^32, lastack advanced across the wrap;
+     * unsigned math still yields the small pre-ACK distance (512), not a huge value. */
+    EXPECT_EQ(512U, tcp_inflight_pre_ack(0x100U, 0xFFFFFF80U, 0x80U));
+}
+
 TEST(tcp_cc, initial_cwnd_uses_rfc3390_formula)
 {
     EXPECT_EQ(4U * 512U, tcp_calc_initial_cwnd(512));


### PR DESCRIPTION
## Description

##### What
Grow TCP cwnd only when the sender is cwnd-limited (congestion window validation), so cwnd no longer inflates without bound on loss-free, receive-window-limited flows - fixes the high-connection RX throughput collapse (RM#5176178).

##### Why ?
RM#5176178: on BF4/CX9 the RX throughput collapses under high connection load. Root cause is in XLIO, not the platform: commit `7c7981dc "Prevent TCP cwnd growth from stalling"` floored the congestion-avoidance increment at 1 (it was `mss^2/cwnd`, which truncates to 0 once `cwnd > mss^2`), removing an accidental cwnd ceiling. Because the established-state ssthresh is effectively infinite (`0x7FFFFFFF`), a loss-free, receive-window-limited XLIO<->XLIO flow lives in slow start with in-flight data well below cwnd, so cwnd then grew on every ACK without bound (measured: ~1 GiB, ~8192x the ~128 KB rwnd) and destabilized the steady state into a bistable ~310<->~55 G collapse. Bisected 3.70.3->3.71.0, matched both ends, N=3.

##### How ?
Grow cwnd only when the window was full when the ACK arrived (pre-ACK in-flight >= cwnd). This is congestion window validation - RFC 2861 §3: _"the correct behavior is for the sender to increase the congestion window only if the window was full when the acknowledgment arrived"_. RFC 7661 (which obsoletes 2861) permits growth more broadly (also whenever at least half the window is in use - its validated phase), so this gate is conservative with respect to both; Linux enforces the same rule via `tcp_is_cwnd_limited()`, gating both slow start and congestion avoidance. Utilization is measured on the **pre-ACK** in-flight, reconstructed as `(snd_nxt - lastack) + acked` (a new `tcp_inflight_pre_ack` helper) - `lwip_ack_received` runs after `lastack` has advanced by `acked`, so the post-ACK value would understate a cwnd-limited flow by one window and wrongly throttle it. The gate (`tcp_cwnd_may_grow`) wraps both slow-start and congestion-avoidance growth; loss-recovery inflation (`CC_DUPACK`) is unchanged. The CA increment floor-at-1 is retained (removing it reintroduces the original stall) and is safe now that it can only fire on a fully-utilized cwnd. Unit tests cover the predicate and the pre-ACK reconstruction (incl. seqno wrap).

## Change type
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [x] Code follows the style de facto guidelines of this project
- [x] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [x] Test has been added (if possible)

---

## Evidence

- libxlio commit: this PR head (single commit on `vNext`).
- app: `xlio_perf` (oci_pattern / streaming), 16 workers, 4KB req-resp + 32KB streaming.
- XLIO config: new-config JSON (`XLIO_USE_NEW_CONFIG=1`), lwip CC, striding-RQ + HW-LRO + TSO, quickack, memory limit.
- NIC / FW: ConnectX-9, FW 82.48.1310 (collapse also invariant across FW 1674 -> GA 82.50.0454 and OS 341/311 - platform exonerated).
- lab host: beni02-bf4 (Grace aarch64) <-> beni01 (x86), single-port, via one Cumulus switch (sw-xlio-rnd03, flat VLAN 1).

**RED-GREEN (collapse - the reported bug):**
- Streaming: RED collapses/bistable; GREEN 9/9 mono @ 404G. Direct mechanism proof: instrumented cwnd reaches 1,073,742,336 B (1 GiB) on RED; GREEN stays at the receive window.
- Req-resp write-fanout (4096 conns/QD16), per-second reporting: RED pinned flat ~37 G / 1.13 Mop/s the whole run; GREEN ~260 G / 7.9 Mop/s. N=3.
- gtest: `tcp_cc.*` 5/5 (incl. `inflight_pre_ack_reconstructs_flightsize`); build clean (5-flavor); 197 unit tests.

**Known tradeoff (disclosed):** on deep-queue-depth (QD64) 4KB request-response the fix trades peak IOPS (read 32c/QD64 ~8.95M vs ~12.06M pre-fix, ~0.74x) - it removes the over-buffering that a runaway cwnd was accidentally exploiting for deeper HW-LRO coalescing on the pps-limited RX. 10M IOPS @ 4KB is still reached at higher-conn/mixed profiles (peak ~15.6M) and the 2M-IOPS-per-namespace floor is met ~4.5x. Feature-owner/QA sign-off on the #4892692 acceptance is being obtained separately. A defensive per-connection cwnd cap was evaluated and **proven non-viable** (32MB recovers the IOPS but re-collapses at 4096-conn fanout - the collapse is aggregate over-commit), so the utilization gate is the correct fix; recovering the deep-QD peak would need a separate TX-side pacing lever (out of scope, follow-up).

**Suspected risk areas:** TCP cwnd growth on receive-window-limited / app-limited flows; interaction with HW-LRO coalescing; no change to loss recovery, RTO, or timers.
