### PR TITLE
issue: 5245126 Keep socket properties on socket reuse

### DIFF
--- a/src/core/sock/sockinfo.cpp
+++ b/src/core/sock/sockinfo.cpp
@@ -156,17 +156,24 @@ sockinfo::~sockinfo()
 
 void sockinfo::socket_stats_init()
 {
-    if (!m_p_socket_stats) { // This check is for listen sockets.
+    if (!m_p_socket_stats) {
         m_p_socket_stats = sock_stats::instance().get_stats_obj();
         if (!m_p_socket_stats) {
             return;
         }
 
+        // The pool doesn't clean an object on release, so it still carries the
+        // properties of the previous socket. Drop them with the connection state.
+        m_p_socket_stats->reset();
+
         // Save stats as local copy and allow state publisher to copy from this location
         xlio_stats_instance_create_socket_block(m_p_socket_stats);
+    } else {
+        // Re-initialization of a reused socket object. Keep the properties: they are
+        // assigned by the derived constructor, which doesn't run on this path.
+        m_p_socket_stats->reset_connection();
     }
 
-    m_p_socket_stats->reset();
     m_p_socket_stats->fd = m_fd;
     m_p_socket_stats->inode = fd2inode(m_fd);
     m_p_socket_stats->b_blocking = m_b_blocking;

--- a/src/core/util/xlio_stats.h
+++ b/src/core/util/xlio_stats.h
@@ -253,14 +253,18 @@ struct socket_stats_t {
 #endif /* DEFINED_UTLS */
     socket_stats_t *_next_stat;
 
-    void reset()
+    /*
+     * Reset the per-connection state only. Socket properties (see reset()) are kept,
+     * because a socket object can be re-initialized for a new connection without a
+     * constructor - see sockinfo_tcp::syn_received_timewait_cb().
+     */
+    void reset_connection()
     {
         fd = 0;
         inode = tcp_state = 0;
-        socket_type = 0;
         sa_family = 0;
-        b_is_offloaded = b_blocking = b_mc_loop = false;
-        bound_if = connected_ip = mc_tx_if = ip_address(in6addr_any);
+        b_blocking = false;
+        bound_if = connected_ip = ip_address(in6addr_any);
         bound_port = connected_port = (in_port_t)0;
         threadid_last_rx = threadid_last_tx = pid_t(0);
         n_rx_ready_pkt_count = n_rx_ready_byte_count = n_tx_ready_byte_count = 0;
@@ -275,6 +279,15 @@ struct socket_stats_t {
         mc_grp_map.reset();
         ring_user_id_rx = ring_user_id_tx = 0;
         ring_alloc_logic_rx = ring_alloc_logic_tx = RING_LOGIC_PER_INTERFACE;
+    }
+
+    /* Full reset, including the properties assigned once per socket object. */
+    void reset()
+    {
+        reset_connection();
+        socket_type = 0;
+        b_is_offloaded = b_mc_loop = false;
+        mc_tx_if = ip_address(in6addr_any);
     };
 
     void set_bound_if(sock_addr &sock)


### PR DESCRIPTION
## Description

socket_stats_t::reset() cleared the socket properties - socket type, offload state and the multicast fields - which are assigned only by the derived sockinfo constructors. sockinfo::socket_stats_init() is called not only from the base constructor, but also for a socket object that is reused in place for a new connection (syn_received_timewait_cb()), where no constructor runs. Every recycled socket therefore reported "???" instead of "TCP" and "Offloaded: No" for the rest of its life, and the tuning report attributed its traffic to the non-offloaded bucket.

Move the properties out of reset() into a new reset_connection() and use it on the re-initialization path. An object freshly taken from the sock_stats pool still gets the full reset, because the pool doesn't clean an object on release.

##### What
When a TIME_WAIT socket is reused, keep the socket type, offloading state and multicast interface.

##### Why ?
Fixes misleading information reported in statistics and tuning report when a TCP socket is reused.

##### How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc._

## Change type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved socket statistics handling when socket resources are reused.
  - Connection-specific statistics are now cleared appropriately without losing persistent socket properties.
  - Newly created socket statistics are fully initialized, helping prevent stale or incorrect values from appearing in monitoring data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->