### PR TITLE
issue: 5229407 Add openssl development files to build dependencies

### DIFF
--- a/.ci/dockerfiles/Dockerfile.ctyunos23.01
+++ b/.ci/dockerfiles/Dockerfile.ctyunos23.01
@@ -40,7 +40,7 @@ RUN printf '%s\n' \
     dnf clean all
 
 RUN dnf --releasever=23.01 install -y autoconf automake make libtool json-c-devel git gcc-c++ \
-    util-linux sudo rpm-build curl \
+    openssl-devel util-linux sudo rpm-build curl \
  && dnf clean all \
  && rm -rf /var/cache/dnf
 

--- a/.ci/dockerfiles/Dockerfile.rhel8.6
+++ b/.ci/dockerfiles/Dockerfile.rhel8.6
@@ -19,7 +19,7 @@ ARG _LOGIN=svc-nbu-swx-media
 
 RUN yum makecache && \
     yum install -y yum-utils clang-tools-extra-21.1.8 sudo curl autoconf automake make libtool \
-    libnl3-devel libnl3 rdma-core-devel rdma-core bc && \
+    libnl3-devel libnl3 rdma-core-devel rdma-core openssl-devel bc && \
     yum-config-manager --add-repo https://archives.fedoraproject.org/pub/archive/epel/7/x86_64/ && \
     yum --nogpgcheck install -y cppcheck && \
     yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \
@@ -52,12 +52,12 @@ RUN yum install --allowerasing -y \
     git autoconf automake libtool gcc \
     sudo gcc-c++ libibverbs-devel json-c-devel rdma-core \
     librdmacm unzip patch wget make \
-    libnl3-devel rpm-build net-tools
+    libnl3-devel openssl-devel rpm-build net-tools
 
 
 FROM harbor.mellanox.com/hpcx/$ARCH/rhel8.6/base as build
 
-RUN yum install -y json-c-devel curl
+RUN yum install -y json-c-devel openssl-devel curl
 
 # Install DOCA
 COPY .ci/scripts/doca_install.sh /tmp/doca_install.sh

--- a/.ci/dockerfiles/Dockerfile.rhel9.6
+++ b/.ci/dockerfiles/Dockerfile.rhel9.6
@@ -21,7 +21,7 @@ FROM core AS static
 RUN dnf install -y dnf-utils \
  && dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm \
  && dnf install --allowerasing -y cppcheck csbuild clang-tools-extra sudo curl autoconf automake make libtool \
-    libnl3-devel libnl3 rdma-core-devel rdma-core bc python3-pip \
+    libnl3-devel libnl3 rdma-core-devel rdma-core openssl-devel bc python3-pip \
  && dnf clean all \
  && rm -rf /var/cache/dnf
 
@@ -31,7 +31,7 @@ RUN pip3 install -U pip --no-cache-dir \
 
 FROM core AS build
 
-RUN dnf install --allowerasing -y json-c-devel curl \
+RUN dnf install --allowerasing -y json-c-devel openssl-devel curl \
     git autoconf automake make libtool gcc-c++ rpm-build \
  && dnf clean all \
  && rm -rf /var/cache/dnf

--- a/.ci/dockerfiles/Dockerfile.ubuntu22.04
+++ b/.ci/dockerfiles/Dockerfile.ubuntu22.04
@@ -2,7 +2,7 @@ ARG ARCH=x86_64
 FROM harbor.mellanox.com/hpcx/$ARCH/ubuntu22.04/base AS build
 
 RUN apt-get update \
- && apt-get install -y libjson-c-dev curl \
+ && apt-get install -y libjson-c-dev libssl-dev curl \
  && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install DOCA

--- a/.ci/dockerfiles/Dockerfile.ubuntu24.04
+++ b/.ci/dockerfiles/Dockerfile.ubuntu24.04
@@ -2,7 +2,7 @@ ARG ARCH=x86_64
 FROM harbor.mellanox.com/hpcx/$ARCH/ubuntu22.04/base AS build
 
 RUN apt-get update \
- && apt-get install -y libjson-c-dev curl \
+ && apt-get install -y libjson-c-dev libssl-dev curl \
  && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install DOCA

--- a/contrib/scripts/libxlio.spec.in
+++ b/contrib/scripts/libxlio.spec.in
@@ -26,6 +26,7 @@ BuildRequires: autoconf
 BuildRequires: libtool
 BuildRequires: gcc-c++
 BuildRequires: rdma-core-devel
+BuildRequires: openssl-devel
 %if 0%{?rhel} >= 7 || 0%{?fedora} >= 24 || 0%{?suse_version} >= 1500
 BuildRequires: pkgconfig(libnl-3.0)
 BuildRequires: pkgconfig(libnl-route-3.0)

--- a/debian/control
+++ b/debian/control
@@ -8,6 +8,7 @@ Build-Depends: debhelper (>= 7),
  automake,
  libibverbs-dev,
  librdmacm-dev,
+ libssl-dev,
  libnl-route-3-dev | libnl-dev,
  dpcp (>= 1.1.58),
 Homepage: https://github.com/Mellanox-lab/libxlio


### PR DESCRIPTION
## Description
Copy of #649.

TLS offload support is gated on openssl/evp.h in config/m4/utls.m4. With the default --enable-utls=auto, the build system silently disables UTLS support if the openssl header is missing.

Neither the rpm spec nor debian/control required the openssl development files, so the default binary packages were built without TLS offload whenever the building setup missed openssl headers.

Add openssl-devel to BuildRequires in libxlio.spec.in and libssl-dev to Build-Depends in debian/control. This is a build-time dependency only.

Also install the package in the CI images that compile XLIO, so the new build dependency resolves and the TLS code is actually covered by the build, static analysis and packaging jobs. Dockerfile.ol9.4 already had it.

##### What
Add openssl-devel to BuildRequires in libxlio.spec.in and libssl-dev to Build-Depends in debian/control.

##### Why ?
Build binary packages with TLS offload support.

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

