### PR TITLE
issue: INFINIOPS-772 [CI] Update secret scan image

### DIFF
--- a/.ci/matrix_job.yaml
+++ b/.ci/matrix_job.yaml
@@ -168,7 +168,7 @@ runs_on_dockers:
      limits: '{memory: 3Gi, cpu: 2000m}',
      requests: '{memory: 3Gi, cpu: 2000m}'
     }
-  - {name: 'secret-scan', url: '${registry_host}/toolbox/secret_scan:0.0.27', arch: 'x86_64', tag: '0.0.27', category: 'tool', limits: '{memory: 3Gi, cpu: 2000m}', requests: '{memory: 3Gi, cpu: 2000m}'}
+  - {name: 'secret-scan', url: '${registry_host}/swx-storage/tools/secret_scan:devops-stable', arch: 'x86_64', tag: 'devops-stable', category: 'tool', limits: '{memory: 3Gi, cpu: 2000m}', requests: '{memory: 3Gi, cpu: 2000m}'}
   - {
      file: '.ci/dockerfiles/Dockerfile.ubuntu22.04',
      arch: 'x86_64',


### PR DESCRIPTION
## Description
Use the relocated secret-scan image and devops-stable tag so the CI scan continues pulling the maintained scanner.

##### What
Use the relocated secret-scan image and devops-stable tag so the CI scan continues pulling the maintained scanner.

##### Why ?
Fixes and modifications in original image.

##### How ?
add a tag within our repo for the required image.

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

