### PR TITLE
[CI] issue: INFINIOPS-726 fix blackduck git safe.directory in CI pipeline

### DIFF
--- a/.ci/blackduck_source.sh
+++ b/.ci/blackduck_source.sh
@@ -1,5 +1,9 @@
 #!/bin/bash -Exel
 
+export GIT_CONFIG_COUNT=1
+export GIT_CONFIG_KEY_0=safe.directory
+export GIT_CONFIG_VALUE_0="${WORKSPACE}"
+
 topdir=$(git rev-parse --show-toplevel)
 cd "$topdir"
 


### PR DESCRIPTION
## Description

**What**
move git safe.directory config from inline pipeline step to blackduck_source.sh script using GIT_CONFIG env vars

**How**
replace git config --local call in release_matrix_job.yaml with GIT_CONFIG_COUNT/KEY/VALUE environment variables exported in blackduck_source.sh

**Why**
environment variable based git config is more portable and avoids relying on the pipeline step's working directory context

## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

