### PR TITLE
issue: 5217929 Fix SIGINT oldact handling

### DIFF
--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -1317,6 +1317,7 @@ extern "C" int xlio_init(void)
     get_orig_funcs();
 #endif /* XLIO_STATIC_BUILD */
     safe_mce_sys();
+    xlio_sigint_init();
 
     g_init_xlio_init_done = true;
 
@@ -1346,6 +1347,12 @@ extern "C" EXPORT_SYMBOL int xlio_exit(void)
     int rc = 0;
 
     PROFILE_FUNC
+
+    // SIGINT can be intercepted before the global constructors run, therefore the restoration
+    // is gated by the signal initialization state and not by the resource cleanup state.
+    if (g_init_xlio_init_done) {
+        xlio_sigint_exit();
+    }
 
     if (g_init_global_ctors_done) {
         rc = free_libxlio_resources();

--- a/src/core/sock/sock-redirect.cpp
+++ b/src/core/sock/sock-redirect.cpp
@@ -61,7 +61,6 @@ using namespace std;
 
 #define EP_MAX_EVENTS (int)((INT_MAX / sizeof(struct epoll_event)))
 struct sigaction g_act_prev;
-sighandler_t g_sighandler = nullptr;
 class ring_simple;
 
 template <typename T> void assign_dlsym(T &ptr, const char *name)
@@ -697,34 +696,44 @@ inline int epoll_wait_helper(int __epfd, struct epoll_event *__events, int __max
     }
 }
 
