### PR TITLE
issue: 5221296: libxlio.a from --disable-shared build ...

### DIFF
--- a/third_party/json-c/Makefile.am
+++ b/third_party/json-c/Makefile.am
@@ -1,4 +1,4 @@
-AM_CFLAGS = -Wno-error -Wno-unused-parameter -Wno-unused-function -D_GNU_SOURCE
+AM_CFLAGS = -Wno-error -Wno-unused-parameter -Wno-unused-function -D_GNU_SOURCE -fPIC
 
 SUBDIRS = .
 


### PR DESCRIPTION
libxlio.a from --disable-shared build is not PIC — bundled json-c breaks PIE linking on (aarch64, GCC 13 / OL9)

Added -fPIC to json-c makefile

## Description
Make json-c compile with -fPIC, to allow creating PIE executable on aarch64.

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [X] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

