### PR TITLE
issue: 5215894 Improve sendfile() performance for multi-worker scenarios

### DIFF
--- a/docs/xlio_config_reference.md
+++ b/docs/xlio_config_reference.md
@@ -724,7 +724,10 @@ Memory limit for the zero-copy mapping cache used by sendfile().
 **How it works:**
 Files sent via sendfile() are mmap'd, registered with RDMA hardware (ibv_reg_mr), and cached
 by file identity (device + inode). Different file descriptors to the same file share one mapping.
-When the cache exceeds this limit, LRU eviction removes oldest unused mappings.
+Frequently used mappings retain one cache-owned reference so sendfile and TX completion avoid
+exclusive cache locking. Retention is bounded by this byte limit. When space is needed, the cache
+evicts zero-reference mappings first, then uses a second-chance policy to demote and evict older
+hot mappings. Open file descriptors do not prevent an idle mapping from being evicted.
 
 **Tradeoffs:**
 

--- a/src/core/proto/mapping.cpp
+++ b/src/core/proto/mapping.cpp
@@ -40,7 +40,6 @@ mapping_t::mapping_t(file_uid_t &uid, mapping_cache *cache, ib_ctx_handler *p_ib
     m_uid = uid;
     m_addr = nullptr;
     m_size = 0;
-    m_ref = 0;
     m_owners = 0;
     m_ib_ctx = p_ib_ctx;
     p_cache = cache;
@@ -173,23 +172,32 @@ bool mapping_t::memory_belongs(uintptr_t addr, size_t size)
 
 void mapping_t::get(void)
 {
-    lock();
-    ++m_ref;
-    unlock();
+    m_ref.get();
+}
+
+bool mapping_t::put_locked(void)
+{
+    return m_ref.put_locked();
 }
 
 void mapping_t::put(void)
 {
-    p_cache->lock();
-    lock();
+    mapping_cache *cache = p_cache;
 
-    --m_ref;
-    if (m_ref == 0) {
-        p_cache->release_mapping(this);
+    if (m_ref.put_fast()) {
+        return;
     }
 
-    unlock();
-    p_cache->unlock();
+    /*
+     * The zero-reference transition must remain serialized with cache lookup
+     * and LRU handling. A concurrent get() may raise the count while this
+     * thread waits for the write lock, so decrement only after taking it.
+     */
+    cache->lock_wr();
+    if (put_locked()) {
+        cache->release_mapping_unlocked(this);
+    }
+    cache->unlock();
 }
 
 int mapping_t::duplicate_fd(int fd, bool &rw)
@@ -234,9 +242,9 @@ int mapping_t::duplicate_fd(int fd, bool &rw)
 }
 
 mapping_cache::mapping_cache(size_t threshold)
-    : lock_spin("mapping_cache_lock")
-    , m_cache_uid()
+    : m_cache_uid()
     , m_cache_fd()
+    , m_hot_list()
     , m_lru_list()
 {
     memset(&m_stats, 0, sizeof(m_stats));
@@ -254,6 +262,14 @@ mapping_cache::~mapping_cache()
         handle_close(fd_map_iter->first);
     }
 
+    while (!m_hot_list.empty()) {
+        mapping = m_hot_list.get_and_pop_front();
+        if (!demote_mapping_unlocked(mapping)) {
+            map_logerr("Mapping %p is still referenced during cache destruction: ref=%u", mapping,
+                       (unsigned)mapping->m_ref.value());
+        }
+    }
+
     while (!m_lru_list.empty()) {
         mapping = m_lru_list.get_and_pop_front();
         evict_mapping_unlocked(mapping);
@@ -263,7 +279,7 @@ mapping_cache::~mapping_cache()
     for (uid_map_iter = m_cache_uid.begin(); uid_map_iter != m_cache_uid.end(); ++uid_map_iter) {
         mapping = uid_map_iter->second;
         map_loginfo("Cache not empty: fd=%d ref=%u owners=%u", mapping->m_fd,
-                    (unsigned)mapping->m_ref, (unsigned)mapping->m_owners);
+                    (unsigned)mapping->m_ref.value(), (unsigned)mapping->m_owners);
     }
 }
 
@@ -274,18 +290,32 @@ mapping_t *mapping_cache::get_mapping(int local_fd, void *p_ctx)
     file_uid_t uid;
     struct stat st;
     ib_ctx_handler *p_ib_ctx = (ib_ctx_handler *)p_ctx;
