### PR TITLE
issue: 5226259 Add openssl development files to build dependencies

### DIFF
--- a/.ci/dockerfiles/Dockerfile.ctyunos23.01
+++ b/.ci/dockerfiles/Dockerfile.ctyunos23.01
@@ -40,7 +40,7 @@ RUN printf '%s\n' \
     dnf clean all
 
 RUN dnf --releasever=23.01 install -y autoconf automake make libtool json-c-devel git gcc-c++ \
-    util-linux sudo rpm-build curl \
+    openssl-devel util-linux sudo rpm-build curl \
  && dnf clean all \
  && rm -rf /var/cache/dnf
 

--- a/.ci/dockerfiles/Dockerfile.ctyunos23.01
+++ b/.ci/dockerfiles/Dockerfile.ctyunos23.01
@@ -7,9 +7,36 @@ ARG _GID=101
 ARG _LOGIN=swx-jenkins
 ARG _HOME=/var/home/$_LOGIN
 
-RUN sed -i 's!baseurl=.*everything.*!baseurl=http://webrepo.gtm.nvidia.com/Ctyunos/Mirrors/23.01/$basearch/everything/!' /etc/yum.repos.d/ctyunos.repo && \
-    sed -i 's!baseurl=.*update.*!baseurl=http://webrepo.gtm.nvidia.com/Ctyunos/Mirrors/23.01/$basearch/update/!' /etc/yum.repos.d/ctyunos.repo && \
-    sed -i 's!baseurl=.*extras.*!baseurl=http://webrepo.gtm.nvidia.com/Ctyunos/Mirrors/23.01/$basearch/extras/!' /etc/yum.repos.d/ctyunos.repo && \
+# Serve CTyunOS 23.01 from the internal mirror, which carries only the frozen
+# "everything" snapshot. The update/extras repos are kept in the file but
+# disabled, so they can be re-enabled without re-deriving the URLs.
+# The file is written whole rather than sed-patched: sed exits 0 when a
+# pattern does not match, so a base-image layout change would silently leave the
+# unreachable repos enabled.
+# Note: $basearch is single-quoted on purpose - it must reach dnf unexpanded.
+RUN printf '%s\n' \
+      '# Temporary: switch back to' \
+      '# http://webrepo.gtm.nvidia.com/Ctyunos/Mirrors/23.01/$basearch/everything/' \
+      '# once that mirror is available again.' \
+      '[everything]' \
+      'name=ctyunos-everything' \
+      'baseurl=http://webrepo.gtm.nvidia.com/Ctyunos/23.01-everything/$basearch/' \
+      'enabled=1' \
+      'gpgcheck=0' \
+      '' \
+      '[update]' \
+      'name=ctyunos-update' \
+      'baseurl=http://webrepo.gtm.nvidia.com/Ctyunos/Mirrors/23.01/$basearch/update/' \
+      'enabled=0' \
+      'gpgcheck=0' \
+      '' \
+      '[extras]' \
+      'name=ctyunos-extras' \
+      'baseurl=http://webrepo.gtm.nvidia.com/Ctyunos/Mirrors/23.01/$basearch/extras/' \
+      'gpgcheck=0' \
+      'enabled=0' \
+      > /etc/yum.repos.d/ctyunos.repo && \
+    cat /etc/yum.repos.d/ctyunos.repo && \
     dnf clean all
 
 RUN dnf --releasever=23.01 install -y autoconf automake make libtool json-c-devel git gcc-c++ \

--- a/.ci/dockerfiles/Dockerfile.rhel8.6
+++ b/.ci/dockerfiles/Dockerfile.rhel8.6
@@ -19,7 +19,7 @@ ARG _LOGIN=svc-nbu-swx-media
 
 RUN yum makecache && \
     yum install -y yum-utils clang-tools-extra-21.1.8 sudo curl autoconf automake make libtool \
-    libnl3-devel libnl3 rdma-core-devel rdma-core bc && \
+    libnl3-devel libnl3 rdma-core-devel rdma-core openssl-devel bc && \
     yum-config-manager --add-repo https://archives.fedoraproject.org/pub/archive/epel/7/x86_64/ && \
     yum --nogpgcheck install -y cppcheck && \
     yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \
@@ -52,12 +52,12 @@ RUN yum install --allowerasing -y \
     git autoconf automake libtool gcc \
     sudo gcc-c++ libibverbs-devel json-c-devel rdma-core \
     librdmacm unzip patch wget make \
-    libnl3-devel rpm-build net-tools
+    libnl3-devel openssl-devel rpm-build net-tools
 
 
 FROM harbor.mellanox.com/hpcx/$ARCH/rhel8.6/base as build
 
-RUN yum install -y json-c-devel curl
+RUN yum install -y json-c-devel openssl-devel curl
 
 # Install DOCA
 COPY .ci/scripts/doca_install.sh /tmp/doca_install.sh

--- a/.ci/dockerfiles/Dockerfile.rhel9.6
+++ b/.ci/dockerfiles/Dockerfile.rhel9.6
@@ -21,7 +21,7 @@ FROM core AS static
 RUN dnf install -y dnf-utils \
  && dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm \
  && dnf install --allowerasing -y cppcheck csbuild clang-tools-extra sudo curl autoconf automake make libtool \
