### PR TITLE
issue: 5260757 Fix the built-in DPCP build on RHEL 9.6

### DIFF
--- a/config/m4/dpcp.m4
+++ b/config/m4/dpcp.m4
@@ -93,7 +93,9 @@ if test "x$dpcp_explicitly_specified" = "xno"; then
         set -f
         set -- $with_dpcp_flags
         set +f
-        CC="$CC" CXX="$CXX" "$CMAKE" "$[]@" \
+        CC="$CC" CXX="$CXX" "$CMAKE" \
+            "-DCMAKE_CXX_FLAGS:STRING=-O2" \
+            "$[]@" \
             "-DCMAKE_INSTALL_PREFIX:PATH=$DPCP_INSTALL_DIR" \
             "-DCMAKE_INSTALL_LIBDIR:PATH=lib" \
             "-DDPCP_STATIC:BOOL=$DPCP_CMAKE_STATIC" \

--- a/tests/build/test-libxlio-build
+++ b/tests/build/test-libxlio-build
@@ -256,6 +256,7 @@ def prepare_external_dpcp(work_root, environment):
                 "-B",
                 "build-shared",
                 "-DCMAKE_INSTALL_PREFIX=install",
+                "-DCMAKE_CXX_FLAGS:STRING=-O2",
             ),
             dpcp_dir,
             "configure shared build",
@@ -278,6 +279,7 @@ def prepare_external_dpcp(work_root, environment):
                 "-B",
                 "build-static",
                 "-DCMAKE_INSTALL_PREFIX=install",
+                "-DCMAKE_CXX_FLAGS:STRING=-O2",
                 "-DDPCP_STATIC=ON",
             ),
             dpcp_dir,
@@ -511,7 +513,10 @@ def run_case(
     if case.dpcp_link_mode == "shared":
         configure_args.append("--enable-dpcp-shared")
     if case.flags_mode == "flags":
-        configure_args.append("--with-dpcp-flags=-DCMAKE_BUILD_TYPE=Debug")
+        configure_args.append(
+            "--with-dpcp-flags=-DCMAKE_BUILD_TYPE=Debug "
+            "-DCMAKE_CXX_FLAGS=-O3"
+        )
     if case.prefix_mode == "prefix":
         configure_args.append(f"--prefix={xlio_prefix}")
     if case.utls_mode == "with-utls":
@@ -771,6 +776,15 @@ def run_case(
                     raise CaseFailure(
                         "CMAKE_BUILD_TYPE unexpectedly equals Debug"
                     )
+
+            expected_cxx_flags = "-O3" if case.flags_mode == "flags" else "-O2"
+            report.append(
+                f"  CHECK CMake cache contains CMAKE_CXX_FLAGS={expected_cxx_flags}"
+            )
+            if f"CMAKE_CXX_FLAGS:STRING={expected_cxx_flags}\n" not in cache:
+                raise CaseFailure(
+                    f"CMAKE_CXX_FLAGS does not equal {expected_cxx_flags}"
+                )
         else:
             check_absent(dpcp_build_dir / "CMakeCache.txt", report)
             check_absent(dpcp_build_dir / "install", report)


### PR DESCRIPTION
## Description
Add -O to dpcp compilation flags by default

##### What
Configure built-in DPCP with CMAKE_CXX_FLAGS=-O by default. Place --with-dpcp-flags options afterward so callers can override the default.

##### Why ?
DPCP enables _FORTIFY_SOURCE and treats compiler warnings as errors. RHEL 9.6 rejects this configuration when optimization is disabled.

## Change type
What kind of change does this PR introduce?
- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [X] Code follows the style de facto guidelines of this project
- [X] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [X] Test has been added (if possible)