+    bool ref_acquired = false;
 
-    lock();
+    // coverity[check_return]
+    lock_rd();
+    iter = m_cache_fd.find(local_fd);
+    if (iter != m_cache_fd.end() && iter->second->m_state == MAPPING_STATE_MAPPED) {
+        mapping = iter->second;
+        if (mapping->m_ref.try_get()) {
+            if (mapping->m_hot_ref.is_retained()) {
+                mapping->m_hot_ref.touch();
+            }
+            unlock();
+            return mapping;
+        }
+        mapping = nullptr;
+    }
+    unlock();
 
+    // coverity[check_return]
+    lock_wr();
+
+    /* Another thread may have populated the FD cache while we changed locks. */
     iter = m_cache_fd.find(local_fd);
     if (iter != m_cache_fd.end()) {
         mapping = iter->second;
-        if (mapping->is_free() && mapping->m_state == MAPPING_STATE_MAPPED) {
-            m_lru_list.erase(mapping);
-        }
-    }
-
-    if (!mapping) {
+    } else {
         if (fstat(local_fd, &st) != 0) {
             map_logerr("fstat() errno=%d (%s)", errno, strerror(errno));
             goto quit;
@@ -302,30 +332,45 @@ mapping_t *mapping_cache::get_mapping(int local_fd, void *p_ctx)
     }
 
 quit:
-    if (mapping) {
+    if (mapping && mapping->m_state != MAPPING_STATE_FAILED) {
+        if (mapping->m_state == MAPPING_STATE_MAPPED) {
+            promote_mapping_unlocked(mapping);
+        }
+
         mapping->get();
+        ref_acquired = true;
 
         /* Mapping object may be unmapped, call mmap() in this case */
         if (mapping->m_state == MAPPING_STATE_UNMAPPED) {
             mapping->map(local_fd);
+            if (mapping->m_state == MAPPING_STATE_MAPPED) {
+                promote_mapping_unlocked(mapping);
+            }
         }
+    } else if (mapping) {
+        mapping = nullptr;
     }
 
     unlock();
 
     if (mapping && mapping->m_state == MAPPING_STATE_FAILED) {
-        mapping->put();
+        if (ref_acquired) {
+            mapping->put();
+        }
         mapping = nullptr;
     }
     return mapping;
 }
 
-void mapping_cache::release_mapping(mapping_t *mapping)
+void mapping_cache::release_mapping_unlocked(mapping_t *mapping)
 {
     assert(mapping->is_free());
+    assert(!mapping->m_hot_ref.is_retained());
 
-    /* TODO Rework */
-    if (mapping->m_state == MAPPING_STATE_FAILED) {
+    if (mapping->m_state != MAPPING_STATE_MAPPED) {
+        if (mapping->m_owners == 0 && mapping->m_state != MAPPING_STATE_UNKNOWN) {
+            destroy_mapping_unlocked(mapping);
+        }
         return;
     }
 
@@ -337,20 +382,18 @@ void mapping_cache::handle_close(int local_fd)
     mapping_t *mapping;
     mapping_fd_map_iter_t iter;
 
-    lock();
+    lock_wr();
     iter = m_cache_fd.find(local_fd);
     if (iter != m_cache_fd.end()) {
         mapping = iter->second;
         assert(mapping->m_owners > 0);
-        --mapping->m_owners;
-        if (mapping->m_owners == 0 &&
-            (mapping->m_state != MAPPING_STATE_MAPPED &&
-             mapping->m_state != MAPPING_STATE_UNKNOWN)) {
-            m_cache_uid.erase(mapping->m_uid);
-            mapping->m_state = MAPPING_STATE_UNKNOWN;
-            delete mapping;
-        }
         m_cache_fd.erase(iter);
+        --mapping->m_owners;
+
+        if (mapping->m_owners == 0 && mapping->is_free() &&
+            mapping->m_state != MAPPING_STATE_MAPPED) {
+            release_mapping_unlocked(mapping);
+        }
     }
     unlock();
 }
@@ -387,9 +430,6 @@ mapping_t *mapping_cache::get_mapping_by_uid_unlocked(file_uid_t &uid, ib_ctx_ha
     iter = m_cache_uid.find(uid);
     if (iter != m_cache_uid.end()) {
         mapping = iter->second;
-        if (mapping->is_free() && mapping->m_state == MAPPING_STATE_MAPPED) {
-            m_lru_list.erase(mapping);
-        }
     }
 
     if (!mapping) {
@@ -402,17 +442,99 @@ mapping_t *mapping_cache::get_mapping_by_uid_unlocked(file_uid_t &uid, ib_ctx_ha
     return mapping;
 }
 
+void mapping_cache::promote_mapping_unlocked(mapping_t *mapping)
+{
+    assert(mapping->m_state == MAPPING_STATE_MAPPED);
+
+    if (mapping->m_hot_ref.is_retained()) {
+        mapping->m_hot_ref.touch();
+        return;
+    }
+
+    if (mapping->is_free()) {
+        m_lru_list.erase(mapping);
+    }
+
+    mapping->m_hot_ref.retain(mapping->m_ref);
+    m_hot_list.push_back(mapping);
+}
+
+bool mapping_cache::demote_mapping_unlocked(mapping_t *mapping)
+{
+    /* Precondition: caller has already removed mapping from m_hot_list. */
+    assert(mapping->m_state == MAPPING_STATE_MAPPED);
+    assert(mapping->m_hot_ref.is_retained());
+
+    bool evictable = mapping->m_hot_ref.release(mapping->m_ref);
+    if (evictable) {
+        release_mapping_unlocked(mapping);
+    }
+    return evictable;
+}
+
+bool mapping_cache::demote_hot_mappings_unlocked()
+{
+    size_t scan = m_hot_list.size();
+    mapping_t *mapping;
+
+    /*
+     * First demote candidates that have already consumed their second chance.
+     * An active candidate does not become evictable immediately, so keep
+     * scanning instead of failing while another candidate may be idle.
+     */
+    while (scan-- > 0) {
+        mapping = m_hot_list.get_and_pop_front();
+        if (unlikely(!mapping)) {
+            return false;
+        }
+        if (mapping->m_hot_ref.consume_recent()) {
+            m_hot_list.push_back(mapping);
+            continue;
+        }
+
+        if (demote_mapping_unlocked(mapping)) {
+            return true;
+        }
+    }
+
+    /*
+     * Only second-chance candidates remain. Their recent bits were cleared by
+     * the first pass; demote them oldest-first until one is evictable or the
+     * bounded candidate set is exhausted.
+     */
+    scan = m_hot_list.size();
+    while (scan-- > 0) {
+        mapping = m_hot_list.get_and_pop_front();
+        if (unlikely(!mapping)) {
+            return false;
+        }
+        if (demote_mapping_unlocked(mapping)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void mapping_cache::destroy_mapping_unlocked(mapping_t *mapping)
+{
+    assert(mapping->m_owners == 0);
+    assert(mapping->m_state != MAPPING_STATE_UNKNOWN);
+
+    m_cache_uid.erase(mapping->m_uid);
+    mapping->m_state = MAPPING_STATE_UNKNOWN;
+    delete mapping;
+}
+
 void mapping_cache::evict_mapping_unlocked(mapping_t *mapping)
 {
     assert(mapping->is_free());
+    assert(!mapping->m_hot_ref.is_retained());
 
     if (mapping->m_state == MAPPING_STATE_MAPPED) {
         mapping->unmap();
     }
     if (mapping->m_owners == 0 && (mapping->m_state != MAPPING_STATE_UNKNOWN)) {
-        m_cache_uid.erase(mapping->m_uid);
-        mapping->m_state = MAPPING_STATE_UNKNOWN;
-        delete mapping;
+        destroy_mapping_unlocked(mapping);
     }
 }
 
@@ -424,10 +546,14 @@ bool mapping_cache::cache_evict_unlocked(size_t toFree)
     map_logdbg("Evicting cache, LRU list size=%zu", m_lru_list.size());
 
     while (freed < toFree) {
-        if (m_lru_list.empty()) {
+        if (m_lru_list.empty() && !demote_hot_mappings_unlocked()) {
             return false;
         }
+        /* coverity[NULL_RETURNS] */
         mapping = m_lru_list.get_and_pop_front();
+        // No need to check if mapping==nullptr. A true demotion result means a mapping was put
+        // in the LRU, so if we are here, it is not empty.
+        /* coverity[NULL_RETURNS][var_deref_op]*/
         freed += mapping->m_size;
         evict_mapping_unlocked(mapping);
         ++m_stats.n_evicts;

--- a/src/core/proto/mapping.h
+++ b/src/core/proto/mapping.h
@@ -15,21 +15,129 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include <assert.h>
+
+#include <atomic>
 #include <unordered_map>
 
 /* Forward declaration */
 class mapping_cache;
 
+class mapping_ref_count {
+public:
+    /* Initialize a mapping with no active or retained references. */
+    mapping_ref_count()
+        : m_value(0)
+    {
+    }
+
+    /* Acquire a reference when the caller already protects the mapping lifetime. */
+    void get() { m_value.fetch_add(1, std::memory_order_relaxed); }
+
+    /* Acquire a reference only if already referenced; return true if acquired, false at zero. */
+    bool try_get()
+    {
+        uint32_t value = m_value.load(std::memory_order_relaxed);
+
+        while (value != 0) {
+            if (m_value.compare_exchange_weak(value, value + 1, std::memory_order_acquire,
+                                              std::memory_order_relaxed)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /* Drop a non-final reference; return true if dropped, false if locked final-put is required. */
+    bool put_fast()
+    {
+        uint32_t value = m_value.load(std::memory_order_relaxed);
+
+        while (value > 1) {
+            if (m_value.compare_exchange_weak(value, value - 1, std::memory_order_release,
+                                              std::memory_order_relaxed)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /* Drop a reference under the cache write lock; return true if the count reached zero. */
+    bool put_locked()
+    {
+        uint32_t value = m_value.fetch_sub(1, std::memory_order_acq_rel);
+
+        assert(value > 0);
+        return value == 1;
+    }
+
+    /* Return a relaxed snapshot of the total current reference count. */
+    uint32_t value() const { return m_value.load(std::memory_order_relaxed); }
+
+private:
+    /* Total transient references plus the optional cache-owned hot reference. */
+    std::atomic<uint32_t> m_value;
+};
+
+class mapping_hot_ref {
+public:
+    /* Initialize a mapping without a retained hot reference or recent access. */
+    mapping_hot_ref()
+        : m_retained(false)
+        , m_recent(false)
+    {
+    }
+
+    /* Add the single cache-owned hot reference and mark the mapping as recently used. */
+    void retain(mapping_ref_count &refs)
+    {
+        assert(!m_retained);
+        refs.get();
+        m_retained = true;
+        m_recent.store(true, std::memory_order_relaxed);
+    }
+
+    /* Remove the hot reference; return true if it was the final reference. */
+    bool release(mapping_ref_count &refs)
+    {
+        assert(m_retained);
+        m_retained = false;
+        m_recent.store(false, std::memory_order_relaxed);
+        return refs.put_locked();
+    }
+
+    /* Mark the hot mapping as recently accessed without taking the cache write lock. */
+    void touch() { m_recent.store(true, std::memory_order_relaxed); }
+
+    /* Atomically clear recency; return true if the mapping had been touched since the last scan. */
+    bool consume_recent() { return m_recent.exchange(false, std::memory_order_relaxed); }
+
+    /* Return true while the cache owns a retained hot reference, otherwise false. */
+    bool is_retained() const { return m_retained; }
+
+private:
+    /* Cache-lock-protected ownership flag; cache readers only inspect it. */
+    bool m_retained;
+
+    /* Lock-free second-chance marker updated by concurrent cache readers. */
+    std::atomic<bool> m_recent;
+};
+
 /* Identifier which must uniquely identify a file within the system. */
 struct file_uid_t {
+    /* Device containing the file. */
     dev_t dev;
+
+    /* Inode identifying the file within its device. */
     ino_t ino;
 
+    /* Return true when both identities have the same device and inode. */
     bool operator==(const file_uid_t &other) const { return dev == other.dev && ino == other.ino; }
 };
 
 namespace std {
 template <> struct hash<file_uid_t> {
+    /* Return the combined device/inode hash used by std::unordered_map. */
     std::size_t operator()(file_uid_t const &uid) const
     {
         std::size_t h1 = std::hash<unsigned long>()((unsigned long)uid.dev);
@@ -46,47 +154,134 @@ typedef enum {
     MAPPING_STATE_FAILED
 } mapping_state_t;
 
-/* TODO replace with rwlock */
-class mapping_t : public mem_desc, lock_spin {
+/*
+ * Mapping cache lifetime and bounded hot-retention model
+ * ======================================================
+ *
+ * A mapping_t is the single canonical mmap/NIC-registration object for one
+ * (device, inode). Two indexes point to that same object:
+ *
+ * - m_cache_fd maps each application FD to its mapping and m_owners counts
+ *   those entries. FD ownership keeps the object discoverable, but does not
+ *   contribute to m_ref and therefore does not prevent memory eviction.
+ * - m_cache_uid deduplicates different FDs for the same file.
+ *
+ * m_ref contains transient sendfile/pbuf references plus at most one retained
+ * hot reference. Frequently reused mappings stay on m_hot_list with that extra
+ * reference, so sendfile and TX-completion puts remain atomic fast-path
+ * decrements and never perform the 1 -> 0 transition.
+ *
+ * Hot retention is bounded by the existing mapping-cache byte threshold:
+ * m_used never exceeds m_threshold. When a new mapping needs space, eviction
+ * first consumes zero-reference mappings from m_lru_list. If the cold LRU is
+ * empty, the cache uses a second-chance policy on m_hot_list: a mapping touched
+ * since the previous scan has its atomic recent bit cleared and moves to the
+ * back. Older mappings lose their hot references until one becomes immediately
+ * evictable. If none of them does, the second-chance mappings are similarly
+ * considered oldest-first. Each eviction attempt scans a bounded snapshot.
+ *
+ * Demotion has two outcomes:
+ *
+ * - No transient users: the hot reference was the last reference, so the
+ *   mapping reaches zero and moves to m_lru_list for immediate eviction.
+ * - Active send/pbuf users: the mapping is removed from m_hot_list but remains
+ *   alive. The final transient put later moves it to m_lru_list.
+ *
+ * The same intrusive m_node is used by the hot list and cold LRU, so a mapping
+ * may be in at most one of them. A mapped object with m_ref == 0 is cold and
+ * must be on m_lru_list. A retained hot object has m_ref >= 1 and is on
+ * m_hot_list. An active, demoted object is temporarily on neither list.
+ *
+ * The mapping-cache RW lock protects both indexes, both lists, m_owners,
+ * m_retained, mapping state, and byte accounting. Fast FD hits hold a read lock
+ * and use try_get(), which never resurrects a zero-reference LRU entry. Cache
+ * misses, promotion/demotion, close, remap, and eviction hold the write lock.
+ * TX completion uses atomic refcount operations; only a final 1 -> 0 put takes
+ * the cache write lock before changing list membership or object lifetime.
+ */
+class mapping_t : public mem_desc {
 public:
+    /* Create an unmapped cache object for a canonical file identity. */
     mapping_t(file_uid_t &uid, mapping_cache *cache, ib_ctx_handler *p_ib_ctx);
+
+    /* Release registration, mapping, and internal FD resources during destruction. */
     ~mapping_t();
 
+    /* Map and register the file; return 0 on success or -1 with errno set on failure. */
     int map(int fd);
+
+    /* Deregister and unmap the file; return the munmap result (0 or -1). */
     int unmap(void);
 
     /* mem_desc interface */
+    /* Return the registered NIC lkey, or LKEY_ERROR when the context is not registered. */
     uint32_t get_lkey(mem_buf_desc_t *desc, ib_ctx_handler *ib_ctx, const void *addr, size_t len);
+
+    /* Acquire an unconditional transient mapping reference. */
     void get(void);
+
+    /* Release a reference, taking the cache write lock only for the final put. */
     void put(void);
 
-    /* For debug */
+    /* Return true when the entire address range lies inside the mapped file region. */
     bool memory_belongs(uintptr_t addr, size_t size);
 
-    bool is_free(void) { return m_ref == 0; }
+    /* Return true when no transient or retained hot references remain. */
+    bool is_free(void) { return m_ref.value() == 0; }
 
+    /* Return the byte offset of the intrusive node within mapping_t. */
     static inline size_t mapping_node_offset(void) { return NODE_OFFSET(mapping_t, m_node); }
 
 private:
+    /* Return an internal FD on success or -1 on failure; rw reports whether it is writable. */
     int duplicate_fd(int fd, bool &rw);
 
+    /* Drop a reference under the cache write lock; return true if the count reached zero. */
+    bool put_locked(void);
+
+    friend class mapping_cache;
+
 public:
+    /* Current mapping lifecycle state. */
     mapping_state_t m_state;
+
+    /* Internal reopened or duplicated FD backing the mmap, not the application FD. */
     int m_fd;
+
+    /* Canonical device/inode identity used by the UID cache. */
     file_uid_t m_uid;
+
+    /* Base address of the current mmap, or nullptr while unmapped. */
     void *m_addr;
+
+    /* Length of the current mmap in bytes. */
     size_t m_size;
-    uint32_t m_ref;
+
+    /* Atomic transient-reference count including an optional retained hot reference. */
+    mapping_ref_count m_ref;
+
+    /* Cache-owned hot-reference and second-chance recency state. */
+    mapping_hot_ref m_hot_ref;
+
+    /* Number of application FD-cache entries that point to this mapping. */
     uint32_t m_owners;
 
 private:
+    /* Parent cache that owns indexes, list membership, and mapping lifetime. */
     mapping_cache *p_cache;
+
+    /* Optional device context used to scope memory registration. */
     ib_ctx_handler *m_ib_ctx;
+
+    /* Owns the NIC memory registrations associated with the mapped range. */
     xlio_registrator m_registrator;
+
+    /* Intrusive node used exclusively by either m_hot_list or m_lru_list. */
     list_node<mapping_t, mapping_t::mapping_node_offset> m_node;
 };
 
 struct mapping_cache_stats {
+    /* Number of mappings removed from the cold LRU to free cache capacity. */
     uint32_t n_evicts;
 };
 
@@ -96,32 +291,74 @@ typedef std::unordered_map<file_uid_t, mapping_t *> mapping_uid_map_t;
 typedef std::unordered_map<file_uid_t, mapping_t *>::iterator mapping_uid_map_iter_t;
 typedef xlio_list_t<mapping_t, mapping_t::mapping_node_offset> mapping_list_t;
 
-class mapping_cache : public lock_spin {
+class mapping_cache : public lock_rw {
 public:
+    /* Create an empty cache with the supplied mapped-byte limit. */
     mapping_cache(size_t threshold);
+
+    /* Drain FD ownership, hot retention, and evictable mappings during shutdown. */
     ~mapping_cache();
 
+    /* Return a referenced mapping for the FD, or nullptr when mapping cannot be prepared. */
     mapping_t *get_mapping(int local_fd, void *p_ctx = nullptr);
-    void release_mapping(mapping_t *mapping);
+
+    /* Process a zero-reference mapping while the cache write lock is held. */
+    void release_mapping_unlocked(mapping_t *mapping);
+
+    /* Remove an application FD from the cache and update mapping ownership. */
     void handle_close(int local_fd);
 
+    /* Reserve mapped bytes; return true on success or false if enough space cannot be evicted. */
     bool memory_reserve_unlocked(size_t size);
+
+    /* Return mapped-byte capacity after a mapping is unmapped. */
     void memory_free(size_t size);
 
+    /* Public counters describing mapping-cache activity. */
     struct mapping_cache_stats m_stats;
 
 private:
+    /* Return the canonical mapping for the UID, or nullptr if object allocation fails. */
     mapping_t *get_mapping_by_uid_unlocked(file_uid_t &uid, ib_ctx_handler *p_ib_ctx = nullptr);
+
+    /* Retain a mapped object in the hot list, removing it from the cold LRU if needed. */
+    void promote_mapping_unlocked(mapping_t *mapping);
+
+    /* Remove the hot reference; return true if the mapping became immediately evictable. */
+    bool demote_mapping_unlocked(mapping_t *mapping);
+
+    /* Demote bounded hot candidates until one becomes immediately evictable. */
+    bool demote_hot_mappings_unlocked();
+
+    /* Remove an ownerless mapping from the UID index and delete its object. */
+    void destroy_mapping_unlocked(mapping_t *mapping);
+
+    /* Unmap one zero-reference mapping and delete it when no FD owners remain. */
     void evict_mapping_unlocked(mapping_t *mapping);
+
+    /* Evict requested bytes; return true if enough was freed, otherwise false. */
     bool cache_evict_unlocked(size_t toFree);
 
+    /* Canonical device/inode index that deduplicates mappings across FDs. */
     mapping_uid_map_t m_cache_uid;
+
+    /* Fast application-FD index into canonical mapping objects. */
     mapping_fd_map_t m_cache_fd;
+
+    /* Recently used mappings that retain one cache-owned reference. */
+    mapping_list_t m_hot_list;
+
+    /* Zero-reference mapped objects ordered from oldest to newest. */
     mapping_list_t m_lru_list;
+
+    /* Total bytes currently mapped and charged to the cache. */
     size_t m_used;
+
+    /* Maximum mapped bytes allowed before eviction is required. */
     size_t m_threshold;
 };
 
+/* Process-global sendfile mapping cache. */
 extern mapping_cache *g_zc_cache;
 
 #endif /* _MAPPING_H */

--- a/tests/unit_tests/Makefile.am
+++ b/tests/unit_tests/Makefile.am
@@ -68,6 +68,7 @@ libgtest_la_SOURCES = \
 unit_tests_LDADD = libgtest.la $(LIBJSON_LIBS)
 
 unit_tests_CPPFLAGS = \
+	-DXLIO_STATIC_BUILD \
 	-I$(top_srcdir)/ \
 	-I$(top_srcdir)/src \
 	-I$(top_srcdir)/src/core \
@@ -94,6 +95,8 @@ unit_tests_SOURCES = \
 	config/parameter_descriptor.cpp \
 	config/schema_analyzer.cpp \
 	job_queue/job_queue_test.cpp \
+	proto/mapping_test.cpp \
+	$(top_builddir)/src/core/proto/mapping.cpp \
     $(top_builddir)/src/core/config/loaders/inline_loader.cpp \
 	$(top_builddir)/src/core/config/loaders/json_loader.cpp \
 	$(top_builddir)/src/core/config/loaders/key_resolver.cpp \

--- a/tests/unit_tests/proto/mapping_test.cpp
+++ b/tests/unit_tests/proto/mapping_test.cpp
@@ -1,0 +1,177 @@
+/*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+ * Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: GPL-2.0-only or BSD-2-Clause
+ */
+
+#include "core/proto/mapping.h"
+#include "vlogger/vlogger.h"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <stdio.h>
+#include <unistd.h>
+
+/*
+ * mapping.cpp is linked into this hardware-free unit-test target. Stub only
+ * memory registration and logging, which are outside the cache policy under
+ * test.
+ */
+vlog_levels_t g_vlogger_level = VLOG_NONE;
+
+void vlog_output(vlog_levels_t, const char *, ...)
+{
+}
+
+xlio_registrator::xlio_registrator()
+{
+}
+
+xlio_registrator::~xlio_registrator()
+{
+}
+
+bool xlio_registrator::register_memory(void *, size_t, ib_ctx_handler *)
+{
+    return true;
+}
+
+void xlio_registrator::deregister_memory()
+{
+}
+
+uint32_t xlio_registrator::find_lkey_by_ib_ctx(ib_ctx_handler *) const
+{
+    return 0;
+}
+
+static FILE *create_mapping_file(size_t size)
+{
+    FILE *file = tmpfile();
+
+    if (file && ftruncate(fileno(file), size) != 0) {
+        fclose(file);
+        file = nullptr;
+    }
+    return file;
+}
+
+struct file_closer {
+    void operator()(FILE *file) const { fclose(file); }
+};
+
+using file_ptr = std::unique_ptr<FILE, file_closer>;
+
+TEST(mapping_ref_count_test, keeps_last_reference_until_cache_is_locked)
+{
+    mapping_ref_count refs;
+
+    refs.get();
+    refs.get();
+
+    EXPECT_TRUE(refs.put_fast());
+    EXPECT_EQ(1U, refs.value());
+    EXPECT_FALSE(refs.put_fast());
+    EXPECT_EQ(1U, refs.value());
+    EXPECT_TRUE(refs.put_locked());
+    EXPECT_EQ(0U, refs.value());
+}
+
+TEST(mapping_ref_count_test, retained_reference_keeps_send_references_on_fast_path)
+{
+    mapping_ref_count refs;
+
+    refs.get(); // Retained hot reference.
+    refs.get(); // sendfile() reference.
+    refs.get(); // queued pbuf reference.
+
+    EXPECT_TRUE(refs.put_fast());
+    EXPECT_TRUE(refs.put_fast());
+    EXPECT_EQ(1U, refs.value());
+
+    EXPECT_FALSE(refs.put_fast());
+    EXPECT_TRUE(refs.put_locked());
+    EXPECT_EQ(0U, refs.value());
+}
+
+TEST(mapping_ref_count_test, try_get_does_not_resurrect_zero)
+{
+    mapping_ref_count refs;
+
+    EXPECT_FALSE(refs.try_get());
+
+    refs.get();
+    EXPECT_TRUE(refs.try_get());
+    EXPECT_EQ(2U, refs.value());
+
+    EXPECT_TRUE(refs.put_fast());
+    EXPECT_TRUE(refs.put_locked());
+    EXPECT_EQ(0U, refs.value());
+}
+
+TEST(mapping_hot_ref_test, retains_one_reference_until_demoted)
+{
+    mapping_ref_count refs;
+    mapping_hot_ref hot;
+
+    hot.retain(refs);
+    EXPECT_TRUE(hot.is_retained());
+    EXPECT_EQ(1U, refs.value());
+    EXPECT_TRUE(hot.consume_recent());
+    EXPECT_FALSE(hot.consume_recent());
+
+    hot.touch();
+    EXPECT_TRUE(hot.consume_recent());
+
+    refs.get(); // Active send reference.
+    EXPECT_TRUE(refs.put_fast());
+    EXPECT_TRUE(hot.release(refs));
+    EXPECT_FALSE(hot.is_retained());
+    EXPECT_EQ(0U, refs.value());
+}
+
+TEST(mapping_hot_ref_test, demotion_waits_for_active_reference)
+{
+    mapping_ref_count refs;
+    mapping_hot_ref hot;
+
+    hot.retain(refs);
+    refs.get(); // Active send reference.
+
+    EXPECT_FALSE(hot.release(refs));
+    EXPECT_EQ(1U, refs.value());
+    EXPECT_FALSE(refs.put_fast());
+    EXPECT_TRUE(refs.put_locked());
+    EXPECT_EQ(0U, refs.value());
+}
+
+TEST(mapping_cache_test, eviction_scans_past_active_hot_candidate)
+{
+    const size_t mapping_size = 4096;
+    file_ptr active_file(create_mapping_file(mapping_size));
+    file_ptr idle_file(create_mapping_file(mapping_size));
+    file_ptr replacement_file(create_mapping_file(mapping_size));
+
+    ASSERT_NE(nullptr, active_file.get());
+    ASSERT_NE(nullptr, idle_file.get());
+    ASSERT_NE(nullptr, replacement_file.get());
+
+    mapping_cache cache(2 * mapping_size);
+    mapping_t *active = cache.get_mapping(fileno(active_file.get()));
+    mapping_t *idle = cache.get_mapping(fileno(idle_file.get()));
+
+    ASSERT_NE(nullptr, active);
+    ASSERT_NE(nullptr, idle);
+    idle->put();
+
+    mapping_t *replacement = cache.get_mapping(fileno(replacement_file.get()));
+
+    EXPECT_NE(nullptr, replacement);
+    EXPECT_EQ(1U, cache.m_stats.n_evicts);
+
+    if (replacement) {
+        replacement->put();
+    }
+    active->put();
+}


### PR DESCRIPTION
Fix global-zc-mapping-cache multi-thread performance bottleneck with a combination of spinlock.try_lock() and a rw-lock

Signed-off-by: Oren Shemesh orshemesh@nvidia.com

## Description

For sendfile() support, xlio maintain a global ZC file mapping DB, which is protected by a global spinlock with simple usage semantics. This creates contention when multiple threads attempt to run sendfile() concurrently, leading to significant performance degradation. This does not affect nginx because it is multi-process, with a single thread in every process, but xlio_perf (POSIX transport) and envoy are significantly affected when attempting to accelarate sendfile() with xlio.

##### What

A new design was chosen after multiple iterations, using a global spinlock with try_lock() for access when there is no contention, plus a heavier RW lock for use in moments of contention. It is already tested and works well. Pushing this to XLIO is needed so that xlio_perf POSIX sendfile support reach maximal performance.


## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [x] Code follows the style de facto guidelines of this project
- [x] Comments have been inserted in hard to understand places
- [x] Documentation has been updated (if necessary)
- [x] Test has been added (if possible)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved file mapping cache retention and eviction behavior.
  * Recently used mappings receive temporary protection from eviction.
  * Cache limits now use byte-based eviction with priority for unreferenced mappings.

* **Bug Fixes**
  * Improved handling of active references, file closure, and cache cleanup.
  * Prevented mappings from being incorrectly restored after their references reach zero.

* **Documentation**
  * Updated configuration guidance for mapping cache eviction behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->