### PR TITLE
issue: INFINIOPS-921 [CI] Disable ctyunOS build images

### DIFF
--- a/.ci/matrix_job.yaml
+++ b/.ci/matrix_job.yaml
@@ -46,24 +46,25 @@ runs_on_dockers:
   - {file: '.ci/dockerfiles/Dockerfile.rhel9.6', name: 'rhel9.6-x86_64',  uri: 'xlio/$arch/$name/build', tag: '20260111', category: 'base', arch: 'x86_64', build_args: '--no-cache --target build', limits: '{cpu: 7000m}', requests: '{cpu: 7000m}'}
   - {file: '.ci/dockerfiles/Dockerfile.ubuntu24.04', name: 'ub24.04-x86_64', uri: 'xlio/$arch/$name/build', tag: '20251202', category: 'base', arch: 'x86_64', build_args: '--build-arg ARCH=x86_64 --no-cache --target build'}
   - {file: '.ci/dockerfiles/Dockerfile.ubuntu24.04', name: 'ub24.04-aarch64', uri: 'xlio/$arch/$name/build', tag: '20251202', category: 'base', arch: 'aarch64', build_args: '--build-arg ARCH=aarch64 --no-cache --target build'}
-  - {
-      file: '.ci/dockerfiles/Dockerfile.ctyunos23.01',
-      arch: 'x86_64',
-      name: 'ctyunos23.01-x86_64',
-      uri: 'xlio/$arch/$name/build',
-      tag: '20251202',
-      build_args: '--build-arg ARCH=x86_64 --no-cache',
-      category: 'base'
-    }
-  - {
-      file: '.ci/dockerfiles/Dockerfile.ctyunos23.01',
-      arch: 'aarch64',
-      name: 'ctyunos23.01-aarch64',
-      uri: 'xlio/$arch/$name/build',
-      tag: '20251202',
-      build_args: '--build-arg ARCH=aarch64 --no-cache',
-      category: 'base'
-    }
+# ctyunOS is temporarily unavailable - re-enable once the distro/repos are back
+#  - {
+#      file: '.ci/dockerfiles/Dockerfile.ctyunos23.01',
+#      arch: 'x86_64',
+#      name: 'ctyunos23.01-x86_64',
+#      uri: 'xlio/$arch/$name/build',
+#      tag: '20251202',
+#      build_args: '--build-arg ARCH=x86_64 --no-cache',
+#      category: 'base'
+#    }
+#  - {
+#      file: '.ci/dockerfiles/Dockerfile.ctyunos23.01',
+#      arch: 'aarch64',
+#      name: 'ctyunos23.01-aarch64',
+#      uri: 'xlio/$arch/$name/build',
+#      tag: '20251202',
+#      build_args: '--build-arg ARCH=aarch64 --no-cache',
+#      category: 'base'
+#    }
 # tool
   - {
      file: '.ci/dockerfiles/Dockerfile.ubuntu22.04',


### PR DESCRIPTION
INFINIOPS-921

## Description
Disable ctyunOS build images

##### What
Commented out the ctyunos23.01 x86_64 and aarch64 docker
entries in the CI matrix job, leaving the Dockerfile and the
doca_install.sh handling in place.

##### Why ?
ctyunOS is temporarily unavailable and its build stages fail
the CI matrix.

##### How ?
Prefixed both runs_on_dockers blocks with # and added a note
marking the removal as temporary, so the images can be
restored by uncommenting.

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