-    libnl3-devel libnl3 rdma-core-devel rdma-core bc python3-pip \
+    libnl3-devel libnl3 rdma-core-devel rdma-core openssl-devel bc python3-pip \
  && dnf clean all \
  && rm -rf /var/cache/dnf
 
@@ -31,7 +31,7 @@ RUN pip3 install -U pip --no-cache-dir \
 
 FROM core AS build
 
-RUN dnf install --allowerasing -y json-c-devel curl \
+RUN dnf install --allowerasing -y json-c-devel openssl-devel curl \
     git autoconf automake make libtool gcc-c++ rpm-build \
  && dnf clean all \
  && rm -rf /var/cache/dnf

--- a/.ci/dockerfiles/Dockerfile.ubuntu22.04
+++ b/.ci/dockerfiles/Dockerfile.ubuntu22.04
@@ -2,7 +2,7 @@ ARG ARCH=x86_64
 FROM harbor.mellanox.com/hpcx/$ARCH/ubuntu22.04/base AS build
 
 RUN apt-get update \
- && apt-get install -y libjson-c-dev curl \
+ && apt-get install -y libjson-c-dev libssl-dev curl \
  && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install DOCA

--- a/.ci/dockerfiles/Dockerfile.ubuntu24.04
+++ b/.ci/dockerfiles/Dockerfile.ubuntu24.04
@@ -2,7 +2,7 @@ ARG ARCH=x86_64
 FROM harbor.mellanox.com/hpcx/$ARCH/ubuntu22.04/base AS build
 
 RUN apt-get update \
- && apt-get install -y libjson-c-dev curl \
+ && apt-get install -y libjson-c-dev libssl-dev curl \
  && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install DOCA

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,10 @@
+Version 3.71.2-1:
+Date + Time 2026-08-21
+=============================================================
+Fixed:
+	- RM #5221296 Fix PIE executables linking against static libxlio.a
+	- RM #5226259 Require openssl dev package during binary packages building
+
 Version 3.71.1-1:
 Date + Time 2026-07-09
 =============================================================

--- a/configure.ac
+++ b/configure.ac
@@ -14,7 +14,7 @@ dnl===-----------------------------------------------------------------------===
 #
 define([prj_ver_major], 3)
 define([prj_ver_minor], 71)
-define([prj_ver_revision], 1)
+define([prj_ver_revision], 2)
 define([prj_ver_release], esyscmd([echo ${PRJ_RELEASE:=0}]))
 
 

--- a/contrib/scripts/libxlio.spec.in
+++ b/contrib/scripts/libxlio.spec.in
@@ -26,6 +26,7 @@ BuildRequires: autoconf
 BuildRequires: libtool
 BuildRequires: gcc-c++
 BuildRequires: rdma-core-devel
+BuildRequires: openssl-devel
 %if 0%{?rhel} >= 7 || 0%{?fedora} >= 24 || 0%{?suse_version} >= 1500
 BuildRequires: pkgconfig(libnl-3.0)
 BuildRequires: pkgconfig(libnl-route-3.0)

--- a/contrib/scripts/libxlio.spec.in
+++ b/contrib/scripts/libxlio.spec.in
@@ -146,7 +146,7 @@ fi
 %{_mandir}/man8/xlio_stats.*
 
 %changelog
-* Thu Jul  9 2026 NVIDIA CORPORATION <networking-support@nvidia.com> 3.71.1-1
-- Bump version to 3.71.1
+* Fri Aug 21 2026 NVIDIA CORPORATION <networking-support@nvidia.com> 3.71.2-1
+- Bump version to 3.71.2
 - Please refer to CHANGES for full changelog.
 

--- a/debian/control
+++ b/debian/control
@@ -8,6 +8,7 @@ Build-Depends: debhelper (>= 7),
  automake,
  libibverbs-dev,
  librdmacm-dev,
+ libssl-dev,
  libnl-route-3-dev | libnl-dev,
  dpcp (>= 1.1.58),
 Homepage: https://github.com/Mellanox-lab/libxlio


### PR DESCRIPTION
## Description

TLS offload support is gated on openssl/evp.h in config/m4/utls.m4. With the default --enable-utls=auto, the build system silently disables UTLS support if the openssl header is missing.

Neither the rpm spec nor debian/control required the openssl development files, so the default binary packages were built without TLS offload whenever the building setup missed openssl headers.

Add openssl-devel to BuildRequires in libxlio.spec.in and libssl-dev to Build-Depends in debian/control. This is a build-time dependency only.

Also install the package in the CI images that compile XLIO, so the new build dependency resolves and the TLS code is actually covered by the build, static analysis and packaging jobs. Dockerfile.ol9.4 already had it.

##### What
Add openssl-devel to BuildRequires in libxlio.spec.in and libssl-dev to Build-Depends in debian/control.

##### Why ?
Build libxlio binary packages with TLS support explicitly.

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated supported build and packaging environments with required OpenSSL development dependencies.
  * Improved consistency of dependency configuration across RHEL, Ubuntu, Debian, and RPM-based builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->