-static void handler_intr(int sig)
+static void dispatch_sigint_action(int sig, siginfo_t *info, void *context)
 {
-    switch (sig) {
-    case SIGINT:
-        g_b_exit = true;
-        srdr_logdbg("Catch Signal: SIGINT (%d)", sig);
-        break;
-    default:
-        srdr_logdbg("Catch Signal: %d", sig);
-        break;
+    /* NOTE:
+     * 1. Don't print logs in the signal handlers, XLIO logs aren't async-signal-safe.
+     * 2. XLIO mustn't change errno.
+     * 3. XLIO mustn't restore errno changed by the application handler, this is the native
+     *    behavior without the trampoline.
+     */
+
+    g_b_exit = true;
+
+    struct sigaction action = g_act_prev;
+
+    if ((action.sa_flags & SA_RESETHAND) != 0) {
+        g_act_prev.sa_handler = SIG_DFL;
     }
 
-    if (g_act_prev.sa_handler) {
-        g_act_prev.sa_handler(sig);
+    // sa_handler and sa_sigaction share the same storage, so the special dispositions must
+    // be excluded before the calling convention is selected.
+    if (action.sa_handler == SIG_DFL || action.sa_handler == SIG_IGN ||
+        action.sa_handler == SIG_ERR) {
+        return;
+    }
+    if ((action.sa_flags & SA_SIGINFO) != 0) {
+        action.sa_sigaction(sig, info, context);
+    } else {
+        action.sa_handler(sig);
     }
 }
 
-static void handle_signal(int signum)
+static void handler_sigint(int sig)
 {
-    srdr_logdbg_entry("Caught signal! signum=%d", signum);
+    dispatch_sigint_action(sig, nullptr, nullptr);
+}
 
-    if (signum == SIGINT) {
-        g_b_exit = true;
-    }
-
-    if (g_sighandler) {
-        g_sighandler(signum);
-    }
+static void handler_sigint_siginfo(int sig, siginfo_t *info, void *context)
+{
+    dispatch_sigint_action(sig, info, context);
 }
 
 int sigaction_internal(int signum, const struct sigaction *act, struct sigaction *oldact)
@@ -733,52 +742,72 @@ int sigaction_internal(int signum, const struct sigaction *act, struct sigaction
 
     PROFILE_FUNC
 
-    if (safe_mce_sys().handle_sigintr) {
-        srdr_logdbg_entry("signum=%d, act=%p, oldact=%p", signum, act, oldact);
+    srdr_logdbg_entry("signum=%d, act=%p, oldact=%p", signum, act, oldact);
 
-        switch (signum) {
-        case SIGINT:
-            if (oldact && g_act_prev.sa_handler) {
-                *oldact = g_act_prev;
-            }
-            if (act) {
-                struct sigaction xlio_action;
-                xlio_action.sa_handler = handler_intr;
-                xlio_action.sa_flags = 0;
-                sigemptyset(&xlio_action.sa_mask);
+    if (signum == SIGINT && safe_mce_sys().handle_sigintr) {
+        srdr_logdbg("SIGINT is intercepted by XLIO");
 
-                ret = SYSCALL(sigaction, SIGINT, &xlio_action, nullptr);
+        if (oldact) {
+            *oldact = g_act_prev;
+        }
+        if (act) {
+            struct sigaction xlio_action = *act;
+            // SIG_ERR isn't a callback, but the kernel installs it as a regular handler and
+            // jumps to it. Install it as is, so the process faults on delivery exactly as it
+            // does without XLIO.
+            bool special_action = act->sa_handler == SIG_DFL || act->sa_handler == SIG_IGN ||
+                act->sa_handler == SIG_ERR;
 
-                if (ret < 0) {
-                    srdr_logdbg("Failed to register SIGINT handler, calling to original sigaction "
-                                "handler");
-                    break;
+            if (!special_action) {
+                if ((act->sa_flags & SA_SIGINFO) != 0) {
+                    xlio_action.sa_sigaction = handler_sigint_siginfo;
+                } else {
+                    xlio_action.sa_handler = handler_sigint;
                 }
-                srdr_logdbg("Registered SIGINT handler");
+            }
+            ret = SYSCALL(sigaction, SIGINT, &xlio_action, nullptr);
+            if (ret == 0) {
                 g_act_prev = *act;
             }
-            if (ret >= 0) {
-                srdr_logdbg_exit("returned with %d", ret);
-            } else {
-                srdr_logdbg_exit("failed (errno=%d %m)", errno);
-            }
-
-            return ret;
-            break;
-        default:
-            break;
         }
+    } else {
+        ret = SYSCALL(sigaction, signum, act, oldact);
     }
-    ret = SYSCALL(sigaction, signum, act, oldact);
 
-    if (safe_mce_sys().handle_sigintr) {
-        if (ret >= 0) {
-            srdr_logdbg_exit("returned with %d", ret);
-        } else {
-            srdr_logdbg_exit("failed (errno=%d %m)", errno);
-        }
-    }
+    srdr_logdbg_exit("ret=%d (errno=%d)", ret, errno);
     return ret;
+}
+
+static bool is_xlio_sigint_action(const struct sigaction &action)
+{
+    return ((action.sa_flags & SA_SIGINFO) != 0 && action.sa_sigaction == handler_sigint_siginfo) ||
+        (action.sa_handler == handler_sigint);
+}
+
+void xlio_sigint_init()
+{
+    struct sigaction oldact = {};
+
+    if (SYSCALL(sigaction, SIGINT, nullptr, &oldact) != 0) {
+        oldact = {};
+        oldact.sa_handler = SIG_DFL;
+        sigemptyset(&oldact.sa_mask);
+    }
+
+    // SIGINT may be intercepted before initialization, g_act_prev already holds the application
+    // action in this case.
+    if (!is_xlio_sigint_action(oldact)) {
+        g_act_prev = oldact;
+    }
+}
+
+void xlio_sigint_exit()
+{
+    // Check whether XLIO has registered own SIGINT handler and replace it with the user handler.
+    struct sigaction oldact = {};
+    if (SYSCALL(sigaction, SIGINT, nullptr, &oldact) == 0 && is_xlio_sigint_action(oldact)) {
+        SYSCALL(sigaction, SIGINT, &g_act_prev, nullptr);
+    }
 }
 
 extern "C" {
@@ -2447,16 +2476,21 @@ EXPORT_SYMBOL sighandler_t XLIO_SYMBOL(signal)(int signum, sighandler_t handler)
 {
     PROFILE_FUNC
 
-    if (safe_mce_sys().handle_sigintr) {
-        srdr_logdbg_entry("signum=%d, handler=%p", signum, handler);
-
-        if (handler && handler != SIG_ERR && handler != SIG_DFL && handler != SIG_IGN) {
-            // Only SIGINT is supported for now
-            if (signum == SIGINT) {
-                g_sighandler = handler;
-                return SYSCALL(signal, SIGINT, &handle_signal);
-            }
+    if (signum == SIGINT && safe_mce_sys().handle_sigintr) {
+        if (handler == SIG_ERR) {
+            errno = EINVAL;
+            return SIG_ERR;
         }
+
+        struct sigaction action = {};
+        struct sigaction old_action = {};
+        action.sa_handler = handler;
+        sigemptyset(&action.sa_mask);
+        action.sa_flags = SA_RESTART;
+        if (sigaction_internal(signum, &action, &old_action) < 0) {
+            return SIG_ERR;
+        }
+        return old_action.sa_handler;
     }
 
     return SYSCALL(signal, signum, handler);

--- a/src/core/sock/sock-redirect.h
+++ b/src/core/sock/sock-redirect.h
@@ -204,6 +204,9 @@ extern os_api orig_os_api;
 extern void get_orig_funcs();
 #endif /* XLIO_STATIC_BUILD */
 
+void xlio_sigint_init();
+void xlio_sigint_exit();
+
 /**
  *-----------------------------------------------------------------------------
  *  variables to hold the function-pointers to original functions

--- a/tests/gtest/Makefile.am
+++ b/tests/gtest/Makefile.am
@@ -122,6 +122,7 @@ gtest_SOURCES = \
 	udp/udp_sendto.cc \
 	udp/udp_rfs.cc \
 	\
+	core/sigaction.cc \
 	core/xlio_base.cc \
 	core/xlio_sockopt.cc \
 	\

--- a/tests/gtest/core/sigaction.cc
+++ b/tests/gtest/core/sigaction.cc
@@ -1,0 +1,293 @@
+/*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+ * Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: GPL-2.0-only or BSD-2-Clause
+ */
+
+#include <functional>
+
+#include "common/def.h"
+#include "common/log.h"
+#include "common/cmn.h"
+#include "common/base.h"
+
+/*
+ * XLIO interposes SIGINT to set g_b_exit and then chains the application action. From the
+ * application point of view the interposition must be transparent, therefore the
+ * expectations below hold both with and without libxlio preloaded.
+ *
+ * A SIGINT disposition is a process wide side effect, so every test configures it in a child
+ * process and reports the verdict with the exit status.
+ */
+
+static const int HANDLER_NONE = 0;
+static const int HANDLER_A = 1;
+static const int HANDLER_B = 2;
+static const int HANDLER_SIGINFO = 3;
+
+static volatile sig_atomic_t g_handler_id;
+static volatile sig_atomic_t g_handler_signo;
+static volatile sig_atomic_t g_handler_si_pid;
+
+static void handler_a(int signo)
+{
+    g_handler_id = HANDLER_A;
+    g_handler_signo = signo;
+}
+
+static void handler_b(int signo)
+{
+    g_handler_id = HANDLER_B;
+    g_handler_signo = signo;
+}
+
+static void handler_siginfo(int signo, siginfo_t *info, void *context)
+{
+    UNREFERENCED_PARAMETER(context);
+    g_handler_id = HANDLER_SIGINFO;
+    g_handler_signo = signo;
+    g_handler_si_pid = (info ? info->si_pid : -1);
+}
+
+/* Runs the body in a child process. The child never returns to the test body. */
+static pid_t fork_child(const std::function<void()> &body)
+{
+    pid_t pid = fork();
+
+    if (pid == 0) {
+        g_handler_id = HANDLER_NONE;
+        body();
+        fflush(nullptr);
+        _exit(testing::Test::HasFailure() ? 1 : 0);
+    }
+    return pid;
+}
+
+/*
+ * oldact must be filled even when the saved disposition is SIG_DFL, and a query must report
+ * the application action with its flags and mask - not the XLIO trampoline.
+ */
+TEST(sigaction_test, oldact_reports_application_action)
+{
+    pid_t pid = fork_child([]() {
+        struct sigaction action = {};
+        action.sa_handler = SIG_DFL;
+        sigemptyset(&action.sa_mask);
+        EXPECT_EQ(0, sigaction(SIGINT, &action, nullptr));
+
+        struct sigaction old_action = {};
+        old_action.sa_handler = SIG_ERR;
+        action.sa_handler = handler_a;
+        action.sa_flags = SA_RESTART;
+        sigaddset(&action.sa_mask, SIGUSR1);
+        EXPECT_EQ(0, sigaction(SIGINT, &action, &old_action));
+        EXPECT_EQ(SIG_DFL, old_action.sa_handler);
+
+        old_action.sa_handler = SIG_ERR;
+        old_action.sa_flags = 0;
+        EXPECT_EQ(0, sigaction(SIGINT, nullptr, &old_action));
+        EXPECT_EQ(&handler_a, old_action.sa_handler);
+        EXPECT_EQ(SA_RESTART, old_action.sa_flags & SA_RESTART);
+        EXPECT_EQ(1, sigismember(&old_action.sa_mask, SIGUSR1));
+    });
+
+    ASSERT_LE(0, pid);
+    EXPECT_EQ(0, test_base::wait_fork(pid));
+}
+
+/* A plain application handler is chained from the XLIO SIGINT trampoline. */
+TEST(sigaction_test, chains_application_handler)
+{
+    pid_t pid = fork_child([]() {
+        struct sigaction action = {};
+        action.sa_handler = handler_a;
+        sigemptyset(&action.sa_mask);
+        EXPECT_EQ(0, sigaction(SIGINT, &action, nullptr));
+
+        EXPECT_EQ(0, raise(SIGINT));
+        EXPECT_EQ(HANDLER_A, static_cast<int>(g_handler_id));
+        EXPECT_EQ(SIGINT, static_cast<int>(g_handler_signo));
+    });
+
+    ASSERT_LE(0, pid);
+    EXPECT_EQ(0, test_base::wait_fork(pid));
+}
+
+/* An SA_SIGINFO action keeps its 3-argument calling convention and receives a valid siginfo. */
+TEST(sigaction_test, chains_siginfo_handler)
+{
+    pid_t pid = fork_child([]() {
+        struct sigaction action = {};
+        action.sa_sigaction = handler_siginfo;
+        sigemptyset(&action.sa_mask);
+        action.sa_flags = SA_SIGINFO;
+        EXPECT_EQ(0, sigaction(SIGINT, &action, nullptr));
+
+        struct sigaction old_action = {};
+        EXPECT_EQ(0, sigaction(SIGINT, nullptr, &old_action));
+        EXPECT_EQ(SA_SIGINFO, old_action.sa_flags & SA_SIGINFO);
+        EXPECT_EQ(&handler_siginfo, old_action.sa_sigaction);
+
+        EXPECT_EQ(0, raise(SIGINT));
+        EXPECT_EQ(HANDLER_SIGINFO, static_cast<int>(g_handler_id));
+        EXPECT_EQ(SIGINT, static_cast<int>(g_handler_signo));
+        EXPECT_EQ(getpid(), static_cast<pid_t>(g_handler_si_pid));
+    });
+
+    ASSERT_LE(0, pid);
+    EXPECT_EQ(0, test_base::wait_fork(pid));
+}
+
+/* SIG_DFL is not trampolined - SIGINT terminates the process as usual. */
+TEST(sigaction_test, default_disposition_terminates_process)
+{
+    pid_t pid = fork_child([]() {
+        struct sigaction action = {};
+        action.sa_handler = SIG_DFL;
+        sigemptyset(&action.sa_mask);
+        EXPECT_EQ(0, sigaction(SIGINT, &action, nullptr));
+
+        raise(SIGINT);
+        ADD_FAILURE() << "SIGINT did not terminate the process";
+    });
+
+    ASSERT_LE(0, pid);
+    int status = 0;
+    ASSERT_EQ(pid, waitpid(pid, &status, 0));
+    ASSERT_TRUE(WIFSIGNALED(status)) << "status=" << status;
+    EXPECT_EQ(SIGINT, WTERMSIG(status));
+}
+
+/* SIG_IGN is not trampolined - SIGINT is dropped and the disposition is reported back. */
+TEST(sigaction_test, ignored_disposition_drops_signal)
+{
+    pid_t pid = fork_child([]() {
+        struct sigaction action = {};
+        action.sa_handler = SIG_IGN;
+        sigemptyset(&action.sa_mask);
+        EXPECT_EQ(0, sigaction(SIGINT, &action, nullptr));
+
+        EXPECT_EQ(0, raise(SIGINT));
+        EXPECT_EQ(HANDLER_NONE, static_cast<int>(g_handler_id));
+
+        struct sigaction old_action = {};
+        EXPECT_EQ(0, sigaction(SIGINT, nullptr, &old_action));
+        EXPECT_EQ(SIG_IGN, old_action.sa_handler);
+    });
+
+    ASSERT_LE(0, pid);
+    EXPECT_EQ(0, test_base::wait_fork(pid));
+}
+
+/* signal() and sigaction() share a single saved action, and the latest handler is dispatched. */
+TEST(sigaction_test, signal_and_sigaction_share_state)
+{
+    pid_t pid = fork_child([]() {
+        signal(SIGINT, SIG_DFL);
+        EXPECT_EQ(SIG_DFL, signal(SIGINT, handler_a));
+        EXPECT_EQ(&handler_a, signal(SIGINT, handler_b));
+
+        struct sigaction old_action = {};
+        EXPECT_EQ(0, sigaction(SIGINT, nullptr, &old_action));
+        EXPECT_EQ(&handler_b, old_action.sa_handler);
+
+        EXPECT_EQ(0, raise(SIGINT));
+        EXPECT_EQ(HANDLER_B, static_cast<int>(g_handler_id));
+    });
+
+    ASSERT_LE(0, pid);
+    EXPECT_EQ(0, test_base::wait_fork(pid));
+}
+
+/* Only SIGINT is interposed - any other signal is a plain pass-through. */
+TEST(sigaction_test, other_signals_are_not_interposed)
+{
+    pid_t pid = fork_child([]() {
+        struct sigaction action = {};
+        action.sa_handler = handler_a;
+        sigemptyset(&action.sa_mask);
+        EXPECT_EQ(0, sigaction(SIGUSR1, &action, nullptr));
+
+        struct sigaction old_action = {};
+        EXPECT_EQ(0, sigaction(SIGUSR1, nullptr, &old_action));
+        EXPECT_EQ(&handler_a, old_action.sa_handler);
+
+        EXPECT_EQ(0, raise(SIGUSR1));
+        EXPECT_EQ(HANDLER_A, static_cast<int>(g_handler_id));
+        EXPECT_EQ(SIGUSR1, static_cast<int>(g_handler_signo));
+    });
+
+    ASSERT_LE(0, pid);
+    EXPECT_EQ(0, test_base::wait_fork(pid));
+}
+
+/* signal() rejects SIG_ERR with EINVAL, like glibc does, and keeps the current action. */
+TEST(sigaction_test, signal_rejects_sig_err)
+{
+    pid_t pid = fork_child([]() {
+        EXPECT_NE(SIG_ERR, signal(SIGINT, handler_a));
+
+        errno = EOK;
+        EXPECT_EQ(SIG_ERR, signal(SIGINT, SIG_ERR));
+        EXPECT_EQ(EINVAL, errno);
+
+        /* The rejected call must not clobber the installed action. */
+        struct sigaction old_action = {};
+        EXPECT_EQ(0, sigaction(SIGINT, nullptr, &old_action));
+        EXPECT_EQ(&handler_a, old_action.sa_handler);
+    });
+
+    ASSERT_LE(0, pid);
+    EXPECT_EQ(0, test_base::wait_fork(pid));
+}
+
+/* A one-shot action is consumed by the first delivery and leaves SIG_DFL behind. */
+TEST(sigaction_test, one_shot_action_resets_to_default)
+{
+    pid_t pid = fork_child([]() {
+        struct sigaction action = {};
+        action.sa_handler = handler_a;
+        sigemptyset(&action.sa_mask);
+        action.sa_flags = SA_RESETHAND;
+        EXPECT_EQ(0, sigaction(SIGINT, &action, nullptr));
+
+        EXPECT_EQ(0, raise(SIGINT));
+        EXPECT_EQ(HANDLER_A, static_cast<int>(g_handler_id));
+
+        struct sigaction old_action = {};
+        old_action.sa_handler = SIG_ERR;
+        EXPECT_EQ(0, sigaction(SIGINT, nullptr, &old_action));
+        EXPECT_EQ(SIG_DFL, old_action.sa_handler);
+    });
+
+    ASSERT_LE(0, pid);
+    EXPECT_EQ(0, test_base::wait_fork(pid));
+}
+
+/*
+ * SIG_ERR is not a callback, but sigaction() takes it as a regular handler address, while
+ * signal() rejects it with EINVAL. XLIO must reproduce both.
+ *
+ * The fault on delivery is not checked: raising SIGINT would kill the child, and a piped
+ * kernel.core_pattern hands the dump to a system service regardless of RLIMIT_CORE.
+ */
+TEST(sigaction_test, sig_err_is_accepted_by_sigaction_only)
+{
+    pid_t pid = fork_child([]() {
+        struct sigaction action = {};
+        action.sa_handler = SIG_ERR;
+        sigemptyset(&action.sa_mask);
+        EXPECT_EQ(0, sigaction(SIGINT, &action, nullptr));
+
+        struct sigaction old_action = {};
+        EXPECT_EQ(0, sigaction(SIGINT, nullptr, &old_action));
+        EXPECT_EQ(SIG_ERR, old_action.sa_handler);
+
+        errno = EOK;
+        EXPECT_EQ(SIG_ERR, signal(SIGINT, SIG_ERR));
+        EXPECT_EQ(EINVAL, errno);
+    });
+
+    ASSERT_LE(0, pid);
+    EXPECT_EQ(0, test_base::wait_fork(pid));
+}


### PR DESCRIPTION
## Description
Fix segfault and compliancy with Linux sigaction().

XLIO intercepted sigaction() could skip setting oldact what could keep garbage in the returning structure.

Unify signal() and sigaction() for XLIO intercepted flow and make the implementation more robust.

##### What
Fix segfault and compliancy with Linux sigaction().

##### Why ?
Fix segfault in Envoy during termination and potentially other libevent applications.

## Change type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SIGINT handling during initialization and shutdown.
  * Preserved application signal handlers and special signal dispositions.
  * Improved compatibility with traditional and extended signal handlers.
  * Ensured signal behavior is correctly restored when the library exits.
  * Improved handling of reset-once signal behavior and non-intercepted signals.

* **Tests**
  * Added comprehensive coverage for SIGINT and signal-action behavior, including reset, ignore, default, chaining, and invalid-handler scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->